### PR TITLE
Flow movements

### DIFF
--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -958,10 +958,10 @@ endfunction
 " skip over the near end of the element). The special logic assumes that the
 " brackets to be ignored will always be in an ignored region, as the plugin
 " currently treats all other brackets as list delimiters. In theory, however,
-" it is possible for a bracket to appear (escaped) in an atom. I don't think
-" it's a problem that the plugin doesn't support this (since brackets in atoms
-" probably falls into the category of things that could but shouldn't be
-" done), but if the plugin were eventually to support it, the special logic
+" it is possible for a bracket to appear (escaped) in a symbol. I don't think
+" it's a problem that the plugin doesn't support this (since brackets in
+" symbols probably falls into the category of things that could but shouldn't
+" be done), but if the plugin were eventually to support it, the special logic
 " would need to be tweaked slightly.
 function! sexp#list_flow(mode, count, next, close)
     let cnt = a:count ? a:count : 1
@@ -1094,7 +1094,8 @@ function! sexp#leaf_flow(mode, count, next, tail)
             " need to reposition on true end of element.
             " Note: Currently, spurious brackets are possible only in ignored
             " regions. If plugin ever supports (e.g.) escaped brackets in
-            " atoms, the following test will need to be adjusted accordingly.
+            " symbols, the following test will need to be adjusted
+            " accordingly.
             if !a:next && s:syntax_match(s:ignored_region, pos[0], pos[1])
                 let npos = s:move_to_current_element_terminal(1)
             else

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -958,7 +958,6 @@ endfunction
 " searchpair.
 function! sexp#list_flow(mode, count, next, close)
     let cnt = a:count ? a:count : 1
-    let cursor = getpos('.')
     " Loop until we've landed on [count]th non-ignored bracket of desired type
     " or exhausted buffer trying.
     " Note: Intentionally using searchpos with unmatchable start/end patterns

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -704,7 +704,7 @@ function! s:is_list(line, col)
     let chars = getline(a:line)[a:col - 1:]
     let maybe = chars =~#
         \ '\v^' . s:vm_cc(s:macro_chars()) . '*%(' . s:opening_bracket . ')'
-        \ ? chars[0] == '(' ? 2 : 1
+        \ ? chars[0] =~# s:opening_bracket ? 2 : 1
         \ : chars =~# '\v^%(' . s:closing_bracket . ')' ? 3 : 0
     " Extra test needed to ensure we're not fooled by spurious brackets within
     " ignored region.

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -978,9 +978,9 @@ endfunction
 " balance. For this reason, operator variants of flow commands are not
 " provided at all, and the visual variants select the target rather than
 " extending the current selection.
-" Note: Complementary with sexp#flow_to_adjacent_element, which flows
+" Note: Complementary with sexp#flow_to_nearest_nonlist, which flows
 " similarly, but stops only on *non-list* elements.
-function! sexp#flow_to_adjacent_list(mode, count, next)
+function! sexp#flow_to_nearest_list(mode, count, next, out)
     let cnt = a:count ? a:count : 1
     " Maintain a fallback or beach head position, in case we can't accomplish
     " [count] full jumps. (Prevent partial jumps.)
@@ -1001,11 +1001,13 @@ function! sexp#flow_to_adjacent_list(mode, count, next)
     " Get distinct very-magic character classes for forwards/backwards cases.
     " Note: Use sub-pattern flag to differentiate between alternatives.
     let macro_chars = s:macro_chars_vre()
-    let re = a:next
+    echomsg "next/out=" . a:next . "/" . a:out
+    let re = a:next != a:out
         \ ? '\v' . macro_chars . '*\zs(' . s:opening_bracket . ')|'
         \ . '%(' . s:closing_bracket . ')@!(\S)'
         \ : '\v(' . s:closing_bracket . ')|'
-        \ . '(\S)%(' . macro_chars . s:opening_bracket . ')@<!'
+        \ . '%(' . macro_chars . '*' . s:opening_bracket . ')@!(\S)'
+        "\ . '(\S)%(' . macro_chars . '*' . s:opening_bracket . ')@<!'
     " Loop until we've landed on [count]th bracket of desired type.
     " Maintain 'pos' as beach head, which isn't updated by intermediate jumps
     " that land on non-bracket chars.
@@ -1048,11 +1050,12 @@ endfunction
 " Note: If BOF or EOF preclude [count] jumps, go as far as possible, even to
 " the point of ignoring 'tail' to land on far end of the final element.
 " Selection Non Extension: See corresponding note in header of
-" sexp#flow_to_adjacent_list for reason visual commands do not extend
+" sexp#flow_to_nearest_list for reason visual commands do not extend
 " selection.
-" Note: Complementary with sexp#flow_to_adjacent_list, which flows similarly,
+" Note: Complementary with sexp#flow_to_nearest_list, which flows similarly,
 " but stops only on list elements.
-function! sexp#flow_to_adjacent_element(mode, count, next, tail)
+" TODO: Consider changing "element" to "non_list"
+function! sexp#flow_to_nearest_nonlist(mode, count, next, tail)
     " Is optimal destination near or far side of element?
     let near = !!a:next != !!a:tail
     let cnt = a:count ? a:count : 1

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -195,87 +195,95 @@ g<M-e>                                *<Plug>(sexp_move_to_prev_element_tail)*
         c]e will delete and insert at the "then" form, while c2]e will delete
         and insert at the "else" form.
 
-UNBOUNDED TRAVERSALS (normal, visual)~
+"FLOW" COMMANDS (normal, visual)~
 
 Although the preceding commands are useful for moving forward and backward
 within a list, sometimes you want to "escape" from the current list, or
-descend into a child list. The commands in this section permit list traversals
-that are not bound by the current list. In fact, it is possible to use an
-unbroken sequence of traversal commands to move all the way from one end of
-the buffer to the other. The traversal commands fall into 2 basic categories:
+descend into a child list. The commands in this section are called "flow"
+commands because they permit you to flow freely in and out of lists. In fact,
+it is possible to use an unbroken sequence of flow commands to move all the
+way from one end of the buffer to the other. Flow commands fall into 2 basic
+categories:
 
 1. List
    Land only on brackets. There are 4 variants, differentiated by both the
-   direction moved in the buffer (forward or backward), and the type of
-   bracket landed on (open or close).
+   direction moved in the buffer, and the type of bracket landed on (open or
+   close).
    
 2. Leaf
    Land only on non-list (leaf) elements (atoms, strings, comments)
 
 Visualizing forms as trees~
 It may be helpful to visualize a top-level form as a "tree" whose nodes can be
-either branches (lists) or leaves (atoms, strings, comments). The list
-commands traverse trees in depth-first fashion, either left to right ("forward
-to open") or right to left ("backward to close"). There is even a pair of
-commands ("backward to open" and "forward to close"), specifically designed to
-permit "backing up" when one of the normal list traversal commands has gone
-too far.) The non-list (leaf) commands visit only the leaf nodes in the tree:
-i.e., they will never land on a bracket.
+either branches (lists) or leaves (atoms, strings, comments). The list flow
+commands traverse these trees in depth-first fashion, either left to right
+(|sexp_flow_to_next_open|) or right to left (|sexp_flow_to_prev_close|),
+skipping over leaf elements. Additionally, there is a pair of commands
+(|sexp_flow_to_prev_open| and |sexp_flow_to_next_close|) specifically designed
+to permit "backing up" when one of the normal list flow commands has gone too
+far.) The leaf flow commands visit only leaf nodes in the tree: i.e., they
+will never land on a bracket.
 
-Note: The list and leaf traversal commands are complementary and completely
-orthogonal: the target of a list traversal command can never be the target of
-a leaf traversal command; moreover, every element in the buffer can be reached
-using either list or leaf traversal commands (but not both).
+Note: The list and leaf commands are complementary and completely orthogonal:
+the target of a list flow command can never be the target of a leaf flow
+command and vice-versa; moreover, every element in the buffer can be reached
+using either list or leaf flow commands (but not both).
 
 Visual and operator mode note~
-Because the traversal commands intentionally cross list boundaries, operator
+Because the flow commands are designed to cross list boundaries, operator
 commands and commands that extend the visual selection would make it too easy
-for the user to destroy bracket balance. For this reason, the traversal
-commands are not defined in operator mode at all, and the visual mode variants
-do not extend the current selection, but simply select the target
-element/list.
+for the user to destroy bracket balance. For this reason, the flow commands
+are not defined in operator mode at all, and the visual mode variants do not
+extend the current selection, but simply select the target element/list.
 
-List traversal commands~
+Idiom: Use v[count]<M-S-w> in normal mode to select the [count]th non-list
+element from cursor. (Once you get the hang of ignoring brackets, it's easy to
+select an arbitrary child, grandchild or even more deeply-nested element with
+a single command.)
+
+List flow commands~
 
 -- ALTERNATIVE PRESENTATION #1 --
-<M-]>                                           *<Plug>(sexp_forward_to_open)*
-        [count] open brackets forward. Movement is NOT bounded by the parent
-        list.
-        Performs a left-to-right (forward) depth-first traversal of each
-        top-level form encountered.
+<M-]>                                         *<Plug>(sexp_flow_to_next_open)*
+        [count] open brackets forward (ignoring any close brackets). Movement
+        is NOT bounded by the parent list.
+        Performs left-to-right, depth-first traversal of each form
+        encountered.
 
