### PR TITLE
Convolute

### DIFF
--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -1650,8 +1650,8 @@ fu! sexp#convolute(count, ...)
             let pos = s:nearest_element_terminal(1, 0)
         endif
     endif
-    " Do the inner/outer lists end on same line?
-    let colinear_ends = tpos_o[1] == pos[1]
+    " Will the closing bracket's distance from eol be changed by convolute?
+    let edist_changing = tpos_i[1] == pos[1] && tpos_o[1] != pos[1]
 
     " Record distance from dividing point to end of line to facilitate
     " subsequent cursor positioning
@@ -1686,7 +1686,7 @@ fu! sexp#convolute(count, ...)
     " Note: When outer list ends on a different line from inner list, the
     " convolution will decrease number of close brackets after pos by 1.
     " Assumption: Closing brackets always a single byte.
-    let pos[2] = col([pos[1], '$']) - pos_edist - !colinear_ends
+    let pos[2] = col([pos[1], '$']) - pos_edist + edist_changing
     call s:setcursor(pos)
 
     " Restore marks

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -1672,7 +1672,7 @@ endfunction
 " Logic:
 " 1. Attempt to position at head of current element.
 " 2. Cut text back to beginning of containing form.
-" 3. Raise what remains of the form (saving open/close brackets).
+" 3. Splice what remains of the form (saving open/close brackets).
 " 4. Wrap the form <count>+1 levels up with the saved open/close brackets,
 "    placing the text cut from step 2 just inside the open.
 " 5. Re-indent the form *containing* the newly-added form.
@@ -1680,8 +1680,6 @@ endfunction
 "    Note: In the general case, this will leave cursor where it was before the
 "    convolute.
 fu! sexp#convolute(count, ...)
-    " Save marks/pos for subsequent restore.
-    let marks = s:get_visual_marks()
     let cursor = getpos('.')
 
     " Var Nomenclature:
@@ -1723,8 +1721,6 @@ fu! sexp#convolute(count, ...)
     " 3. at cursor (when in whitespace preceding closing bracket)
     if cursor == tpos_i
         " Special Case: Cursor on closing bracket
-        " Alternative: Could use test like this.
-        " if !(pos[1] > 0 && getline(pos[1])[pos[2] - 1] =~# s:closing_bracket)
         let pos = tpos_i
     else
         " Try to position on head of current element (including macro chars).
@@ -1784,9 +1780,6 @@ fu! sexp#convolute(count, ...)
     " Assumption: Closing brackets always a single byte.
     let pos[2] = col([pos[1], '$']) - pos_edist + edist_changing
     call s:setcursor(pos)
-
-    " Restore marks
-    call s:set_visual_marks(marks)
 endfu
 
 " Remove brackets from current list, placing cursor at position of deleted

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -1582,9 +1582,13 @@ function! s:yankdel_range(start, end, del, ...)
             exe sl + 1 "," el - 1 a:del ? "d" : "y" "a"
             let ret .= "\n" . @a
             let @a = reg_save
+        else
+            " No linewise :y/:d cmd means we have to add NL before final line
+            " manually.
+            let ret .= "\n"
         endif
         " Accumulate in-range portion of final line.
-        let ret .= "\n" . strpart(elt, 0, ec)
+        let ret .= strpart(elt, 0, ec)
     endif
     " Fix cursor position if it was invalidated by delete.
     if a:del

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -1827,6 +1827,15 @@ fu! sexp#convolute(count, ...)
     let del = s:yankdel_range(bpos_i, pos, 1, [0, 0])
     let bra = s:yankdel_range(spos_i, bpos_i, 1, 1)
 
+    " Since the deleted text is going to be prepended to a list, make sure
+    " that if it contains non-whitespace, it ends with whitespace. Normally,
+    " our positioning on the start of an element will ensure this happens
+    " naturally, but there are corner cases where it doesn't: e.g., when we're
+    " positioned on a list closing bracket.
+    if del =~ '\%(\S.*\)\@<=\S$'
+        let del .= ' '
+    endif
+
     " Note: Deletion above may have invalidated tpos_o; use bpos_o to find it.
     call s:setcursor(bpos_o)
     let tpos_o = s:nearest_bracket(1)

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -262,42 +262,51 @@ LIST MANIPULATION (normal, visual)~
         list, element, or visual selection.
 
 <LocalLeader>?                                        *<Plug>(sexp_convolute)*
