### PR TITLE
Ignore help tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
If you use `vim-sexp` by way of `pathogen.vim` and run `:Helptags`, and you store your plugins as submodules of a git repository which contains all of your dot files (see the `homesick` ruby gem), then you see a very annoying "vimfiles/bundle/vim-sexp (changed content)" in the git status.  This fixes.