-<M-{>                                          *<Plug>(sexp_backward_to_open)*
-        [count] open brackets backward. Movement is NOT bounded by the parent
-        list.
-        Visits the same positions as the previous command, but in reverse
+<M-{>                                         *<Plug>(sexp_flow_to_prev_open)*
+        [count] open brackets backward (ignoring any open brackets). Movement
+        is NOT bounded by the parent list.
+        Visits the same positions as the preceding command, but in reverse
         order: i.e, may be used to "rewind" a sequence of <M-]> commands.
 
-<M-[>                                         *<Plug>(sexp_backward_to_close)*
-        [count] close brackets backward. Movement is NOT bounded by the parent
-        list.
-        Performs a right-to-left (backward) depth-first traversal of each
-        top-level form encountered.
+<M-[>                                        *<Plug>(sexp_flow_to_prev_close)*
+        [count] close brackets backward (ignoring any open brackets). Movement
+        is NOT bounded by the parent list.
+        Performs right-to-left, depth-first traversal of each form
+        encountered.
 
-<M-}>                                          *<Plug>(sexp_forward_to_close)*
-        [count] close brackets forward. Movement is NOT bounded by the parent
-        list.
-        Visits the same positions as the previous command, but in reverse
+<M-}>                                        *<Plug>(sexp_flow_to_next_close)*
+        [count] close brackets forward (ignoring any open brackets). Movement
+        is NOT bounded by the parent list.
+        Visits the same positions as the preceding command, but in reverse
         order: i.e, may be used to "rewind" a sequence of <M-[> commands.
 
 -- ALTERNATIVE PRESENTATION #2 --
 
 
-<M-[>                                         *<Plug>(sexp_backward_to_close)*    
-<M-]>                                           *<Plug>(sexp_forward_to_open)*
-        [count] close brackets backward or open brackets forward. Movement is
-        NOT bounded by the parent list.
-        Note: These commands perform a left-to-right (forward) or
-        right-to-left (backward) depth-first traversal.
+<M-[>                                        *<Plug>(sexp_flow_to_prev_close)*
+<M-]>                                         *<Plug>(sexp_flow_to_next_open)*
+        [count] close brackets backward or open brackets forward (ignoring any
+        brackets of the other type). Movement is NOT bounded by the parent
+        list.
+        Note: These commands perform a left-to-right (<M-]>) or right-to-left
+        (<M-[>) depth-first traversal.
 
-<M-{>                                          *<Plug>(sexp_backward_to_open)*
-<M-}>                                          *<Plug>(sexp_forward_to_close)*
-        [count] open brackets backward or close brackets forward. Movement is
-        NOT bounded by the parent list.
+<M-{>                                         *<Plug>(sexp_flow_to_prev_open)*
+<M-}>                                        *<Plug>(sexp_flow_to_next_close)*
+        [count] open brackets backward or close brackets forward (ignoring any
+        brackets of the other type). Movement is NOT bounded by the parent
+        list.
         Note: These two commands visit the same set of nodes as the preceding
         two, but in reverse order: i.e.,
             <M-{> "reverses" <M-]>
@@ -283,62 +291,61 @@ List traversal commands~
 
 -- END ALTERNATIVES --
 
-Note: Another way of looking at the list commands is that the square-bracket
-commands tend to move down into lists, whereas the curly-bracket commands tend
-to move up and out of them. Or, continuing the tree analogy... The
-square-bracket commands perform depth-first traversals, with the curly-bracket
-commands providing a way to "rewind" or "back up" at any point in the descent.
-The following examples should clarify...
+Note: Another way of looking at the list flow commands is that the
+square-bracket commands tend to move down into lists, whereas the
+curly-bracket commands tend to move up and out of them. While it's true that
+the square-bracket commands also move out of lists, they do so only when they
+can go no deeper. In this way, they are exactly like depth-first tree
+traversals, which always choose to descend when descent is possible.
 
 Examples:~
         Note: | denotes starting cursor position.
               ^ denotes positions reached by successive applications of the
                 indicated command.
 
-        sexp_forward_to_open              (forward / in)~
-                                 | (x1 (x2) (x3 (x4) (x5))) (x6)
-                                   ^   ^    ^   ^    ^      ^
-                                   1   2    3   4    5      6
-                                 --------------------------->
+        sexp_flow_to_next_open               (forward / in)~
+                                   | (x1 (x2) (x3 (x4) (x5))) (x6)
+                                     ^   ^    ^   ^    ^      ^
+                                     1   2    3   4    5      6
+                                   --------------------------->
 
-        sexp_backward_to_open             (backward / out)~
-                                   (x1 (x2) (x3 (x4) (x5))) (x6) |
-                                   ^   ^    ^   ^    ^      ^
-                                   6   5    4   3    2      1
-                                   <------------------------------
+        sexp_flow_to_prev_open              (backward / out)~
+                                     (x1 (x2) (x3 (x4) (x5))) (x6) |
+                                     ^   ^    ^   ^    ^      ^
+                                     6   5    4   3    2      1
+                                     <------------------------------
 
-        sexp_backward_to_close            (backward / in)~
-                                   (x1) (((x2) (x3) x4) (x5) x6) |
-                                      ^      ^    ^   ^    ^   ^
-                                      6      5    4   3    2   1
-                                   <------------------------------
+        sexp_flow_to_prev_close             (backward / in)~
+                                     (x1) (((x2) (x3) x4) (x5) x6) |
+                                        ^      ^    ^   ^    ^   ^
+                                        6      5    4   3    2   1
+                                     <------------------------------
 
-        sexp_forward_to_close             (forward / out)~
-                                 | (x1) (((x2) (x3) x4) (x5) x6)
-                                      ^      ^    ^   ^    ^   ^
-                                      1      2    3   4    5   6
-                                 ------------------------------>
+        sexp_flow_to_next_close              (forward / out)~
+                                   | (x1) (((x2) (x3) x4) (x5) x6)
+                                        ^      ^    ^   ^    ^   ^
+                                        1      2    3   4    5   6
+                                   ------------------------------>
 
 
-Leaf traversal commands~
+Leaf flow commands~
 
-<M-S-b>                                   *<Plug>(sexp_backward_to_leaf_head)*
-<M-S-w>                                    *<Plug>(sexp_forward_to_leaf_head)*
-        [count] leaf (non-list) elements backward or forward, landing on the
-        head of an element. Movement is NOT bounded by the parent list.
+<M-S-b>                                  *<Plug>(sexp_flow_to_prev_leaf_head)*
+<M-S-w>                                  *<Plug>(sexp_flow_to_next_leaf_head)*
+        [count] leaf (non-list) elements backward or forward, placing the
+        cursor on the head of an element. Movement is NOT bounded by the
+        parent list.
 
         Analogous to |b| and |w| motions.
 
-<M-S-g>                                   *<Plug>(sexp_backward_to_leaf_tail)*
-<M-S-e>                                    *<Plug>(sexp_forward_to_leaf_tail)*
-        [count] leaf (non-list) elements backward or forward, landing on the
-        tail of an element. Movement is NOT bounded by the parent list.
+<M-S-g>                                  *<Plug>(sexp_flow_to_prev_leaf_tail)*
+<M-S-e>                                  *<Plug>(sexp_flow_to_next_leaf_tail)*
+        [count] leaf (non-list) elements backward or forward, placing the
+        cursor on the tail of an element. Movement is NOT bounded by the
+        parent list.
 
         Analogous to |ge| and |e| motions.
 
-Idiom: Use v[count]<M-S-w> in normal mode to select the [count]th non-list
-element from cursor. (Once you get the hang of ignoring brackets, it's easy to
-jump directly to the desired element with a single command.)
 
 
 INDENT COMMANDS (normal)~

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -195,40 +195,56 @@ g<M-e>                                *<Plug>(sexp_move_to_prev_element_tail)*
         c]e will delete and insert at the "then" form, while c2]e will delete
         and insert at the "else" form.
 
-FLOW COMMANDS (normal)~
+FLOW COMMANDS (normal, visual)~
 
 Unlike the preceding movement commands, "flow" commands move freely in and out
-of lists, moving to the next/prev list or element in the buffer, even when
-doing so means crossing a list boundary.
-Note: The "flow" commands are intentionally provided only in normal mode.
-Because flow commands effectively ignore list structure, operator/visual
-variants would make it very easy (perhaps too easy?) to operate on text in an
-unbalanced way. While vim-sexp does not generally attempt to prevent this (as
-some other paredit-like plugins do), it may not make sense to provide commands
-whose primary use-case would be to facilitate it. If you feel strongly that
-operator pending and/or visual variants of the flow commands would be useful,
-feel free to present relevant use-cases to the author...
+of lists, moving to the [count]th next/previous list/element in the buffer,
+even when doing so requires crossing one or more list boundaries.
+Motivation: Although the preceding commands are useful for moving forward and
+backward within a list, sometimes you want to escape from the current list, or
+descend into a child list.
 
-TODO: Add documentation for visual flow operators (to be added)!
+Visual Mode Note: Because flow commands intentionally cross list boundaries,
+both operator commands and commands that extend the visual selection would
+make it too easy for the user to destroy paren balance. For this reason,
+operator flow commands are not provided at all, and the visual commands do not
+extend the current selection, but simply select the target element/list.
+
+Idiom: Use v[count]<M-S-w> in normal mode to select the [count]th element from
+cursor. (Once you get the hang of ignoring brackets, it's easy to jump
+directly to the desired element with a single command.)
+
+Heuristic: It may be helpful to visualize the "flow" commands as performing
+depth-first traversals of "trees" of lists. If you start at one end of the
+buffer, repeated flow commands will eventually take you to the other end, with
+the list commands visiting each list, and the element commands visiting each
+non-list element, in the order they appear in the file.
 
 <M-S-(>                                       *<Plug>(sexp_flow_to_prev_list)*
 <M-S-)>                                       *<Plug>(sexp_flow_to_next_list)*
-        Move forward/backward to [count]th opening/closing bracket. Movement
-        is NOT bounded by the parent list, if any.
+        [count] lists backward or forward, landing on the bracket at the near
+        end of a list. Movement is NOT bounded by the parent list.
 
-        Repeated applications visit every list in the direction specified.
+        Note: List flow commands always land on the near side of the adjacent
+        list (i.e., open bracket if moving forward, close bracket if moving
+        backward) since landing on the far side would prevent the sort of
+        descent for which the flow commands were designed. Of course, if you
+        wish to skip descent into a particular list in the middle of a flow
+        traversal, simply hit |%| (or |o| in visual mode) to skip to the other
+        side.
+
 
 <M-S-b>                               *<Plug>(sexp_flow_to_prev_element_head)*
 <M-S-w>                               *<Plug>(sexp_flow_to_next_element_head)*
-        [count] elements backward or forward, placing the cursor on the head
-        of an element. Movement is NOT bounded by the parent list, if any.
+        [count] non-list elements backward or forward, landing on the head of
+        an element. Movement is NOT bounded by the parent list.
 
         Analogous to |b| and |w| motions.
 
 <M-S-g>                               *<Plug>(sexp_flow_to_prev_element_tail)*
 <M-S-e>                               *<Plug>(sexp_flow_to_next_element_tail)*
-        [count] elements backward or forward, placing the cursor on the tail
-        of an element. Movement is NOT bounded by the parent list, if any.
+        [count] non-list elements backward or forward, landing on the tail of
+        an element. Movement is NOT bounded by the parent list.
 
         Analogous to |ge| and |e| motions.
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -201,8 +201,8 @@ Unlike the preceding movement commands, "flow" commands move freely in and out
 of lists, moving to the [count]th next/previous list/element in the buffer,
 even when doing so requires crossing one or more list boundaries.
 Motivation: Although the preceding commands are useful for moving forward and
-backward within a list, sometimes you want to escape from the current list, or
-descend into a child list.
+backward within a list, sometimes you want to "escape" from the current list,
+or descend into a child list.
 
 Visual Mode Note: Because flow commands intentionally cross list boundaries,
 both operator commands and commands that extend the visual selection would
@@ -214,14 +214,26 @@ Idiom: Use v[count]<M-S-w> in normal mode to select the [count]th element from
 cursor. (Once you get the hang of ignoring brackets, it's easy to jump
 directly to the desired element with a single command.)
 
-Heuristic: It may be helpful to visualize the "flow" commands as performing
-depth-first traversals of "trees" of lists. If you start at one end of the
-buffer, repeated flow commands will eventually take you to the other end, with
-the list commands visiting each list, and the element commands visiting each
+                                                            *visualizing-flow*
+It may be helpful to visualize the "flow" commands as performing depth-first
+traversals of "trees" of lists. If you start at one end of the buffer,
+repeated flow commands will eventually take you to the other end, with the
+list commands visiting each list, and the non-list commands visiting each
 non-list element, in the order they appear in the file.
 
-<M-S-(>                                       *<Plug>(sexp_flow_to_prev_list)*
-<M-S-)>                                       *<Plug>(sexp_flow_to_next_list)*
+                                                         *flow-in-vs-flow-out*
+Continuing the analogy to tree traversal, the "flow in" commands perform an
+ordinary traversal, with the "next" variant moving left to right through the
+tree, and the "prev" version moving right to left. The "flow-out" commands
+actually reverse the traversal
+
+The "flow-in" and "flow-out" variants of the list flow commands differ in the
+end of the list landed on. The names come from the fact that "flow-in"
+commands will generally recurse into 
+
+
+<M-[>                                      *<Plug>(sexp_flow_in_to_prev_list)*
+<M-]>                                      *<Plug>(sexp_flow_in_to_next_list)*
         [count] lists backward or forward, landing on the bracket at the near
         end of a list. Movement is NOT bounded by the parent list.
 
@@ -232,17 +244,19 @@ non-list element, in the order they appear in the file.
         wish to skip descent into a particular list in the middle of a flow
         traversal, simply hit |%| (or |o| in visual mode) to skip to the other
         side.
+<M-{>                                     *<Plug>(sexp_flow_out_to_prev_list)*
+<M-}>                                     *<Plug>(sexp_flow_out_to_next_list)*
 
 
-<M-S-b>                               *<Plug>(sexp_flow_to_prev_element_head)*
-<M-S-w>                               *<Plug>(sexp_flow_to_next_element_head)*
+<M-S-b>                               *<Plug>(sexp_flow_to_prev_nonlist_head)*
+<M-S-w>                               *<Plug>(sexp_flow_to_next_nonlist_head)*
         [count] non-list elements backward or forward, landing on the head of
         an element. Movement is NOT bounded by the parent list.
 
         Analogous to |b| and |w| motions.
 