-        Splice the tail of the current list (ie, the elements after the
-        cursor) into the enclosing list, moving the head of the current list
-        (ie, the "car" and all elements up to cursor) to the head of a
-        new list containing the [count]th parent of the current list. This
-        mapping is not available in visual mode.
-        Note: This convolute is very similar to the emacs paredit version, but
-        in some cases a bit smarter. For instance, paredit always breaks _at_
-        the cursor, even if this means doing something silly (and potentially
-        dangerous) like splitting an atom. Vim-sexp on the other hand always
-        attempts to divide the current list at a sensible location: preferably
-        at the head of the current element (or the subsequent one if cursor is
-        in whitespace between elements).
+        Splice the tail of the current list into the current list's parent,
+        moving the head of the current list to the head of a new list
+        containing the [count]th parent of the current list.
+
+        Definitions~
+        current list:  list containing cursor
+        list head:     elements in current list lying completely before cursor
+        list tail:     elements in current list lying on or after cursor
+
+        Note: This mapping is not available in visual mode. (Since convolution
+        is defined in terms of cursor position, a visual mode variant would
+        introduce significant ambiguity without providing any appreciable
+        benefit: hence, convolute is supported only in normal mode.)
+
+        Comparison with Emacs Paredit~
+        This convolute is very similar to the Emacs Paredit version, but in
+        some cases a bit smarter. For instance, Paredit always divides the
+        current list _at_ the cursor, even if this means doing something silly
+        (and potentially dangerous) like splitting an atom. Vim-sexp on the
+        other hand always attempts to divide the current list at a sensible
+        location: preferably at the head of the current element (or the
+        subsequent one if cursor is in whitespace between elements).
 
         Intended Use Case~
         Widen the scope of a let binding to include [count] ancestor forms.
-
-        Examples:~
-        (cursor position denoted by `|')
+        The following examples illustrate the intended usage.
+        Note: cursor position denoted by `|'
 
         Original Form:~
         (defun foo (a b)
           (if (bar x y)
-            (baz (let ((x (+ a b)) (y (* a b)))
-                   |(+ x y)))))
+              (baz (let ((x 1) (y 2))
+                     |(+ x y)))))
 
-        After convolute with [count]=1 (default):~
+        Example 1: convolute with [count]=1 (default):~
         (defun foo (a b)
           (if (bar x y)
-            (let ((x (+ a b)) (y (* a b)))
-              (baz |(+ x y)))))
+              (let ((x 1) (y 2))
+                (baz |(+ x y)))))
 
-        After convolute with [count]=2:~
+        Example 2: convolute with [count]=2:~
         (defun foo (a b)
-          (let ((x (+ a b)) (y (* a b)))
+          (let ((x 1) (y 2))
             (if (bar x y)
-              (baz |(+ x y)))))
+                (baz |(+ x y)))))
 
 <M-k>                                        *<Plug>(sexp_swap_list_backward)*
 <M-j>                                         *<Plug>(sexp_swap_list_forward)*

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -261,6 +261,44 @@ LIST MANIPULATION (normal, visual)~
         Replace [count] enclosing lists (compound FORMs) with the current
         list, element, or visual selection.
 
