### PR TITLE
Don't break undo with delimiter insertion

### DIFF
--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -1707,11 +1707,11 @@ function! sexp#opening_insertion(bra)
     endif
 
     let buf .= a:bra . ket
-    let buftail .= "\<Left>"
+    let buftail .= "\<C-G>U\<Left>"
 
     if cur =~# '\v\S' && cur !~# s:closing_bracket
         let buf .= ' '
-        let buftail .= "\<Left>"
+        let buftail .= "\<C-G>U\<Left>"
     endif
 
     return buf . buftail
@@ -1739,7 +1739,7 @@ function! sexp#closing_insertion(ket)
     elseif prev ==# '\' && pprev !=# '\'
         return a:ket
     elseif cur ==# a:ket
-        return "\<Right>"
+        return "\<C-G>U\<Right>"
     endif
 
     let bra = '\V' . s:pairs[a:ket]
@@ -1782,7 +1782,7 @@ function! sexp#quote_insertion(quote)
         if curline[col - 2] ==# '\'
             return a:quote
         else
-            return curline[col - 1] ==# a:quote ? "\<Right>" : a:quote
+            return curline[col - 1] ==# a:quote ? "\<C-G>U\<Right>" : a:quote
         endif
     elseif s:syntax_match(s:ignored_region, line, col)
         return a:quote
@@ -1806,11 +1806,11 @@ function! sexp#quote_insertion(quote)
         endif
 
         let buf .= a:quote . a:quote
-        let buftail .= "\<Left>"
+        let buftail .= "\<C-G>U\<Left>"
 
         if cur =~# '\v\S' && cur !~# s:closing_bracket
             let buf .= ' '
-            let buftail .= "\<Left>"
+            let buftail .= "\<C-G>U\<Left>"
         endif
 
         return buf . buftail


### PR DESCRIPTION
This patch uses the `CTRL-G U` special key introduced in version [7.4.849](https://github.com/vim/vim/releases/tag/v7.4.849) so that the arrow keys sent after inserting a matching closing delimiter don't break the undo history.

All occurences of `\<Left>` are replaced by `\<C-G>U\<Left>`, and likewise for `\<Right>`.