-<M-S-g>                               *<Plug>(sexp_flow_to_prev_element_tail)*
-<M-S-e>                               *<Plug>(sexp_flow_to_next_element_tail)*
+<M-S-g>                               *<Plug>(sexp_flow_to_prev_nonlist_tail)*
+<M-S-e>                               *<Plug>(sexp_flow_to_next_nonlist_tail)*
         [count] non-list elements backward or forward, landing on the tail of
         an element. Movement is NOT bounded by the parent list.
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -224,7 +224,7 @@ flow commands, jump directly from leaf to leaf, never stopping on a bracket.
 
 Note: The list and leaf commands are complementary and completely orthogonal:
 the target of a list flow command can never be the target of a leaf flow
-command and vice-versa; moreover, every element in the buffer can be reached
+command, and vice-versa; moreover, every element in the buffer can be reached
 using either list or leaf flow commands, but not both.
 
 Visual and operator-pending mode note~

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -195,72 +195,151 @@ g<M-e>                                *<Plug>(sexp_move_to_prev_element_tail)*
         c]e will delete and insert at the "then" form, while c2]e will delete
         and insert at the "else" form.
 
-FLOW COMMANDS (normal, visual)~
+UNBOUNDED TRAVERSALS (normal, visual)~
 
-Unlike the preceding movement commands, "flow" commands move freely in and out
-of lists, moving to the [count]th next/previous list/element in the buffer,
-even when doing so requires crossing one or more list boundaries.
-Motivation: Although the preceding commands are useful for moving forward and
-backward within a list, sometimes you want to "escape" from the current list,
-or descend into a child list.
+Although the preceding commands are useful for moving forward and backward
+within a list, sometimes you want to "escape" from the current list, or
+descend into a child list. The commands in this section permit list traversals
+that are not bound by the current list. In fact, it is possible to use an
+unbroken sequence of traversal commands to move all the way from one end of
+the buffer to the other. The traversal commands fall into 2 basic categories:
 
-Visual Mode Note: Because flow commands intentionally cross list boundaries,
-both operator commands and commands that extend the visual selection would
-make it too easy for the user to destroy paren balance. For this reason,
-operator flow commands are not provided at all, and the visual commands do not
-extend the current selection, but simply select the target element/list.
+1. List
+   Land only on brackets. There are 4 variants, differentiated by both the
+   direction moved in the buffer (forward or backward), and the type of
+   bracket landed on (open or close).
+   
+2. Leaf
+   Land only on non-list (leaf) elements (atoms, strings, comments)
 
-Idiom: Use v[count]<M-S-w> in normal mode to select the [count]th element from
-cursor. (Once you get the hang of ignoring brackets, it's easy to jump
-directly to the desired element with a single command.)
+Visualizing forms as trees~
+It may be helpful to visualize a top-level form as a "tree" whose nodes can be
+either branches (lists) or leaves (atoms, strings, comments). The list
+commands traverse trees in depth-first fashion, either left to right ("forward
+to open") or right to left ("backward to close"). There is even a pair of
+commands ("backward to open" and "forward to close"), specifically designed to
+permit "backing up" when one of the normal list traversal commands has gone
+too far.) The non-list (leaf) commands visit only the leaf nodes in the tree:
+i.e., they will never land on a bracket.
 
-                                                            *visualizing-flow*
-It may be helpful to visualize the "flow" commands as performing depth-first
-traversals of "trees" of lists. If you start at one end of the buffer,
-repeated flow commands will eventually take you to the other end, with the
-list commands visiting each list, and the non-list commands visiting each
-non-list element, in the order they appear in the file.
+Note: The list and leaf traversal commands are complementary and completely
+orthogonal: the target of a list traversal command can never be the target of
+a leaf traversal command; moreover, every element in the buffer can be reached
+using either list or leaf traversal commands (but not both).
 
-                                                         *flow-in-vs-flow-out*
-Continuing the analogy to tree traversal, the "flow in" commands perform an
-ordinary traversal, with the "next" variant moving left to right through the
-tree, and the "prev" version moving right to left. The "flow-out" commands
-actually reverse the traversal
+Visual and operator mode note~
+Because the traversal commands intentionally cross list boundaries, operator
+commands and commands that extend the visual selection would make it too easy
+for the user to destroy bracket balance. For this reason, the traversal
+commands are not defined in operator mode at all, and the visual mode variants
+do not extend the current selection, but simply select the target
+element/list.
 
-The "flow-in" and "flow-out" variants of the list flow commands differ in the
-end of the list landed on. The names come from the fact that "flow-in"
-commands will generally recurse into 
+List traversal commands~
+
+-- ALTERNATIVE PRESENTATION #1 --
+<M-]>                                           *<Plug>(sexp_forward_to_open)*
+        [count] open brackets forward. Movement is NOT bounded by the parent
+        list.
+        Performs a left-to-right (forward) depth-first traversal of each
+        top-level form encountered.
+
+<M-{>                                          *<Plug>(sexp_backward_to_open)*
+        [count] open brackets backward. Movement is NOT bounded by the parent
+        list.
+        Visits the same positions as the previous command, but in reverse
+        order: i.e, may be used to "rewind" a sequence of <M-]> commands.
+
+<M-[>                                         *<Plug>(sexp_backward_to_close)*
+        [count] close brackets backward. Movement is NOT bounded by the parent
+        list.
+        Performs a right-to-left (backward) depth-first traversal of each
+        top-level form encountered.
+
+<M-}>                                          *<Plug>(sexp_forward_to_close)*
+        [count] close brackets forward. Movement is NOT bounded by the parent
+        list.
+        Visits the same positions as the previous command, but in reverse
+        order: i.e, may be used to "rewind" a sequence of <M-[> commands.
+
+-- ALTERNATIVE PRESENTATION #2 --
 
 
-<M-[>                                      *<Plug>(sexp_flow_in_to_prev_list)*
-<M-]>                                      *<Plug>(sexp_flow_in_to_next_list)*
-        [count] lists backward or forward, landing on the bracket at the near
-        end of a list. Movement is NOT bounded by the parent list.
+<M-[>                                         *<Plug>(sexp_backward_to_close)*    
+<M-]>                                           *<Plug>(sexp_forward_to_open)*
+        [count] close brackets backward or open brackets forward. Movement is
+        NOT bounded by the parent list.
+        Note: These commands perform a left-to-right (forward) or
+        right-to-left (backward) depth-first traversal.
 
-        Note: List flow commands always land on the near side of the adjacent
-        list (i.e., open bracket if moving forward, close bracket if moving
-        backward) since landing on the far side would prevent the sort of
-        descent for which the flow commands were designed. Of course, if you
-        wish to skip descent into a particular list in the middle of a flow
-        traversal, simply hit |%| (or |o| in visual mode) to skip to the other
-        side.
-<M-{>                                     *<Plug>(sexp_flow_out_to_prev_list)*
-<M-}>                                     *<Plug>(sexp_flow_out_to_next_list)*
+<M-{>                                          *<Plug>(sexp_backward_to_open)*
+<M-}>                                          *<Plug>(sexp_forward_to_close)*
+        [count] open brackets backward or close brackets forward. Movement is
+        NOT bounded by the parent list.
+        Note: These two commands visit the same set of nodes as the preceding
+        two, but in reverse order: i.e.,
+            <M-{> "reverses" <M-]>
+            <M-}> "reverses" <M-[>
+
+-- END ALTERNATIVES --
+
+Note: Another way of looking at the list commands is that the square-bracket
+commands tend to move down into lists, whereas the curly-bracket commands tend
+to move up and out of them. Or, continuing the tree analogy... The
+square-bracket commands perform depth-first traversals, with the curly-bracket
+commands providing a way to "rewind" or "back up" at any point in the descent.
+The following examples should clarify...
+
+Examples:~
+        Note: | denotes starting cursor position.
+              ^ denotes positions reached by successive applications of the
+                indicated command.
+
+        sexp_forward_to_open              (forward / in)~
+                                 | (x1 (x2) (x3 (x4) (x5))) (x6)
+                                   ^   ^    ^   ^    ^      ^
+                                   1   2    3   4    5      6
+                                 --------------------------->
+
+        sexp_backward_to_open             (backward / out)~
+                                   (x1 (x2) (x3 (x4) (x5))) (x6) |
+                                   ^   ^    ^   ^    ^      ^
+                                   6   5    4   3    2      1
+                                   <------------------------------
+
+        sexp_backward_to_close            (backward / in)~
+                                   (x1) (((x2) (x3) x4) (x5) x6) |
+                                      ^      ^    ^   ^    ^   ^
+                                      6      5    4   3    2   1
+                                   <------------------------------
+
+        sexp_forward_to_close             (forward / out)~
+                                 | (x1) (((x2) (x3) x4) (x5) x6)
+                                      ^      ^    ^   ^    ^   ^
+                                      1      2    3   4    5   6
+                                 ------------------------------>
 
 
-<M-S-b>                               *<Plug>(sexp_flow_to_prev_nonlist_head)*
-<M-S-w>                               *<Plug>(sexp_flow_to_next_nonlist_head)*
-        [count] non-list elements backward or forward, landing on the head of
-        an element. Movement is NOT bounded by the parent list.
+Leaf traversal commands~
+
+<M-S-b>                                   *<Plug>(sexp_backward_to_leaf_head)*
+<M-S-w>                                    *<Plug>(sexp_forward_to_leaf_head)*
+        [count] leaf (non-list) elements backward or forward, landing on the
+        head of an element. Movement is NOT bounded by the parent list.
 
         Analogous to |b| and |w| motions.
 
-<M-S-g>                               *<Plug>(sexp_flow_to_prev_nonlist_tail)*
-<M-S-e>                               *<Plug>(sexp_flow_to_next_nonlist_tail)*
-        [count] non-list elements backward or forward, landing on the tail of
-        an element. Movement is NOT bounded by the parent list.
+<M-S-g>                                   *<Plug>(sexp_backward_to_leaf_tail)*
+<M-S-e>                                    *<Plug>(sexp_forward_to_leaf_tail)*
+        [count] leaf (non-list) elements backward or forward, landing on the
+        tail of an element. Movement is NOT bounded by the parent list.
 
         Analogous to |ge| and |e| motions.
+
+Idiom: Use v[count]<M-S-w> in normal mode to select the [count]th non-list
+element from cursor. (Once you get the hang of ignoring brackets, it's easy to
+jump directly to the desired element with a single command.)
+
 
 INDENT COMMANDS (normal)~
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -195,6 +195,43 @@ g<M-e>                                *<Plug>(sexp_move_to_prev_element_tail)*
         c]e will delete and insert at the "then" form, while c2]e will delete
         and insert at the "else" form.
 