+<LocalLeader>?                                        *<Plug>(sexp_convolute)*
+        Splice the tail of the current list (ie, the elements after the
+        cursor) into the enclosing list, moving the head of the current list
+        (ie, the "car" and all elements up to cursor) to the head of a
+        new list containing the [count]th parent of the current list. This
+        mapping is not available in visual mode.
+        Note: This convolute is very similar to the emacs paredit version, but
+        in some cases a bit smarter. For instance, paredit always breaks _at_
+        the cursor, even if this means doing something silly (and potentially
+        dangerous) like splitting an atom. Vim-sexp on the other hand always
+        attempts to divide the current list at a sensible location: preferably
+        at the head of the current element (or the subsequent one if cursor is
+        in whitespace between elements).
+
+        Intended Use Case~
+        Widen the scope of a let binding to include [count] ancestor forms.
+
+        Examples:~
+        (cursor position denoted by `|')
+
+        Original Form:~
+        (defun foo (a b)
+          (if (bar x y)
+            (baz (let ((x (+ a b)) (y (* a b)))
+                   |(+ x y)))))
+
+        After convolute with [count]=1 (default):~
+        (defun foo (a b)
+          (if (bar x y)
+            (let ((x (+ a b)) (y (* a b)))
+              (baz |(+ x y)))))
+
+        After convolute with [count]=2:~
+        (defun foo (a b)
+          (let ((x (+ a b)) (y (* a b)))
+            (if (bar x y)
+              (baz |(+ x y)))))
+
 <M-k>                                        *<Plug>(sexp_swap_list_backward)*
 <M-j>                                         *<Plug>(sexp_swap_list_forward)*
 <M-h>                                     *<Plug>(sexp_swap_element_backward)*

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -71,6 +71,7 @@ let s:sexp_mappings = {
     \ 'sexp_insert_at_list_head':       '<LocalLeader>h',
     \ 'sexp_insert_at_list_tail':       '<LocalLeader>l',
     \ 'sexp_splice_list':               '<LocalLeader>@',
+    \ 'sexp_convolute':                 '<LocalLeader>?',
     \ 'sexp_raise_list':                '<LocalLeader>o',
     \ 'sexp_raise_element':             '<LocalLeader>O',
     \ 'sexp_swap_list_backward':        '<M-k>',
@@ -136,7 +137,6 @@ function! s:defplug(flags, mapmode, name, ...)
                  \ . ':<C-u>let b:sexp_count = v:count \| '
                  \ . (nojump ? '' : 'execute "normal! ' . (opmode ? 'vv' : '') . 'm`" \| ')
                  \ . 'call ' . substitute(rhs, '\v<v:count>', 'b:sexp_count', 'g')
-
     " Expression, non-repeating
     if !repeat || (repeat && !s:have_repeat_set)
         execute prefix . '<CR>'
@@ -195,7 +195,7 @@ function! s:sexp_create_mappings()
 
     for plug in ['sexp_indent',              'sexp_indent_top',
                \ 'sexp_insert_at_list_head', 'sexp_insert_at_list_tail',
-               \ 'sexp_splice_list']
+	       \ 'sexp_convolute',           'sexp_splice_list']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -352,6 +352,10 @@ Defplug! nnoremap sexp_raise_list    sexp#docount(v:count, 'sexp#raise', 'n', 's
 Defplug  xnoremap sexp_raise_list    sexp#docount(v:count, 'sexp#raise', 'v', '')
 Defplug! nnoremap sexp_raise_element sexp#docount(v:count, 'sexp#raise', 'n', 'sexp#select_current_element', 'n', 1)
 Defplug  xnoremap sexp_raise_element sexp#docount(v:count, 'sexp#raise', 'v', '')
+
+" Convolute - BPS
+" Note: convolute takes pains to maintain cursor position.
+DefplugN nnoremap sexp_convolute sexp#convolute(v:count, 'n')
 
 " Splice list
 Defplug! nnoremap sexp_splice_list sexp#splice_list(v:count)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -353,9 +353,9 @@ Defplug  xnoremap sexp_raise_list    sexp#docount(v:count, 'sexp#raise', 'v', ''
 Defplug! nnoremap sexp_raise_element sexp#docount(v:count, 'sexp#raise', 'n', 'sexp#select_current_element', 'n', 1)
 Defplug  xnoremap sexp_raise_element sexp#docount(v:count, 'sexp#raise', 'v', '')
 
-" Convolute - BPS
-" Note: convolute takes pains to maintain cursor position.
-DefplugN nnoremap sexp_convolute sexp#convolute(v:count, 'n')
+" Convolute
+" Note: convolute takes pains to preserve cursor position: hence, 'nojump'.
+DefplugN! nnoremap sexp_convolute sexp#convolute(v:count, 'n')
 
 " Splice list
 Defplug! nnoremap sexp_splice_list sexp#splice_list(v:count)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -137,6 +137,7 @@ function! s:defplug(flags, mapmode, name, ...)
                  \ . ':<C-u>let b:sexp_count = v:count \| '
                  \ . (nojump ? '' : 'execute "normal! ' . (opmode ? 'vv' : '') . 'm`" \| ')
                  \ . 'call ' . substitute(rhs, '\v<v:count>', 'b:sexp_count', 'g')
+
     " Expression, non-repeating
     if !repeat || (repeat && !s:have_repeat_set)
         execute prefix . '<CR>'


### PR DESCRIPTION
**Synopsis**
Adds a convolute command, similar to the one provided by Emacs _Paredit_, but significantly smarter: e.g., breaks only at sensible locations, and preserves bracket types.

**Intended Use Case**
Widen the scope of a let binding to include [count] ancestor forms.
The following examples illustrate the intended usage.
**Note:** cursor position denoted by `|'

**Original Form:**
```
(defun foo (a b)
  (if (bar x y)
      (baz (let ((x 1) (y 2))
             |(+ x y)))))

```
**Example 1:** convolute with [count]=1 (default):
```
(defun foo (a b)
  (if (bar x y)
      (let ((x 1) (y 2))
        (baz |(+ x y)))))
```

**Example 2:** convolute with [count]=2:
```
(defun foo (a b)
  (let ((x 1) (y 2))
    (if (bar x y)
        (baz |(+ x y)))))

```