+FLOW COMMANDS (normal)~
+
+Unlike the preceding movement commands, "flow" commands move freely in and out
+of lists, moving to the next/prev list or element in the buffer, even when
+doing so means crossing a list boundary.
+Note: The "flow" commands are intentionally provided only in normal mode.
+Because flow commands effectively ignore list structure, operator/visual
+variants would make it very easy (perhaps too easy?) to operate on text in an
+unbalanced way. While vim-sexp does not generally attempt to prevent this (as
+some other paredit-like plugins do), it may not make sense to provide commands
+whose primary use-case would be to facilitate it. If you feel strongly that
+operator pending and/or visual variants of the flow commands would be useful,
+feel free to present relevant use-cases to the author...
+
+TODO: Add documentation for visual flow operators (to be added)!
+
+<M-S-(>                                       *<Plug>(sexp_flow_to_prev_list)*
+<M-S-)>                                       *<Plug>(sexp_flow_to_next_list)*
+        Move forward/backward to [count]th opening/closing bracket. Movement
+        is NOT bounded by the parent list, if any.
+
+        Repeated applications visit every list in the direction specified.
+
+<M-S-b>                               *<Plug>(sexp_flow_to_prev_element_head)*
+<M-S-w>                               *<Plug>(sexp_flow_to_next_element_head)*
+        [count] elements backward or forward, placing the cursor on the head
+        of an element. Movement is NOT bounded by the parent list, if any.
+
+        Analogous to |b| and |w| motions.
+
+<M-S-g>                               *<Plug>(sexp_flow_to_prev_element_tail)*
+<M-S-e>                               *<Plug>(sexp_flow_to_next_element_tail)*
+        [count] elements backward or forward, placing the cursor on the tail
+        of an element. Movement is NOT bounded by the parent list, if any.
+
+        Analogous to |ge| and |e| motions.
+
 INDENT COMMANDS (normal)~
 
 ==                                                       *<Plug>(sexp_indent)*

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -211,30 +211,31 @@ categories:
    close).
    
 2. Leaf
-   Land only on non-list (leaf) elements (atoms, strings, comments)
+   Land only on leaf (non-list) elements (atoms, strings, comments)
 
 Visualizing forms as trees~
 It may be helpful to visualize a top-level form as a "tree" whose nodes can be
-either branches (lists) or leaves (atoms, strings, comments). The list flow
-commands traverse these trees in depth-first fashion, either left to right
-(|sexp_flow_to_next_open|) or right to left (|sexp_flow_to_prev_close|),
-skipping over leaf elements. Additionally, there is a pair of commands
-(|sexp_flow_to_prev_open| and |sexp_flow_to_next_close|) specifically designed
-to permit "backing up" when one of the normal list flow commands has gone too
-far.) The leaf flow commands visit only leaf nodes in the tree: i.e., they
-will never land on a bracket.
+either branches (lists) or leaves (atoms, strings, comments). One pair of list
+flow commands traverses the trees in depth-first fashion, skipping over leaf
+elements. A second pair of list flow commands permits "rewinding" these
+traversals (e.g., when a command from the first pair has gone too far). Leaf
+flow commands also perform a sort of depth-first traversal, but unlike list
+flow commands, jump directly from leaf to leaf, never stopping on a bracket.
 
 Note: The list and leaf commands are complementary and completely orthogonal:
 the target of a list flow command can never be the target of a leaf flow
 command and vice-versa; moreover, every element in the buffer can be reached
-using either list or leaf flow commands (but not both).
+using either list or leaf flow commands, but not both.
 
-Visual and operator mode note~
-Because the flow commands are designed to cross list boundaries, operator
-commands and commands that extend the visual selection would make it too easy
-for the user to destroy bracket balance. For this reason, the flow commands
-are not defined in operator mode at all, and the visual mode variants do not
-extend the current selection, but simply select the target element/list.
+Visual and operator-pending mode note~
+Because the flow commands are designed to cross list boundaries,
+operator-pending commands and commands that extend the visual selection would
+make it too easy for the user to destroy bracket balance. For this reason, the
+flow commands are not defined in operator-pending mode at all, and the visual
+mode variants do not extend the current selection, but simply select the
+target element/list. Note that this is actually a very useful feature, which
+allows you to use the flow commands much as you would use |]e| and |[e|, but
+without being confined to the current list.
 
 Idiom: Use v[count]<M-S-w> in normal mode to select the [count]th non-list
 element from cursor. (Once you get the hang of ignoring brackets, it's easy to
@@ -243,7 +244,6 @@ a single command.)
 
 List flow commands~
 
--- ALTERNATIVE PRESENTATION #1 --
 <M-]>                                         *<Plug>(sexp_flow_to_next_open)*
         [count] open brackets forward (ignoring any close brackets). Movement
         is NOT bounded by the parent list.
@@ -251,7 +251,7 @@ List flow commands~
         encountered.
 
 <M-{>                                         *<Plug>(sexp_flow_to_prev_open)*
-        [count] open brackets backward (ignoring any open brackets). Movement
+        [count] open brackets backward (ignoring any close brackets). Movement
         is NOT bounded by the parent list.
         Visits the same positions as the preceding command, but in reverse
         order: i.e, may be used to "rewind" a sequence of <M-]> commands.
@@ -268,29 +268,6 @@ List flow commands~
         Visits the same positions as the preceding command, but in reverse
         order: i.e, may be used to "rewind" a sequence of <M-[> commands.
 
--- ALTERNATIVE PRESENTATION #2 --
-
-
-<M-[>                                        *<Plug>(sexp_flow_to_prev_close)*
-<M-]>                                         *<Plug>(sexp_flow_to_next_open)*
-        [count] close brackets backward or open brackets forward (ignoring any
-        brackets of the other type). Movement is NOT bounded by the parent
-        list.
-        Note: These commands perform a left-to-right (<M-]>) or right-to-left
-        (<M-[>) depth-first traversal.
-
-<M-{>                                         *<Plug>(sexp_flow_to_prev_open)*
-<M-}>                                        *<Plug>(sexp_flow_to_next_close)*
-        [count] open brackets backward or close brackets forward (ignoring any
-        brackets of the other type). Movement is NOT bounded by the parent
-        list.
-        Note: These two commands visit the same set of nodes as the preceding
-        two, but in reverse order: i.e.,
-            <M-{> "reverses" <M-]>
-            <M-}> "reverses" <M-[>
-
--- END ALTERNATIVES --
-
 Note: Another way of looking at the list flow commands is that the
 square-bracket commands tend to move down into lists, whereas the
 curly-bracket commands tend to move up and out of them. While it's true that
@@ -298,30 +275,30 @@ the square-bracket commands also move out of lists, they do so only when they
 can go no deeper. In this way, they are exactly like depth-first tree
 traversals, which always choose to descend when descent is possible.
 
-Examples:~
+List flow command examples:~
         Note: | denotes starting cursor position.
               ^ denotes positions reached by successive applications of the
                 indicated command.
 
-        sexp_flow_to_next_open               (forward / in)~
+        sexp_flow_to_next_open                forward / in~
                                    | (x1 (x2) (x3 (x4) (x5))) (x6)
                                      ^   ^    ^   ^    ^      ^
                                      1   2    3   4    5      6
                                    --------------------------->
 
-        sexp_flow_to_prev_open              (backward / out)~
+        sexp_flow_to_prev_open               backward / out~
                                      (x1 (x2) (x3 (x4) (x5))) (x6) |
                                      ^   ^    ^   ^    ^      ^
                                      6   5    4   3    2      1
                                      <------------------------------
 
-        sexp_flow_to_prev_close             (backward / in)~
+        sexp_flow_to_prev_close              backward / in~
                                      (x1) (((x2) (x3) x4) (x5) x6) |
                                         ^      ^    ^   ^    ^   ^
                                         6      5    4   3    2   1
                                      <------------------------------
 
-        sexp_flow_to_next_close              (forward / out)~
+        sexp_flow_to_next_close               forward / out~
                                    | (x1) (((x2) (x3) x4) (x5) x6)
                                         ^      ^    ^   ^    ^   ^
                                         1      2    3   4    5   6

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -201,8 +201,6 @@ function! s:sexp_create_mappings()
 
     for plug in ['sexp_indent',                    'sexp_indent_top',
                \ 'sexp_insert_at_list_head',       'sexp_insert_at_list_tail',
-               \ 'sexp_flow_to_prev_element_head', 'sexp_flow_to_next_element_head',
-               \ 'sexp_flow_to_prev_element_tail', 'sexp_flow_to_next_element_tail',
                \ 'sexp_splice_list']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
@@ -210,18 +208,20 @@ function! s:sexp_create_mappings()
         endif
     endfor
 
-    for plug in ['sexp_round_head_wrap_list',     'sexp_round_tail_wrap_list',
-               \ 'sexp_square_head_wrap_list',    'sexp_square_tail_wrap_list',
-               \ 'sexp_curly_head_wrap_list',     'sexp_curly_tail_wrap_list',
-               \ 'sexp_round_head_wrap_element',  'sexp_round_tail_wrap_element',
-               \ 'sexp_square_head_wrap_element', 'sexp_square_tail_wrap_element',
-               \ 'sexp_curly_head_wrap_element',  'sexp_curly_tail_wrap_element',
-               \ 'sexp_raise_list',               'sexp_raise_element',
-               \ 'sexp_swap_list_backward',       'sexp_swap_list_forward',
-               \ 'sexp_swap_element_backward',    'sexp_swap_element_forward',
-               \ 'sexp_emit_head_element',        'sexp_emit_tail_element',
-               \ 'sexp_capture_prev_element',     'sexp_capture_next_element',
-               \ 'sexp_flow_to_prev_list',        'sexp_flow_to_next_list']
+    for plug in ['sexp_round_head_wrap_list',      'sexp_round_tail_wrap_list',
+               \ 'sexp_square_head_wrap_list',     'sexp_square_tail_wrap_list',
+               \ 'sexp_curly_head_wrap_list',      'sexp_curly_tail_wrap_list',
+               \ 'sexp_round_head_wrap_element',   'sexp_round_tail_wrap_element',
+               \ 'sexp_square_head_wrap_element',  'sexp_square_tail_wrap_element',
+               \ 'sexp_curly_head_wrap_element',   'sexp_curly_tail_wrap_element',
+               \ 'sexp_raise_list',                'sexp_raise_element',
+               \ 'sexp_swap_list_backward',        'sexp_swap_list_forward',
+               \ 'sexp_swap_element_backward',     'sexp_swap_element_forward',
+               \ 'sexp_emit_head_element',         'sexp_emit_tail_element',
+               \ 'sexp_capture_prev_element',      'sexp_capture_next_element',
+               \ 'sexp_flow_to_prev_list',         'sexp_flow_to_next_list',
+               \ 'sexp_flow_to_prev_element_head', 'sexp_flow_to_next_element_head',
+               \ 'sexp_flow_to_prev_element_tail', 'sexp_flow_to_next_element_tail']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -302,16 +302,19 @@ DefplugN! onoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element(
 
 " Movements that 'flow' across lists.
 " Note: Because these movements are inherently inimical to preservation of
-" list structure, they are implemented as pure movement commands: i.e., no
-" operator pending or visual motions.
+" list structure, operator pending variants are omitted.
 Defplug   nnoremap sexp_flow_to_prev_list sexp#flow_to_adjacent_list('n', v:count, 0)
 DEFPLUG   xnoremap sexp_flow_to_prev_list <Esc>:<C-u>call sexp#flow_to_adjacent_list('v', v:count, 0)<CR>
 Defplug   nnoremap sexp_flow_to_next_list sexp#flow_to_adjacent_list('n', v:count, 1)
 DEFPLUG   xnoremap sexp_flow_to_next_list <Esc>:<C-u>call sexp#flow_to_adjacent_list('v', v:count, 1)<CR>
-DefplugN  nnoremap sexp_flow_to_prev_element_head sexp#flow_to_adjacent_element(v:count1, 0, 0)
-DefplugN  nnoremap sexp_flow_to_next_element_head sexp#flow_to_adjacent_element(v:count1, 1, 0)
-DefplugN  nnoremap sexp_flow_to_prev_element_tail sexp#flow_to_adjacent_element(v:count1, 0, 1)
-DefplugN  nnoremap sexp_flow_to_next_element_tail sexp#flow_to_adjacent_element(v:count1, 1, 1)
+DefplugN  nnoremap sexp_flow_to_prev_element_head sexp#flow_to_adjacent_element('n', v:count, 0, 0)
+DEFPLUG   xnoremap sexp_flow_to_prev_element_head <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:count, 0, 0)<CR>
+DefplugN  nnoremap sexp_flow_to_next_element_head sexp#flow_to_adjacent_element('n', v:count, 1, 0)
+DEFPLUG   xnoremap sexp_flow_to_next_element_head <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:count, 1, 0)<CR>
+DefplugN  nnoremap sexp_flow_to_prev_element_tail sexp#flow_to_adjacent_element('n', v:count, 0, 1)
+DEFPLUG   xnoremap sexp_flow_to_prev_element_tail <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:count, 0, 1)<CR>
+DefplugN  nnoremap sexp_flow_to_next_element_tail sexp#flow_to_adjacent_element('n', v:count, 1, 1)
+DEFPLUG   xnoremap sexp_flow_to_next_element_tail <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:count, 1, 1)<CR>
 
 " Adjacent top element
 Defplug  nnoremap sexp_move_to_prev_top_element sexp#move_to_adjacent_element('n', v:count, 0, 0, 1)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -50,6 +50,10 @@ let s:sexp_mappings = {
     \ 'sexp_move_to_next_element_head': '<M-w>',
     \ 'sexp_move_to_prev_element_tail': 'g<M-e>',
     \ 'sexp_move_to_next_element_tail': '<M-e>',
+    \ 'sexp_move_to_prev_ELEMENT_head': '<M-S-b>',
+    \ 'sexp_move_to_next_ELEMENT_head': '<M-S-w>',
+    \ 'sexp_move_to_prev_ELEMENT_tail': 'g<M-S-e>',
+    \ 'sexp_move_to_next_ELEMENT_tail': '<M-S-e>',
     \ 'sexp_move_to_prev_top_element':  '[[',
     \ 'sexp_move_to_next_top_element':  ']]',
     \ 'sexp_select_prev_element':       '[e',
@@ -193,8 +197,10 @@ function! s:sexp_create_mappings()
         endif
     endfor
 
-    for plug in ['sexp_indent',              'sexp_indent_top',
-               \ 'sexp_insert_at_list_head', 'sexp_insert_at_list_tail',
+    for plug in ['sexp_indent',                    'sexp_indent_top',
+               \ 'sexp_insert_at_list_head',       'sexp_insert_at_list_tail',
+               \ 'sexp_move_to_prev_ELEMENT_head', 'sexp_move_to_next_ELEMENT_head',
+               \ 'sexp_move_to_prev_ELEMENT_tail', 'sexp_move_to_next_ELEMENT_tail',
                \ 'sexp_splice_list']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
@@ -286,10 +292,8 @@ DEFPLUG   xnoremap sexp_move_to_next_element_head <Esc>:<C-u>call sexp#move_to_a
 DefplugN! onoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element('o', v:count, 1, 0, 0)
 
 " Adjacent ELEMENT head
-DefplugN  nnoremap sexp_move_to_prev_ELEMENT_head sexp#move_to_adjacent_ELEMENT('n', v:count, 0, 0, 0)
-DEFPLUG   xnoremap sexp_move_to_prev_ELEMENT_head <Esc>:<C-u>call sexp#move_to_adjacent_ELEMENT('v', v:prevcount, 0, 0, 0)<CR>
-DefplugN  nnoremap sexp_move_to_next_ELEMENT_head sexp#move_to_adjacent_ELEMENT('n', v:count, 1, 0, 0)
-DEFPLUG   xnoremap sexp_move_to_next_ELEMENT_head <Esc>:<C-u>call sexp#move_to_adjacent_ELEMENT('v', v:prevcount, 1, 0, 0)<CR>
+DefplugN  nnoremap sexp_move_to_prev_ELEMENT_head sexp#move_to_adjacent_ELEMENT('n', v:count, 0, 0)
+DefplugN  nnoremap sexp_move_to_next_ELEMENT_head sexp#move_to_adjacent_ELEMENT('n', v:count, 1, 0)
 
 " Adjacent element tail
 "
@@ -306,10 +310,8 @@ DefplugN! onoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element(
 "
 " Inclusive operator pending motions require a visual mode selection to
 " include the last character of a line.
-DefplugN  nnoremap sexp_move_to_prev_ELEMENT_tail sexp#move_to_adjacent_ELEMENT('n', v:count, 0, 1, 0)
-DEFPLUG   xnoremap sexp_move_to_prev_ELEMENT_tail <Esc>:<C-u>call sexp#move_to_adjacent_ELEMENT('v', v:prevcount, 0, 1, 0)<CR>
-DefplugN  nnoremap sexp_move_to_next_ELEMENT_tail sexp#move_to_adjacent_ELEMENT('n', v:count, 1, 1, 0)
-DEFPLUG   xnoremap sexp_move_to_next_ELEMENT_tail <Esc>:<C-u>call sexp#move_to_adjacent_ELEMENT('v', v:prevcount, 1, 1, 0)<CR>
+DefplugN  nnoremap sexp_move_to_prev_ELEMENT_tail sexp#move_to_adjacent_ELEMENT('n', v:count, 0, 1)
+DefplugN  nnoremap sexp_move_to_next_ELEMENT_tail sexp#move_to_adjacent_ELEMENT('n', v:count, 1, 1)
 
 " Adjacent top element
 Defplug  nnoremap sexp_move_to_prev_top_element sexp#move_to_adjacent_element('n', v:count, 0, 0, 1)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -177,10 +177,10 @@ endfunction
 " Bind <Plug> mappings in current buffer to values in g:sexp_mappings or
 " s:sexp_mappings
 function! s:sexp_create_mappings()
-    for plug in ['sexp_outer_list',        'sexp_inner_list',
-               \ 'sexp_outer_top_list',    'sexp_inner_top_list',
-               \ 'sexp_outer_string',      'sexp_inner_string',
-               \ 'sexp_outer_element',     'sexp_inner_element']
+    for plug in ['sexp_outer_list',     'sexp_inner_list',
+               \ 'sexp_outer_top_list', 'sexp_inner_top_list',
+               \ 'sexp_outer_string',   'sexp_inner_string',
+               \ 'sexp_outer_element',  'sexp_inner_element']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'xmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -201,8 +201,8 @@ function! s:sexp_create_mappings()
         endif
     endfor
 
-    for plug in ['sexp_indent',                    'sexp_indent_top',
-               \ 'sexp_insert_at_list_head',       'sexp_insert_at_list_tail',
+    for plug in ['sexp_indent',              'sexp_indent_top',
+               \ 'sexp_insert_at_list_head', 'sexp_insert_at_list_tail',
                \ 'sexp_splice_list']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
@@ -210,21 +210,21 @@ function! s:sexp_create_mappings()
         endif
     endfor
 
-    for plug in ['sexp_round_head_wrap_list',      'sexp_round_tail_wrap_list',
-               \ 'sexp_square_head_wrap_list',     'sexp_square_tail_wrap_list',
-               \ 'sexp_curly_head_wrap_list',      'sexp_curly_tail_wrap_list',
-               \ 'sexp_round_head_wrap_element',   'sexp_round_tail_wrap_element',
-               \ 'sexp_square_head_wrap_element',  'sexp_square_tail_wrap_element',
-               \ 'sexp_curly_head_wrap_element',   'sexp_curly_tail_wrap_element',
-               \ 'sexp_raise_list',                'sexp_raise_element',
-               \ 'sexp_swap_list_backward',        'sexp_swap_list_forward',
-               \ 'sexp_swap_element_backward',     'sexp_swap_element_forward',
-               \ 'sexp_emit_head_element',         'sexp_emit_tail_element',
-               \ 'sexp_capture_prev_element',      'sexp_capture_next_element',
-               \ 'sexp_flow_to_prev_close',        'sexp_flow_to_next_open',
-               \ 'sexp_flow_to_prev_open',         'sexp_flow_to_next_close',
-               \ 'sexp_flow_to_prev_leaf_head',    'sexp_flow_to_next_leaf_head',
-               \ 'sexp_flow_to_prev_leaf_tail',    'sexp_flow_to_next_leaf_tail']
+    for plug in ['sexp_round_head_wrap_list',     'sexp_round_tail_wrap_list',
+               \ 'sexp_square_head_wrap_list',    'sexp_square_tail_wrap_list',
+               \ 'sexp_curly_head_wrap_list',     'sexp_curly_tail_wrap_list',
+               \ 'sexp_round_head_wrap_element',  'sexp_round_tail_wrap_element',
+               \ 'sexp_square_head_wrap_element', 'sexp_square_tail_wrap_element',
+               \ 'sexp_curly_head_wrap_element',  'sexp_curly_tail_wrap_element',
+               \ 'sexp_raise_list',               'sexp_raise_element',
+               \ 'sexp_swap_list_backward',       'sexp_swap_list_forward',
+               \ 'sexp_swap_element_backward',    'sexp_swap_element_forward',
+               \ 'sexp_emit_head_element',        'sexp_emit_tail_element',
+               \ 'sexp_capture_prev_element',     'sexp_capture_next_element',
+               \ 'sexp_flow_to_prev_close',       'sexp_flow_to_next_open',
+               \ 'sexp_flow_to_prev_open',        'sexp_flow_to_next_close',
+               \ 'sexp_flow_to_prev_leaf_head',   'sexp_flow_to_next_leaf_head',
+               \ 'sexp_flow_to_prev_leaf_tail',   'sexp_flow_to_next_leaf_tail']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -290,7 +290,6 @@ DefplugN! onoremap sexp_move_to_prev_element_head sexp#move_to_adjacent_element(
 DefplugN  nnoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element('n', v:count, 1, 0, 0)
 DEFPLUG   xnoremap sexp_move_to_next_element_head <Esc>:<C-u>call sexp#move_to_adjacent_element('v', v:prevcount, 1, 0, 0)<CR>
 DefplugN! onoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element('o', v:count, 1, 0, 0)
-
 
 " Adjacent element tail
 "

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -44,18 +44,18 @@ let s:sexp_mappings = {
     \ 'sexp_inner_string':              'is',
     \ 'sexp_outer_element':             'ae',
     \ 'sexp_inner_element':             'ie',
-    \ 'sexp_move_to_prev_BRACKET':      '<M-(>',
-    \ 'sexp_move_to_next_BRACKET':      '<M-)>',
     \ 'sexp_move_to_prev_bracket':      '(',
     \ 'sexp_move_to_next_bracket':      ')',
     \ 'sexp_move_to_prev_element_head': '<M-b>',
     \ 'sexp_move_to_next_element_head': '<M-w>',
     \ 'sexp_move_to_prev_element_tail': 'g<M-e>',
     \ 'sexp_move_to_next_element_tail': '<M-e>',
-    \ 'sexp_move_to_prev_ELEMENT_head': '<M-S-b>',
-    \ 'sexp_move_to_next_ELEMENT_head': '<M-S-w>',
-    \ 'sexp_move_to_prev_ELEMENT_tail': 'g<M-S-e>',
-    \ 'sexp_move_to_next_ELEMENT_tail': '<M-S-e>',
+    \ 'sexp_flow_to_prev_list':         '<M-(>',
+    \ 'sexp_flow_to_next_list':         '<M-)>',
+    \ 'sexp_flow_to_prev_element_head': '<M-S-b>',
+    \ 'sexp_flow_to_next_element_head': '<M-S-w>',
+    \ 'sexp_flow_to_prev_element_tail': '<M-S-g>',
+    \ 'sexp_flow_to_next_element_tail': '<M-S-e>',
     \ 'sexp_move_to_prev_top_element':  '[[',
     \ 'sexp_move_to_next_top_element':  ']]',
     \ 'sexp_select_prev_element':       '[e',
@@ -201,9 +201,9 @@ function! s:sexp_create_mappings()
 
     for plug in ['sexp_indent',                    'sexp_indent_top',
                \ 'sexp_insert_at_list_head',       'sexp_insert_at_list_tail',
-               \ 'sexp_move_to_prev_BRACKET',      'sexp_move_to_next_BRACKET',
-               \ 'sexp_move_to_prev_ELEMENT_head', 'sexp_move_to_next_ELEMENT_head',
-               \ 'sexp_move_to_prev_ELEMENT_tail', 'sexp_move_to_next_ELEMENT_tail',
+               \ 'sexp_flow_to_prev_list',         'sexp_flow_to_next_list',
+               \ 'sexp_flow_to_prev_element_head', 'sexp_flow_to_next_element_head',
+               \ 'sexp_flow_to_prev_element_tail', 'sexp_flow_to_next_element_tail',
                \ 'sexp_splice_list']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
@@ -277,10 +277,6 @@ Defplug  nnoremap sexp_move_to_next_bracket sexp#docount(v:count, 'sexp#move_to_
 DEFPLUG  xnoremap sexp_move_to_next_bracket <Esc>:<C-u>call sexp#docount(v:prevcount, 'sexp#move_to_nearest_bracket', 'v', 1)<CR>
 Defplug! onoremap sexp_move_to_next_bracket sexp#move_to_nearest_bracket('o', 1)
 
-" Nearest BRACKET
-Defplug  nnoremap sexp_move_to_prev_BRACKET sexp#move_to_adjacent_BRACKET('n', v:count, 0)
-Defplug  nnoremap sexp_move_to_next_BRACKET sexp#move_to_adjacent_BRACKET('n', v:count, 1)
-
 " Adjacent element head
 "
 " Visual mappings must break out of visual mode in order to detect which end
@@ -292,9 +288,6 @@ DefplugN  nnoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element(
 DEFPLUG   xnoremap sexp_move_to_next_element_head <Esc>:<C-u>call sexp#move_to_adjacent_element('v', v:prevcount, 1, 0, 0)<CR>
 DefplugN! onoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element('o', v:count, 1, 0, 0)
 
-" Adjacent ELEMENT head
-DefplugN  nnoremap sexp_move_to_prev_ELEMENT_head sexp#move_to_adjacent_ELEMENT('n', v:count, 0, 0)
-DefplugN  nnoremap sexp_move_to_next_ELEMENT_head sexp#move_to_adjacent_ELEMENT('n', v:count, 1, 0)
 
 " Adjacent element tail
 "
@@ -307,12 +300,16 @@ DefplugN  nnoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element(
 DEFPLUG   xnoremap sexp_move_to_next_element_tail <Esc>:<C-u>call sexp#move_to_adjacent_element('v', v:prevcount, 1, 1, 0)<CR>
 DefplugN! onoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element('o', v:count, 1, 1, 0)
 
-" Adjacent ELEMENT tail
-"
-" Inclusive operator pending motions require a visual mode selection to
-" include the last character of a line.
-DefplugN  nnoremap sexp_move_to_prev_ELEMENT_tail sexp#move_to_adjacent_ELEMENT('n', v:count, 0, 1)
-DefplugN  nnoremap sexp_move_to_next_ELEMENT_tail sexp#move_to_adjacent_ELEMENT('n', v:count, 1, 1)
+" Movements that 'flow' across lists.
+" Note: Because these movements are inherently inimical to preservation of
+" list structure, they are implemented as pure movement commands: i.e., no
+" operator pending or visual motions.
+Defplug   nnoremap sexp_flow_to_prev_list sexp#flow_to_adjacent_list(v:count1, 0)
+Defplug   nnoremap sexp_flow_to_next_list sexp#flow_to_adjacent_list(v:count1, 1)
+DefplugN  nnoremap sexp_flow_to_prev_element_head sexp#flow_to_adjacent_element(v:count1, 0, 0)
+DefplugN  nnoremap sexp_flow_to_next_element_head sexp#flow_to_adjacent_element(v:count1, 1, 0)
+DefplugN  nnoremap sexp_flow_to_prev_element_tail sexp#flow_to_adjacent_element(v:count1, 0, 1)
+DefplugN  nnoremap sexp_flow_to_next_element_tail sexp#flow_to_adjacent_element(v:count1, 1, 1)
 
 " Adjacent top element
 Defplug  nnoremap sexp_move_to_prev_top_element sexp#move_to_adjacent_element('n', v:count, 0, 0, 1)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -50,14 +50,14 @@ let s:sexp_mappings = {
     \ 'sexp_move_to_next_element_head': '<M-w>',
     \ 'sexp_move_to_prev_element_tail': 'g<M-e>',
     \ 'sexp_move_to_next_element_tail': '<M-e>',
-    \ 'sexp_flow_in_to_prev_list':      '<M-[>',
-    \ 'sexp_flow_in_to_next_list':      '<M-]>',
-    \ 'sexp_flow_out_to_prev_list':     '<M-{>',
-    \ 'sexp_flow_out_to_next_list':     '<M-}>',
-    \ 'sexp_flow_to_prev_nonlist_head': '<M-S-b>',
-    \ 'sexp_flow_to_next_nonlist_head': '<M-S-w>',
-    \ 'sexp_flow_to_prev_nonlist_tail': '<M-S-g>',
-    \ 'sexp_flow_to_next_nonlist_tail': '<M-S-e>',
+    \ 'sexp_flow_to_prev_close':        '<M-[>',
+    \ 'sexp_flow_to_next_open':         '<M-]>',
+    \ 'sexp_flow_to_prev_open':         '<M-{>',
+    \ 'sexp_flow_to_next_close':        '<M-}>',
+    \ 'sexp_flow_to_prev_leaf_head':    '<M-S-b>',
+    \ 'sexp_flow_to_next_leaf_head':    '<M-S-w>',
+    \ 'sexp_flow_to_prev_leaf_tail':    '<M-S-g>',
+    \ 'sexp_flow_to_next_leaf_tail':    '<M-S-e>',
     \ 'sexp_move_to_prev_top_element':  '[[',
     \ 'sexp_move_to_next_top_element':  ']]',
     \ 'sexp_select_prev_element':       '[e',
@@ -221,10 +221,10 @@ function! s:sexp_create_mappings()
                \ 'sexp_swap_element_backward',     'sexp_swap_element_forward',
                \ 'sexp_emit_head_element',         'sexp_emit_tail_element',
                \ 'sexp_capture_prev_element',      'sexp_capture_next_element',
-               \ 'sexp_flow_in_to_prev_list',      'sexp_flow_in_to_next_list',
-               \ 'sexp_flow_out_to_prev_list',     'sexp_flow_out_to_next_list',
-               \ 'sexp_flow_to_prev_nonlist_head', 'sexp_flow_to_next_nonlist_head',
-               \ 'sexp_flow_to_prev_nonlist_tail', 'sexp_flow_to_next_nonlist_tail']
+               \ 'sexp_flow_to_prev_close',        'sexp_flow_to_next_open',
+               \ 'sexp_flow_to_prev_open',         'sexp_flow_to_next_close',
+               \ 'sexp_flow_to_prev_leaf_head',    'sexp_flow_to_next_leaf_head',
+               \ 'sexp_flow_to_prev_leaf_tail',    'sexp_flow_to_next_leaf_tail']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -303,26 +303,26 @@ DefplugN  nnoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element(
 DEFPLUG   xnoremap sexp_move_to_next_element_tail <Esc>:<C-u>call sexp#move_to_adjacent_element('v', v:prevcount, 1, 1, 0)<CR>
 DefplugN! onoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element('o', v:count, 1, 1, 0)
 
-" Movements that 'flow' across lists.
+" Movements that 'flow' in and out of lists.
 " Note: Because these movements are inherently inimical to preservation of
 " list structure, operator pending variants are omitted.
-Defplug   nnoremap sexp_flow_in_to_prev_list sexp#flow_to_nearest_list('n', v:count, 0, 0)
-DEFPLUG   xnoremap sexp_flow_in_to_prev_list <Esc>:<C-u>call sexp#flow_to_nearest_list('v', v:prevcount, 0, 0)<CR>
-Defplug   nnoremap sexp_flow_out_to_prev_list sexp#flow_to_nearest_list('n', v:count, 0, 1)
-DEFPLUG   xnoremap sexp_flow_out_to_prev_list <Esc>:<C-u>call sexp#flow_to_nearest_list('v', v:prevcount, 0, 1)<CR>
-Defplug   nnoremap sexp_flow_in_to_next_list sexp#flow_to_nearest_list('n', v:count, 1, 0)
-DEFPLUG   xnoremap sexp_flow_in_to_next_list <Esc>:<C-u>call sexp#flow_to_nearest_list('v', v:prevcount, 1, 0)<CR>
-Defplug   nnoremap sexp_flow_out_to_next_list sexp#flow_to_nearest_list('n', v:count, 1, 1)
-DEFPLUG   xnoremap sexp_flow_out_to_next_list <Esc>:<C-u>call sexp#flow_to_nearest_list('v', v:prevcount, 1, 1)<CR>
+Defplug   nnoremap sexp_flow_to_prev_close sexp#list_flow('n', v:count, 0, 1)
+DEFPLUG   xnoremap sexp_flow_to_prev_close <Esc>:<C-u>call sexp#list_flow('v', v:prevcount, 0, 1)<CR>
+Defplug   nnoremap sexp_flow_to_prev_open sexp#list_flow('n', v:count, 0, 0)
+DEFPLUG   xnoremap sexp_flow_to_prev_open <Esc>:<C-u>call sexp#list_flow('v', v:prevcount, 0, 0)<CR>
+Defplug   nnoremap sexp_flow_to_next_open sexp#list_flow('n', v:count, 1, 0)
+DEFPLUG   xnoremap sexp_flow_to_next_open <Esc>:<C-u>call sexp#list_flow('v', v:prevcount, 1, 0)<CR>
+Defplug   nnoremap sexp_flow_to_next_close sexp#list_flow('n', v:count, 1, 1)
+DEFPLUG   xnoremap sexp_flow_to_next_close <Esc>:<C-u>call sexp#list_flow('v', v:prevcount, 1, 1)<CR>
 
-DefplugN  nnoremap sexp_flow_to_prev_nonlist_head sexp#flow_to_nearest_nonlist('n', v:count, 0, 0)
-DEFPLUG   xnoremap sexp_flow_to_prev_nonlist_head <Esc>:<C-u>call sexp#flow_to_nearest_nonlist('v', v:prevcount, 0, 0)<CR>
-DefplugN  nnoremap sexp_flow_to_next_nonlist_head sexp#flow_to_nearest_nonlist('n', v:count, 1, 0)
-DEFPLUG   xnoremap sexp_flow_to_next_nonlist_head <Esc>:<C-u>call sexp#flow_to_nearest_nonlist('v', v:prevcount, 1, 0)<CR>
-DefplugN  nnoremap sexp_flow_to_prev_nonlist_tail sexp#flow_to_nearest_nonlist('n', v:count, 0, 1)
-DEFPLUG   xnoremap sexp_flow_to_prev_nonlist_tail <Esc>:<C-u>call sexp#flow_to_nearest_nonlist('v', v:prevcount, 0, 1)<CR>
-DefplugN  nnoremap sexp_flow_to_next_nonlist_tail sexp#flow_to_nearest_nonlist('n', v:count, 1, 1)
-DEFPLUG   xnoremap sexp_flow_to_next_nonlist_tail <Esc>:<C-u>call sexp#flow_to_nearest_nonlist('v', v:prevcount, 1, 1)<CR>
+DefplugN  nnoremap sexp_flow_to_prev_leaf_head sexp#leaf_flow('n', v:count, 0, 0)
+DEFPLUG   xnoremap sexp_flow_to_prev_leaf_head <Esc>:<C-u>call sexp#leaf_flow('v', v:prevcount, 0, 0)<CR>
+DefplugN  nnoremap sexp_flow_to_next_leaf_head sexp#leaf_flow('n', v:count, 1, 0)
+DEFPLUG   xnoremap sexp_flow_to_next_leaf_head <Esc>:<C-u>call sexp#leaf_flow('v', v:prevcount, 1, 0)<CR>
+DefplugN  nnoremap sexp_flow_to_prev_leaf_tail sexp#leaf_flow('n', v:count, 0, 1)
+DEFPLUG   xnoremap sexp_flow_to_prev_leaf_tail <Esc>:<C-u>call sexp#leaf_flow('v', v:prevcount, 0, 1)<CR>
+DefplugN  nnoremap sexp_flow_to_next_leaf_tail sexp#leaf_flow('n', v:count, 1, 1)
+DEFPLUG   xnoremap sexp_flow_to_next_leaf_tail <Esc>:<C-u>call sexp#leaf_flow('v', v:prevcount, 1, 1)<CR>
 
 " Adjacent top element
 Defplug  nnoremap sexp_move_to_prev_top_element sexp#move_to_adjacent_element('n', v:count, 0, 0, 1)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -175,10 +175,10 @@ endfunction
 " Bind <Plug> mappings in current buffer to values in g:sexp_mappings or
 " s:sexp_mappings
 function! s:sexp_create_mappings()
-    for plug in ['sexp_outer_list',     'sexp_inner_list',
-               \ 'sexp_outer_top_list', 'sexp_inner_top_list',
-               \ 'sexp_outer_string',   'sexp_inner_string',
-               \ 'sexp_outer_element',  'sexp_inner_element']
+    for plug in ['sexp_outer_list',        'sexp_inner_list',
+               \ 'sexp_outer_top_list',    'sexp_inner_top_list',
+               \ 'sexp_outer_string',      'sexp_inner_string',
+               \ 'sexp_outer_element',     'sexp_inner_element']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'xmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -201,7 +201,6 @@ function! s:sexp_create_mappings()
 
     for plug in ['sexp_indent',                    'sexp_indent_top',
                \ 'sexp_insert_at_list_head',       'sexp_insert_at_list_tail',
-               \ 'sexp_flow_to_prev_list',         'sexp_flow_to_next_list',
                \ 'sexp_flow_to_prev_element_head', 'sexp_flow_to_next_element_head',
                \ 'sexp_flow_to_prev_element_tail', 'sexp_flow_to_next_element_tail',
                \ 'sexp_splice_list']
@@ -221,7 +220,8 @@ function! s:sexp_create_mappings()
                \ 'sexp_swap_list_backward',       'sexp_swap_list_forward',
                \ 'sexp_swap_element_backward',    'sexp_swap_element_forward',
                \ 'sexp_emit_head_element',        'sexp_emit_tail_element',
-               \ 'sexp_capture_prev_element',     'sexp_capture_next_element']
+               \ 'sexp_capture_prev_element',     'sexp_capture_next_element',
+               \ 'sexp_flow_to_prev_list',        'sexp_flow_to_next_list']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -304,8 +304,10 @@ DefplugN! onoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element(
 " Note: Because these movements are inherently inimical to preservation of
 " list structure, they are implemented as pure movement commands: i.e., no
 " operator pending or visual motions.
-Defplug   nnoremap sexp_flow_to_prev_list sexp#flow_to_adjacent_list(v:count1, 0)
-Defplug   nnoremap sexp_flow_to_next_list sexp#flow_to_adjacent_list(v:count1, 1)
+Defplug   nnoremap sexp_flow_to_prev_list sexp#flow_to_adjacent_list('n', v:count, 0)
+DEFPLUG   xnoremap sexp_flow_to_prev_list <Esc>:<C-u>call sexp#flow_to_adjacent_list('v', v:count, 0)<CR>
+Defplug   nnoremap sexp_flow_to_next_list sexp#flow_to_adjacent_list('n', v:count, 1)
+DEFPLUG   xnoremap sexp_flow_to_next_list <Esc>:<C-u>call sexp#flow_to_adjacent_list('v', v:count, 1)<CR>
 DefplugN  nnoremap sexp_flow_to_prev_element_head sexp#flow_to_adjacent_element(v:count1, 0, 0)
 DefplugN  nnoremap sexp_flow_to_next_element_head sexp#flow_to_adjacent_element(v:count1, 1, 0)
 DefplugN  nnoremap sexp_flow_to_prev_element_tail sexp#flow_to_adjacent_element(v:count1, 0, 1)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -268,6 +268,12 @@ Defplug  nnoremap sexp_move_to_next_bracket sexp#docount(v:count, 'sexp#move_to_
 DEFPLUG  xnoremap sexp_move_to_next_bracket <Esc>:<C-u>call sexp#docount(v:prevcount, 'sexp#move_to_nearest_bracket', 'v', 1)<CR>
 Defplug! onoremap sexp_move_to_next_bracket sexp#move_to_nearest_bracket('o', 1)
 
+" Nearest BRACKET
+Defplug  nnoremap sexp_move_to_prev_BRACKET sexp#docount(v:count, 'sexp#move_to_nearest_BRACKET', 'n', 0)
+DEFPLUG  xnoremap sexp_move_to_prev_BRACKET <Esc>:<C-u>call sexp#docount(v:prevcount, 'sexp#move_to_nearest_BRACKET', 'v', 0)<CR>
+Defplug  nnoremap sexp_move_to_next_BRACKET sexp#docount(v:count, 'sexp#move_to_nearest_BRACKET', 'n', 1)
+DEFPLUG  xnoremap sexp_move_to_next_BRACKET <Esc>:<C-u>call sexp#docount(v:prevcount, 'sexp#move_to_nearest_BRACKET', 'v', 1)<CR>
+
 " Adjacent element head
 "
 " Visual mappings must break out of visual mode in order to detect which end
@@ -279,6 +285,12 @@ DefplugN  nnoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element(
 DEFPLUG   xnoremap sexp_move_to_next_element_head <Esc>:<C-u>call sexp#move_to_adjacent_element('v', v:prevcount, 1, 0, 0)<CR>
 DefplugN! onoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element('o', v:count, 1, 0, 0)
 
+" Adjacent ELEMENT head
+DefplugN  nnoremap sexp_move_to_prev_ELEMENT_head sexp#move_to_adjacent_ELEMENT('n', v:count, 0, 0, 0)
+DEFPLUG   xnoremap sexp_move_to_prev_ELEMENT_head <Esc>:<C-u>call sexp#move_to_adjacent_ELEMENT('v', v:prevcount, 0, 0, 0)<CR>
+DefplugN  nnoremap sexp_move_to_next_ELEMENT_head sexp#move_to_adjacent_ELEMENT('n', v:count, 1, 0, 0)
+DEFPLUG   xnoremap sexp_move_to_next_ELEMENT_head <Esc>:<C-u>call sexp#move_to_adjacent_ELEMENT('v', v:prevcount, 1, 0, 0)<CR>
+
 " Adjacent element tail
 "
 " Inclusive operator pending motions require a visual mode selection to
@@ -289,6 +301,15 @@ DefplugN! onoremap sexp_move_to_prev_element_tail sexp#move_to_adjacent_element(
 DefplugN  nnoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element('n', v:count, 1, 1, 0)
 DEFPLUG   xnoremap sexp_move_to_next_element_tail <Esc>:<C-u>call sexp#move_to_adjacent_element('v', v:prevcount, 1, 1, 0)<CR>
 DefplugN! onoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element('o', v:count, 1, 1, 0)
+
+" Adjacent ELEMENT tail
+"
+" Inclusive operator pending motions require a visual mode selection to
+" include the last character of a line.
+DefplugN  nnoremap sexp_move_to_prev_ELEMENT_tail sexp#move_to_adjacent_ELEMENT('n', v:count, 0, 1, 0)
+DEFPLUG   xnoremap sexp_move_to_prev_ELEMENT_tail <Esc>:<C-u>call sexp#move_to_adjacent_ELEMENT('v', v:prevcount, 0, 1, 0)<CR>
+DefplugN  nnoremap sexp_move_to_next_ELEMENT_tail sexp#move_to_adjacent_ELEMENT('n', v:count, 1, 1, 0)
+DEFPLUG   xnoremap sexp_move_to_next_ELEMENT_tail <Esc>:<C-u>call sexp#move_to_adjacent_ELEMENT('v', v:prevcount, 1, 1, 0)<CR>
 
 " Adjacent top element
 Defplug  nnoremap sexp_move_to_prev_top_element sexp#move_to_adjacent_element('n', v:count, 0, 0, 1)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -44,6 +44,8 @@ let s:sexp_mappings = {
     \ 'sexp_inner_string':              'is',
     \ 'sexp_outer_element':             'ae',
     \ 'sexp_inner_element':             'ie',
+    \ 'sexp_move_to_prev_BRACKET':      '<M-(>',
+    \ 'sexp_move_to_next_BRACKET':      '<M-)>',
     \ 'sexp_move_to_prev_bracket':      '(',
     \ 'sexp_move_to_next_bracket':      ')',
     \ 'sexp_move_to_prev_element_head': '<M-b>',
@@ -199,6 +201,7 @@ function! s:sexp_create_mappings()
 
     for plug in ['sexp_indent',                    'sexp_indent_top',
                \ 'sexp_insert_at_list_head',       'sexp_insert_at_list_tail',
+               \ 'sexp_move_to_prev_BRACKET',      'sexp_move_to_next_BRACKET',
                \ 'sexp_move_to_prev_ELEMENT_head', 'sexp_move_to_next_ELEMENT_head',
                \ 'sexp_move_to_prev_ELEMENT_tail', 'sexp_move_to_next_ELEMENT_tail',
                \ 'sexp_splice_list']
@@ -275,10 +278,8 @@ DEFPLUG  xnoremap sexp_move_to_next_bracket <Esc>:<C-u>call sexp#docount(v:prevc
 Defplug! onoremap sexp_move_to_next_bracket sexp#move_to_nearest_bracket('o', 1)
 
 " Nearest BRACKET
-Defplug  nnoremap sexp_move_to_prev_BRACKET sexp#docount(v:count, 'sexp#move_to_nearest_BRACKET', 'n', 0)
-DEFPLUG  xnoremap sexp_move_to_prev_BRACKET <Esc>:<C-u>call sexp#docount(v:prevcount, 'sexp#move_to_nearest_BRACKET', 'v', 0)<CR>
-Defplug  nnoremap sexp_move_to_next_BRACKET sexp#docount(v:count, 'sexp#move_to_nearest_BRACKET', 'n', 1)
-DEFPLUG  xnoremap sexp_move_to_next_BRACKET <Esc>:<C-u>call sexp#docount(v:prevcount, 'sexp#move_to_nearest_BRACKET', 'v', 1)<CR>
+Defplug  nnoremap sexp_move_to_prev_BRACKET sexp#move_to_adjacent_BRACKET('n', v:count, 0)
+Defplug  nnoremap sexp_move_to_next_BRACKET sexp#move_to_adjacent_BRACKET('n', v:count, 1)
 
 " Adjacent element head
 "

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -303,9 +303,7 @@ DefplugN  nnoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element(
 DEFPLUG   xnoremap sexp_move_to_next_element_tail <Esc>:<C-u>call sexp#move_to_adjacent_element('v', v:prevcount, 1, 1, 0)<CR>
 DefplugN! onoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element('o', v:count, 1, 1, 0)
 
-" Movements that 'flow' in and out of lists.
-" Note: Because these movements are inherently inimical to preservation of
-" list structure, operator pending variants are omitted.
+" List flow commands
 Defplug   nnoremap sexp_flow_to_prev_close sexp#list_flow('n', v:count, 0, 1)
 DEFPLUG   xnoremap sexp_flow_to_prev_close <Esc>:<C-u>call sexp#list_flow('v', v:prevcount, 0, 1)<CR>
 Defplug   nnoremap sexp_flow_to_prev_open sexp#list_flow('n', v:count, 0, 0)
@@ -315,6 +313,7 @@ DEFPLUG   xnoremap sexp_flow_to_next_open <Esc>:<C-u>call sexp#list_flow('v', v:
 Defplug   nnoremap sexp_flow_to_next_close sexp#list_flow('n', v:count, 1, 1)
 DEFPLUG   xnoremap sexp_flow_to_next_close <Esc>:<C-u>call sexp#list_flow('v', v:prevcount, 1, 1)<CR>
 
+" Leaf flow commands
 DefplugN  nnoremap sexp_flow_to_prev_leaf_head sexp#leaf_flow('n', v:count, 0, 0)
 DEFPLUG   xnoremap sexp_flow_to_prev_leaf_head <Esc>:<C-u>call sexp#leaf_flow('v', v:prevcount, 0, 0)<CR>
 DefplugN  nnoremap sexp_flow_to_next_leaf_head sexp#leaf_flow('n', v:count, 1, 0)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -304,17 +304,17 @@ DefplugN! onoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element(
 " Note: Because these movements are inherently inimical to preservation of
 " list structure, operator pending variants are omitted.
 Defplug   nnoremap sexp_flow_to_prev_list sexp#flow_to_adjacent_list('n', v:count, 0)
-DEFPLUG   xnoremap sexp_flow_to_prev_list <Esc>:<C-u>call sexp#flow_to_adjacent_list('v', v:count, 0)<CR>
+DEFPLUG   xnoremap sexp_flow_to_prev_list <Esc>:<C-u>call sexp#flow_to_adjacent_list('v', v:prevcount, 0)<CR>
 Defplug   nnoremap sexp_flow_to_next_list sexp#flow_to_adjacent_list('n', v:count, 1)
-DEFPLUG   xnoremap sexp_flow_to_next_list <Esc>:<C-u>call sexp#flow_to_adjacent_list('v', v:count, 1)<CR>
+DEFPLUG   xnoremap sexp_flow_to_next_list <Esc>:<C-u>call sexp#flow_to_adjacent_list('v', v:prevcount, 1)<CR>
 DefplugN  nnoremap sexp_flow_to_prev_element_head sexp#flow_to_adjacent_element('n', v:count, 0, 0)
-DEFPLUG   xnoremap sexp_flow_to_prev_element_head <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:count, 0, 0)<CR>
+DEFPLUG   xnoremap sexp_flow_to_prev_element_head <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:prevcount, 0, 0)<CR>
 DefplugN  nnoremap sexp_flow_to_next_element_head sexp#flow_to_adjacent_element('n', v:count, 1, 0)
-DEFPLUG   xnoremap sexp_flow_to_next_element_head <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:count, 1, 0)<CR>
+DEFPLUG   xnoremap sexp_flow_to_next_element_head <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:prevcount, 1, 0)<CR>
 DefplugN  nnoremap sexp_flow_to_prev_element_tail sexp#flow_to_adjacent_element('n', v:count, 0, 1)
-DEFPLUG   xnoremap sexp_flow_to_prev_element_tail <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:count, 0, 1)<CR>
+DEFPLUG   xnoremap sexp_flow_to_prev_element_tail <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:prevcount, 0, 1)<CR>
 DefplugN  nnoremap sexp_flow_to_next_element_tail sexp#flow_to_adjacent_element('n', v:count, 1, 1)
-DEFPLUG   xnoremap sexp_flow_to_next_element_tail <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:count, 1, 1)<CR>
+DEFPLUG   xnoremap sexp_flow_to_next_element_tail <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:prevcount, 1, 1)<CR>
 
 " Adjacent top element
 Defplug  nnoremap sexp_move_to_prev_top_element sexp#move_to_adjacent_element('n', v:count, 0, 0, 1)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -50,12 +50,14 @@ let s:sexp_mappings = {
     \ 'sexp_move_to_next_element_head': '<M-w>',
     \ 'sexp_move_to_prev_element_tail': 'g<M-e>',
     \ 'sexp_move_to_next_element_tail': '<M-e>',
-    \ 'sexp_flow_to_prev_list':         '<M-(>',
-    \ 'sexp_flow_to_next_list':         '<M-)>',
-    \ 'sexp_flow_to_prev_element_head': '<M-S-b>',
-    \ 'sexp_flow_to_next_element_head': '<M-S-w>',
-    \ 'sexp_flow_to_prev_element_tail': '<M-S-g>',
-    \ 'sexp_flow_to_next_element_tail': '<M-S-e>',
+    \ 'sexp_flow_in_to_prev_list':      '<M-[>',
+    \ 'sexp_flow_in_to_next_list':      '<M-]>',
+    \ 'sexp_flow_out_to_prev_list':     '<M-{>',
+    \ 'sexp_flow_out_to_next_list':     '<M-}>',
+    \ 'sexp_flow_to_prev_nonlist_head': '<M-S-b>',
+    \ 'sexp_flow_to_next_nonlist_head': '<M-S-w>',
+    \ 'sexp_flow_to_prev_nonlist_tail': '<M-S-g>',
+    \ 'sexp_flow_to_next_nonlist_tail': '<M-S-e>',
     \ 'sexp_move_to_prev_top_element':  '[[',
     \ 'sexp_move_to_next_top_element':  ']]',
     \ 'sexp_select_prev_element':       '[e',
@@ -219,9 +221,10 @@ function! s:sexp_create_mappings()
                \ 'sexp_swap_element_backward',     'sexp_swap_element_forward',
                \ 'sexp_emit_head_element',         'sexp_emit_tail_element',
                \ 'sexp_capture_prev_element',      'sexp_capture_next_element',
-               \ 'sexp_flow_to_prev_list',         'sexp_flow_to_next_list',
-               \ 'sexp_flow_to_prev_element_head', 'sexp_flow_to_next_element_head',
-               \ 'sexp_flow_to_prev_element_tail', 'sexp_flow_to_next_element_tail']
+               \ 'sexp_flow_in_to_prev_list',      'sexp_flow_in_to_next_list',
+               \ 'sexp_flow_out_to_prev_list',     'sexp_flow_out_to_next_list',
+               \ 'sexp_flow_to_prev_nonlist_head', 'sexp_flow_to_next_nonlist_head',
+               \ 'sexp_flow_to_prev_nonlist_tail', 'sexp_flow_to_next_nonlist_tail']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -303,18 +306,23 @@ DefplugN! onoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element(
 " Movements that 'flow' across lists.
 " Note: Because these movements are inherently inimical to preservation of
 " list structure, operator pending variants are omitted.
-Defplug   nnoremap sexp_flow_to_prev_list sexp#flow_to_adjacent_list('n', v:count, 0)
-DEFPLUG   xnoremap sexp_flow_to_prev_list <Esc>:<C-u>call sexp#flow_to_adjacent_list('v', v:prevcount, 0)<CR>
-Defplug   nnoremap sexp_flow_to_next_list sexp#flow_to_adjacent_list('n', v:count, 1)
-DEFPLUG   xnoremap sexp_flow_to_next_list <Esc>:<C-u>call sexp#flow_to_adjacent_list('v', v:prevcount, 1)<CR>
-DefplugN  nnoremap sexp_flow_to_prev_element_head sexp#flow_to_adjacent_element('n', v:count, 0, 0)
-DEFPLUG   xnoremap sexp_flow_to_prev_element_head <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:prevcount, 0, 0)<CR>
-DefplugN  nnoremap sexp_flow_to_next_element_head sexp#flow_to_adjacent_element('n', v:count, 1, 0)
-DEFPLUG   xnoremap sexp_flow_to_next_element_head <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:prevcount, 1, 0)<CR>
-DefplugN  nnoremap sexp_flow_to_prev_element_tail sexp#flow_to_adjacent_element('n', v:count, 0, 1)
-DEFPLUG   xnoremap sexp_flow_to_prev_element_tail <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:prevcount, 0, 1)<CR>
-DefplugN  nnoremap sexp_flow_to_next_element_tail sexp#flow_to_adjacent_element('n', v:count, 1, 1)
-DEFPLUG   xnoremap sexp_flow_to_next_element_tail <Esc>:<C-u>call sexp#flow_to_adjacent_element('v', v:prevcount, 1, 1)<CR>
+Defplug   nnoremap sexp_flow_in_to_prev_list sexp#flow_to_nearest_list('n', v:count, 0, 0)
+DEFPLUG   xnoremap sexp_flow_in_to_prev_list <Esc>:<C-u>call sexp#flow_to_nearest_list('v', v:prevcount, 0, 0)<CR>
+Defplug   nnoremap sexp_flow_out_to_prev_list sexp#flow_to_nearest_list('n', v:count, 0, 1)
+DEFPLUG   xnoremap sexp_flow_out_to_prev_list <Esc>:<C-u>call sexp#flow_to_nearest_list('v', v:prevcount, 0, 1)<CR>
+Defplug   nnoremap sexp_flow_in_to_next_list sexp#flow_to_nearest_list('n', v:count, 1, 0)
+DEFPLUG   xnoremap sexp_flow_in_to_next_list <Esc>:<C-u>call sexp#flow_to_nearest_list('v', v:prevcount, 1, 0)<CR>
+Defplug   nnoremap sexp_flow_out_to_next_list sexp#flow_to_nearest_list('n', v:count, 1, 1)
+DEFPLUG   xnoremap sexp_flow_out_to_next_list <Esc>:<C-u>call sexp#flow_to_nearest_list('v', v:prevcount, 1, 1)<CR>
+
+DefplugN  nnoremap sexp_flow_to_prev_nonlist_head sexp#flow_to_nearest_nonlist('n', v:count, 0, 0)
+DEFPLUG   xnoremap sexp_flow_to_prev_nonlist_head <Esc>:<C-u>call sexp#flow_to_nearest_nonlist('v', v:prevcount, 0, 0)<CR>
+DefplugN  nnoremap sexp_flow_to_next_nonlist_head sexp#flow_to_nearest_nonlist('n', v:count, 1, 0)
+DEFPLUG   xnoremap sexp_flow_to_next_nonlist_head <Esc>:<C-u>call sexp#flow_to_nearest_nonlist('v', v:prevcount, 1, 0)<CR>
+DefplugN  nnoremap sexp_flow_to_prev_nonlist_tail sexp#flow_to_nearest_nonlist('n', v:count, 0, 1)
+DEFPLUG   xnoremap sexp_flow_to_prev_nonlist_tail <Esc>:<C-u>call sexp#flow_to_nearest_nonlist('v', v:prevcount, 0, 1)<CR>
+DefplugN  nnoremap sexp_flow_to_next_nonlist_tail sexp#flow_to_nearest_nonlist('n', v:count, 1, 1)
+DEFPLUG   xnoremap sexp_flow_to_next_nonlist_tail <Esc>:<C-u>call sexp#flow_to_nearest_nonlist('v', v:prevcount, 1, 1)<CR>
 
 " Adjacent top element
 Defplug  nnoremap sexp_move_to_prev_top_element sexp#move_to_adjacent_element('n', v:count, 0, 0, 1)


### PR DESCRIPTION
**Synopsis**
Adds commands for moving in and out of lists in a way that's not possible with vim-sexp's other movement commands. Something like _Paredit_'s up/down list commands, but with a traversal paradigm inspired by the Emacs _Lispy_ package's "flow" command.

**Motivation**
Although vim-sexp already provides commands for moving forward and backward _within_ a list, sometimes you want to "escape" from the current list, or descend into a child list. The added commands are called "flow commands" because they permit you to flow freely in and out of lists. In fact, it is possible to use an unbroken sequence of flow commands to move all the way from one end of the buffer to the other. Flow commands fall into 2 basic categories:

1. List
   Land only on brackets. There are 4 variants, differentiated by both the direction moved in the buffer, and the type of bracket landed on (open or close).
   
2. Leaf
   Land only on leaf (non-list) elements (atoms, strings, comments)

See doc/vim-sexp.txt for details and examples...
