### PR TITLE
Additional motions, commands, text objects, and automatic whitespace cleanup logic

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -68,6 +68,7 @@ Text object selections refer to text _around_ the cursor.
 * The `aF` and `iF` objects select top-level COMPOUND FORMS.
 * The `as` and `is` objects select STRINGS.
 * The `ae` and `ie` objects select ELEMENTS.
+* The `ac` and `ic` objects select child ELEMENTS.
 
 ### Text Object Motions (normal, visual, operator-pending)
 
@@ -81,10 +82,36 @@ operator-pending mode.
 * The `[[` and `]]` motions move the cursor to an adjacent top-level ELEMENT.
 * The `[e` and `]e` mappings select an adjacent ELEMENT.
 
-### Indent Commands (normal)
+### Flow Motions (normal, visual)
+
+Like text object motions, flow motions move the cursor in normal mode and move the selection in visual mode. Unlike text object motions, flow motions are completely unconstrained by list structure, permitting the cursor to move freely in and out of compound forms. For this reason, flow-motions are not provided in operator-pending mode.
+
+TODO: Refine this...
+* The `<M-]>` motion moves the cursor forward by open brackets
+* The `<M-[>` motion moves the cursor backward by close brackets
+* The `<M-}>` motion moves the cursor forward by close brackets
+* The `<M-{>` motion moves the cursor backward by open brackets
+* The `<M-S-b>` motion moves the cursor backward to leaf head
+* The `<M-S-w>` motion moves the cursor forward to leaf head
+* The `<M-S-g>` motion moves the cursor backward to leaf tail
+* The `<M-S-e>` motion moves the cursor forward to leaf tail
+
+TODO: Need list/leaf concept overview...
+
+### Indent Commands (normal, visual)
 
 * `==` indents the current COMPOUND FORM without moving the cursor
-* `=-` indents the current top-level COMPOUND FORM without moving the cursor
+* `=-` indents the current top-level COMPOUND FORM without moving the cursor (normal mode only)
+* `<M-=>` indents and removes extra whitespace from the current COMPOUND FORM without moving the cursor
+* `<M-->` indents and removes extra whitespace from the current top-level COMPOUND FORM without moving the cursor (normal mode only)
+
+If `g:sexp_indent_does_clean` is set (false by default), the `==` and `=-` commands remove extra whitespace before performing indent. If you set this option, you should unmap `<M-=>` and `<M-->` to avoid creating redundant mappings.
+
+### Clone Commands (normal, visual)
+
+* The `<M-C>` and `<M-c>` commands create copies of one or more elements before or after the cursor.
+
+If `g:sexp_clone_does_indent` is set (true by default), all elements involved in the clone (both original and copies) will be indented.
 
 ### Wrap Commands (normal, visual)
 
@@ -114,8 +141,9 @@ current COMPOUND FORM or ELEMENT.
 * `<M-h>` and `<M-l>` swap the position of the current ELEMENT with a sibling ELEMENT.
 * `<M-S-j>` and `<M-S-k>` emit the terminal ELEMENTS of the current COMPOUND FORM.
 * `<M-S-h>` and `<M-S-l>` capture adjacent ELEMENTS into the current COMPOUND FORM.
+* `<M-?>` _convolutes_ the current COMPOUND FORM, splicing the tail of the current list into the current list's parent and moving the head of the current list to the head of a new list containing the parent of the current list.
 
-The last two commands are also known as `barfage` and `slurpage` in [paredit.el][].
+The `Emit` and `capture` commands are known as `barfage` and `slurpage` in [paredit.el][].
 
 ### Cursor Insertion (normal)
 

--- a/README.markdown
+++ b/README.markdown
@@ -85,6 +85,7 @@ operator-pending mode.
 ### Flow Motions (normal, visual)
 
 Flow motions move the cursor in normal mode and move (not extend) the selection in visual mode. Unlike text object motions, flow motions are completely unconstrained by list structure, permitting the cursor to move freely in and out of compound forms.
+
 Note: Since the application of delete operators across list boundaries could destroy structural integrity, flow-motions are not provided in operator-pending mode.
 
 There are 2 types of flow motions:
@@ -96,6 +97,7 @@ There are 2 types of flow motions:
 * The `<M-[>` motion moves the cursor backward by close brackets
 * The `<M-}>` motion moves the cursor forward by close brackets
 * The `<M-{>` motion moves the cursor backward by open brackets
+
 Hint: Square bracket commands tend to move down and into lists, curly braces up and out. If you picture a top-level form as a tree, `<M-]>`/`<M-[>` perform forwards/backwards depth-first recursive descents, and `<M-{>`/`<M-}>` may be used to "rewind" the descent.
 
 #### Leaf flow commands

--- a/README.markdown
+++ b/README.markdown
@@ -68,7 +68,7 @@ Text object selections refer to text _around_ the cursor.
 * The `aF` and `iF` objects select top-level COMPOUND FORMS.
 * The `as` and `is` objects select STRINGS.
 * The `ae` and `ie` objects select ELEMENTS.
-* The `ac` and `ic` objects select child ELEMENTS.
+* The `ac` and `ic` objects select Nth child ELEMENT from start/end of current COMPOUND FORM.
 
 ### Text Object Motions (normal, visual, operator-pending)
 
@@ -87,17 +87,22 @@ operator-pending mode.
 Flow motions move the cursor in normal mode and move (not extend) the selection in visual mode. Unlike text object motions, flow motions are completely unconstrained by list structure, permitting the cursor to move freely in and out of compound forms.
 Note: Since the application of delete operators across list boundaries could destroy structural integrity, flow-motions are not provided in operator-pending mode.
 
-TODO: Refine this...
+There are 2 types of flow motions:
+1. "list" motions land only on brackets
+1. "leaf" motions land only on non-list elements (e.g., atoms, strings and comments).
+
+#### List flow commands
 * The `<M-]>` motion moves the cursor forward by open brackets
 * The `<M-[>` motion moves the cursor backward by close brackets
 * The `<M-}>` motion moves the cursor forward by close brackets
 * The `<M-{>` motion moves the cursor backward by open brackets
+Hint: Square bracket commands tend to move down and into lists, curly braces up and out. If you picture a top-level form as a tree, `<M-]>`/`<M-[>` perform forwards/backwards depth-first recursive descents, and `<M-{>`/`<M-}>` may be used to "rewind" the descent.
+
+#### Leaf flow commands
 * The `<M-S-b>` motion moves the cursor backward to leaf head
 * The `<M-S-w>` motion moves the cursor forward to leaf head
 * The `<M-S-g>` motion moves the cursor backward to leaf tail
 * The `<M-S-e>` motion moves the cursor forward to leaf tail
-
-TODO: Need list/leaf concept overview...
 
 ### Indent Commands (normal, visual)
 
@@ -110,7 +115,7 @@ If `g:sexp_indent_does_clean` is set (false by default), the `==` and `=-` comma
 
 ### Clone Commands (normal, visual)
 
-* `<LocalLeader>c` inserts copy(s) of current list, element or visual selection before cursor without moving cursor
+* `<LocalLeader>c` inserts copy(s) of current list or visual selection before cursor without moving cursor
 * `<LocalLeader><LocalLeader>c` like previous, but inhibits insertion of newlines between copies
 * `<LocalLeader>C` inserts copy(s) of current element or visual selection before cursor without moving cursor
 * `<LocalLeader><LocalLeader>C` like previous, but inhibits insertion of newlines between copies

--- a/README.markdown
+++ b/README.markdown
@@ -110,8 +110,10 @@ If `g:sexp_indent_does_clean` is set (false by default), the `==` and `=-` comma
 
 ### Clone Commands (normal, visual)
 
-* `<LocalLeader>c` creates copy of current list or visual selection before cursor without moving cursor
-* `<LocalLeader>C` creates copy of current element or visual selection before cursor without moving cursor
+* `<LocalLeader>c` inserts copy(s) of current list, element or visual selection before cursor without moving cursor
+* `<LocalLeader><LocalLeader>c` like previous, but inhibits insertion of newlines between copies
+* `<LocalLeader>C` inserts copy(s) of current element or visual selection before cursor without moving cursor
+* `<LocalLeader><LocalLeader>C` like previous, but inhibits insertion of newlines between copies
 
 If `g:sexp_clone_does_indent` is set (true by default) and cloned text spans multiple lines, all elements involved in the clone (both original and copies) will be indented.
 

--- a/README.markdown
+++ b/README.markdown
@@ -84,7 +84,8 @@ operator-pending mode.
 
 ### Flow Motions (normal, visual)
 
-Like text object motions, flow motions move the cursor in normal mode and move the selection in visual mode. Unlike text object motions, flow motions are completely unconstrained by list structure, permitting the cursor to move freely in and out of compound forms. For this reason, flow-motions are not provided in operator-pending mode.
+Flow motions move the cursor in normal mode and move (not extend) the selection in visual mode. Unlike text object motions, flow motions are completely unconstrained by list structure, permitting the cursor to move freely in and out of compound forms.
+Note: Since the application of delete operators across list boundaries could destroy structural integrity, flow-motions are not provided in operator-pending mode.
 
 TODO: Refine this...
 * The `<M-]>` motion moves the cursor forward by open brackets
@@ -100,18 +101,19 @@ TODO: Need list/leaf concept overview...
 
 ### Indent Commands (normal, visual)
 
-* `==` indents the current COMPOUND FORM without moving the cursor
+* `==` indents the current COMPOUND FORM or visual selection without moving the cursor
 * `=-` indents the current top-level COMPOUND FORM without moving the cursor (normal mode only)
-* `<M-=>` indents and removes extra whitespace from the current COMPOUND FORM without moving the cursor
+* `<M-=>` indents and removes extra whitespace from the current COMPOUND FORM or visual selection without moving the cursor
 * `<M-->` indents and removes extra whitespace from the current top-level COMPOUND FORM without moving the cursor (normal mode only)
 
-If `g:sexp_indent_does_clean` is set (false by default), the `==` and `=-` commands remove extra whitespace before performing indent. If you set this option, you should unmap `<M-=>` and `<M-->` to avoid creating redundant mappings.
+If `g:sexp_indent_does_clean` is set (false by default), the `==` and `=-` commands remove extra whitespace before performing indent. If you set this option, you may wish to unmap `<M-=>` and `<M-->` to avoid creating redundant mappings.
 
 ### Clone Commands (normal, visual)
 
-* The `<M-C>` and `<M-c>` commands create copies of one or more elements before or after the cursor.
+* `<LocalLeader>c` creates copy of current list or visual selection before cursor without moving cursor
+* `<LocalLeader>C` creates copy of current element or visual selection before cursor without moving cursor
 
-If `g:sexp_clone_does_indent` is set (true by default), all elements involved in the clone (both original and copies) will be indented.
+If `g:sexp_clone_does_indent` is set (true by default) and cloned text spans multiple lines, all elements involved in the clone (both original and copies) will be indented.
 
 ### Wrap Commands (normal, visual)
 

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -1615,6 +1615,7 @@ function! s:get_cursor_and_visual_info()
         " TODO: Does Vim provide another way?
         let mode = mode()
         if mode !=? 'v'
+            let cursor = getpos('.')
             normal! gv
         endif
         " Note: When range begins past eol, exiting visual mode causes cursor to
@@ -1624,6 +1625,7 @@ function! s:get_cursor_and_visual_info()
         let o.at_end = s:compare_pos(getpos('.'), ve) >= 0
         if mode !=? 'v'
             exe "normal! \<Esc>"
+            call s:setcursor(cursor)
         endif
         let o.cursor = o.at_end ? ve : vs
     else
@@ -1659,8 +1661,6 @@ function! s:set_marks_around_current_element(mode, inner, ...)
     let prefer_leading_ws = 0
     if multi
         if a:mode ==? 'v'
-            " TODO: Don't like the duplication here. Perhaps get from object
-            " saved in pre_op...
             let vi = b:sexp_cmd_cache.cvi
             let dir = vi.at_end
             " Rationalize visual range.

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -742,8 +742,18 @@ function! s:ml_join(twwi)
             return [spos, epos]
         endif
     endif
-    " If here, we couldn't join...
-    return s:partial_ml_join(o)
+    " If here, only 2 join possibilities remain:
+    " 1. The better counterpart to !spos[1] && !bol && !eol earlier. Hmm...
+    "    Can we combine? Actually, maybe just handle this above: the only
+    "    difference between the 2 cases is whether we use [o.start, o.end] or
+    "    [spos, epos]; in fact, !bol && !eol makes the jlen test (above)
+    "    unnecessary!!!!
+    " 2. Partial line join
+    if !o.bol && !o.eol
+        return [spos, epos]
+    else
+        return s:partial_ml_join(o)
+    endif
 endfunction
 
 " TODO: Join may be a bit of a misnomer in the single line case.
@@ -770,9 +780,12 @@ function! s:partial_ml_join(twwi)
                 \ ? [0, o.ws_e[1] - 2, col([o.ws_e[1] - 2, '$']), 0]
                 \ : [0, o.ws_e[1] - 1, col([o.ws_e[1] - 1, '$']) - 1, 0]
         endif
+    elseif !o.bol
+        " !eol && !bol
+        "
     else
         " !eol && bol
-        " Rationale: Can't get into this function if !bol and !eol.
+        " Rationale: Can't get into this function if !bol and !eol (NOT TRUE!).
         " Subsequent element on same line as last selected element means
         " there's no trailing new line to leave. Select all leading whitespace
         " back to but not including first newline. I'm thinking maybe leave

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -767,7 +767,11 @@ function! s:partial_ml_join(twwi)
     return [start, end]
 endfunction
 
-" Given start and end positions, returns new positions [start', end']:
+" FIXME: Rework this comment completely to reflect changed logic!!!!!!!!!
+" Given start and end positions, returns new positions [start', end'],
+" according to logic described below.
+" !!!!!TODO: Pick up here... Question: Do we consider whitespace *under*
+" cursor?
 "
 "   * If trailing whitespace after end, end' is set to include the trailing
 "     whitespace up to the next element, unless start is preceded on its line
@@ -1810,6 +1814,7 @@ function! s:get_cursor_and_visual_info()
     return o
 endfunction
 
+" TODO: Update this comment.
 " Set visual marks to the start and end of the current element. If
 " inner is 0, trailing or leading whitespace is included by way of
 " s:terminals_with_whitespace().
@@ -2729,6 +2734,8 @@ function! s:cleanup_ws(open, ps)
                 \ || !next[1] && (!close[1] || !s:is_comment(prev[1], prev[2]))
                 \ || !prev[1] && (!open[1] || !s:is_comment(next[1], next[2])))
 
+        " FIXME: Need to handle whitespace collapse on single line. Currently
+        " handles only when next and prev are on different lines.
         if do_join || eff_next[1] - eff_prev[1] > 1
             " We're joining and/or removing empty lines.
             " TODO: Problem to have eff_next passed by ref in both spots?

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2679,6 +2679,8 @@ endfunction
 " Indent S-Expression, maintaining cursor position. This is similar to mapping
 " to =<Plug>(sexp_outer_list)`` except that it will fall back to top-level
 " elements not contained in a compound form (e.g. top-level comments).
+" FIXME!!!!: clean no longer needs to be tri-state: can be "force clean"
+" boolean.
 function! sexp#indent(mode, top, count, clean, ...)
     let win = winsaveview()
     let cursor = getpos('.')

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2851,7 +2851,8 @@ function! sexp#indent(mode, top, count, clean, ...)
     endif
     " Position pre-adjustment
     let adj = s:indent_preadjust_positions(
-        \ s:concat_positions(ps, start, end, cursor, vs, ve))
+        \ s:concat_positions(ps, start, end, cursor,
+            \ a:mode ==? 'n' ? [vs, ve] : []))
     silent keepjumps exe "normal! " . start[1] . 'G=' . end[1] . "G"
     " Position post-adjustment
     call s:indent_postadjust_positions(adj)

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2665,7 +2665,6 @@ endfunction
 " Indent S-Expression, maintaining cursor position. This is similar to mapping
 " to =<Plug>(sexp_outer_list)`` except that it will fall back to top-level
 " elements not contained in a compound form (e.g. top-level comments).
-" FIXME: Add param to force cleanup.
 function! sexp#indent(mode, top, count, clean, ...)
     let win = winsaveview()
     let cursor = getpos('.')
@@ -2707,21 +2706,6 @@ function! sexp#indent(mode, top, count, clean, ...)
         " TODO: Decide how to restore visual selection: should it be
         " [start,end] (constrained) or original selection (adjusted by
         " cleanup_ws).
-        " FIXME: s:constrained_range isn't right for this: it constrains based
-        " on the cursor position, and what I really want is a super region
-        " that includes all elements even partly selected.
-        " Example:
-        " ( ( a b (c d (e f))))
-        "     >---------<
-        " I think I'd want to select from a through the end of the list
-        " containing c and d. Note that s:constrained_range would give me this
-        " iff the keep_end arg were 0. What I really want is an inner element
-        " selection with cursor at the end of visual selection that's higher.
-        " Question: Is it possible that this would make sense for inner/outer
-        " element selections as well? In that case, I tend to think that it
-        " makes more sense to consider the cursor position, but that's just
-        " intuition at this point...
-        "let [start, end] = s:constrained_range(vi.vs, vi.ve, vi.at_end)
         let [start, end] = s:super_range(vi.vs, vi.ve)
     endif
     if a:clean
@@ -3132,6 +3116,8 @@ endfu
 function! s:get_clone_target(mode, before)
     let cursor = getpos('.')
     if a:mode ==? 'v'
+        " FIXME!!!: This is wrong. Needs to work more like super_range(). (In
+        " fact, may just use super_range().)
         return s:set_marks_around_current_element('v', 1, 0, 1)
     else
         " Get our bearings...

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2684,6 +2684,7 @@ function! sexp#indent(mode, top, count, clean, ...)
     let cursor = getpos('.')
     let [_b, line, col, _o] = getpos('.')
     let force_syntax = a:0 && !!a:1
+    " If caller hasn't specified clean, defer to option.
     let clean = a:clean < 0 ? g:sexp_indent_does_clean : !!a:clean
 
     if a:mode ==? 'n'
@@ -2722,7 +2723,7 @@ function! sexp#indent(mode, top, count, clean, ...)
         " cleanup_ws).
         let [start, end] = s:super_range(vi.vs, vi.ve)
     endif
-    if a:clean
+    if clean
         " Always force syntax update when we're modifying the buffer.
         let force_syntax = 1
         " Design Decision: Handle both non-list and list elements identically:

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3264,9 +3264,9 @@ function! s:get_clone_target_range(mode, after, list)
             " Are we on an element?
             let p = s:current_element_terminal(0)
             let found = p[1]
-            " Consider an element past the cursor if cloning after.
+            " Consider an element past the cursor.
             " Rationale: Feels right.
-            if !found && a:after
+            if !found
                 let p = getpos('.')
                 " Not on an element. Find adjacent (if one exists in applicable
                 " direction).
@@ -3275,7 +3275,7 @@ function! s:get_clone_target_range(mode, after, list)
             endif
             return found
                 \ ? s:set_marks_around_current_element('n', 1, 0, 1)
-                \ : [0, 0, 0, 0]
+                \ : [[0, 0, 0, 0], [0, 0, 0, 0]]
         endif
     endif
 endfunction

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2834,7 +2834,7 @@ function! sexp#indent(mode, top, count, clean, ...)
         let at_top = at_top || s:at_top(end[1], end[2])
         call s:cleanup_ws(start, at_top,
             \ s:concat_positions(ps, start, end, cursor,
-                \ a:mode ==? 'n' ? [vs, ve] : []]), end)
+                \ a:mode ==? 'n' ? [vs, ve] : []), end)
     endif
     " Caveat: Attempting to apply = operator in visual mode does not work
     " consistently.

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2863,6 +2863,8 @@ function! sexp#indent(mode, top, count, clean, ...)
     let win.col = cursor[2] - 1 " .col is zero-based
     " Restore (potentially adjusted) visual selection.
     call s:set_visual_marks([start, end])
+    " FIXME: Add logic similar to what's in sexp#clone to ensure we don't
+    " change visual marks for normal mode execution!
     call winrestview(win)
 endfunction
 

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3032,15 +3032,14 @@ function! s:cleanup_ws(start, at_top, ps, ...)
                 " line:
                 " 1. next is comment preceded by one or more blank lines
                 " 2. next and prev are at toplevel
-                " Note: Without the appended space, a position that started
-                " out within whitespace would move to first non-blank on the
-                " line following the newline(s), and that position is the one
-                " that would be preserved across the subsequent indent, even
-                " though the indent is likely to add back some leading
-                " whitespace, and it would be more natural to keep the
-                " position in it.
-                " FIXME-ws-contract-logic
-                let spl = precedes_com && gap > 2 || a:at_top ? "\n\n " : "\n "
+                " Note: Without the appended space (non-toplevel case only), a
+                " position that started out within whitespace would move to
+                " first non-blank on the line following the newline(s), and
+                " that position is the one that would be preserved across the
+                " subsequent indent, even though the indent is likely to add
+                " back some leading whitespace, within which it would be more
+                " natural to keep the position.
+                let spl = precedes_com && gap > 2 || a:at_top ? "\n\n" : "\n "
             endif
         " Single-line (whitespace between collinear elements)
         " Cursor Logic: If cursor is in whitespace to be contracted, but not
@@ -3232,7 +3231,8 @@ fu! sexp#convolute(count, ...)
     endif
 
     " Indent the outer list *and* the one that contains it.
-    call sexp#indent('n', 0, 2, clean)
+    " Let 'clean' be determined by options.
+    call sexp#indent('n', 0, 2, -1)
 
     " Re-calculate pos for final cursor positioning.
     " Note: When outer list ends on a different line from inner list, the

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2771,11 +2771,21 @@ function! s:cleanup_ws(start, ps, ...)
         " Descend into list.
         let next = s:list_head()
     else
-        " Cleanup specified range. Can't assume start is a list.
+        " Cleanup specified range without assuming anything about start.
         " Set things up as though loop processing is already in progress:
-        " e.g., open, prev and next (eff_* will be set in loop pre-update, so
-        " no need to set here).
-        let next = a:start[:]
+        " e.g., set open, prev and next (if non-null).
+        " Note: eff_* will be set in loop pre-update, so no need to set here.
+        call s:setcursor(a:start)
+        let next = s:current_element_terminal(0)
+        if !next[1]
+            " Not in element.
+            let next = s:nearest_element_terminal(1, 0)
+            if !s:compare_pos(next, getpos("."))
+                " No element on or after start. Null next so that close will
+                " be set in loop...
+                let next = [0, 0, 0, 0]
+            endif
+        endif
         let prev = s:nearest_element_terminal(0, 1)
         if !s:compare_pos(prev, getpos("."))
             " no previous element

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -569,6 +569,7 @@ function! s:terminals_with_whitespace_info(start, end)
     let bol_text = getline(a:start[1])[: a:start[2] - 1][: -2]
     let eol_text = getline(a:end[1])[a:end[2] - 1 :]
 
+    let [o.start, o.end] = [a:start, a:end]
     let o.bol = bol_text =~ '^\s*$'
     let o.eol = eol_text =~ '^.\s*$'
     " Are we at beginning of sexp?
@@ -596,8 +597,158 @@ function! s:terminals_with_whitespace_info(start, end)
         let o.precedes_com = s:is_comment(p[1], p[2])
     endif
 
+    " Find end of any sequences of whitespace immediately preceding start or
+    " following end.
+    " TODO: Decide whether to let adjacent_whitespace_terminal() handle
+    " special eol positioning, which is currently handled in the
+    " leading/trailing 'all' cases below.
+    let o['ws_s'] = s:adjacent_whitespace_terminal(start, 0)
+    let o['ws_e'] = s:adjacent_whitespace_terminal(end, 1)
+    " Set virtual start/end
+    if o.ws_s[2] == 1 && o.ws_s[1] > 1
+        " Include the newline preceding start.
+        let o.ws_vs = [0, o.ws_s[1] - 1, col([o.ws_s[1] - 1, '$']), 0]
+    else
+        let o.ws_vs = o.ws_s
+    endif
+    if s:offset_pos(o.ws_e, 1)[1] > o.ws_e[1]
+        " Include the newline following end.
+        let o.ws_ve[2] = col([o.ws_e[1], '$'])
+    else
+        let o.ws_ve = o.ws_e
+    endif
+    " TODO: Add sl/ml flags for convenience...
+    let o.ml = !o.bol && !o.eol "o.ws_vs[1] != o.ws_ve[1]
+    let o.sflags = {
+        \ 'ws': o.ws_s != a:start,
+        \ 'eol': o.ws_vs != o.ws_s,
+        \ 'real': o.ws_s != a:start && col([o.ws_s[1], '$']) > 1}
+    let o.eflags = {
+        \ 'ws': o.ws_e != a:end,
+        \ 'eol': o.ws_ve != o.ws_e,
+        \ 'real': o.ws_e != a:end && col([o.ws_e[1], '$']) > 1}
+
+
     call s:setcursor(cursor)
     return o
+endfunction
+
+" Probably rename now that I'm planning to use for single line case too.
+" Assumption: !bos and !eos but there might not be any actual, non-newline
+" whitespace between the two candidate join elements (in which case, we simply
+" take original start/end)
+" Note: Empty lines count as whitespace.
+function! s:maybe_join(twwi, prefer_leading)
+    let o = a:twwi
+    " Do we have *real* whitespace at beginning/end?
+    " Don't use blank line, only actual whitespace.
+    let sws = o.sflags.ws && !o.sflags.eol && o.sflags.real
+    let ews = o.eflags.ws && !o.eflags.eol && o.eflags.real
+    " Get first position to discard on first line and last position to discard
+    " on last line and first position to keep on last line.
+    " TODO: Handle case of leading whitespace specially.
+    let nojoin = 0
+    let ret = [[], []]
+    if ews && (!sws || !a:prefer_leading)
+        let spos = o.ws_vs
+        let eapos = o.ws_e
+        " Handle special case of a kept whitespace at bol.
+        let epos = eapos[2] == 1
+            \ ? [0, eapos[1] - 1, col([eapos[1] - 1, '$']), 0]
+            \ : s:offset_pos(eapos, -1)
+    elseif sws
+        " Handle special case of a kept whitespace at eol.
+        " Assumption: Prior logic ensures...
+        let spos = s:offset_pos(o.ws_s, 1)
+        if spos[1] > o.ws_s[1]
+            " Bring back to end of previous line
+            let spos = [0, o.ws_s[1], col([o.ws_s[1], '$']), 0]
+        endif
+        let epos = o.ws_ve
+    else
+        " No way to join completely.
+        let nojoin = 1
+        if o.eol
+            let spos = o.ws_vs
+            " Select up to but not including end of penultimate line (or final
+            " line if no leading whitespace on final line.
+            let epos = o.eflags.eol
+                \ ? o.ws_e
+                \ : s:offset_pos([0, o.ws_e[1], 1, 0])
+            let ret = [spos, epos]
+        elseif o.bol
+            " Use start as it was.
+            let ret = [twwi.start, o.ws_ve]
+        else
+            " Do the best we can do... May actually join elements spuriously,
+            " but only if user has done something weird like not putting space
+            " around lists.
+            let ret = [o.ws_s, o.ws_e]
+        endif
+    endif
+    if !nojoin
+        " Should have what I need now to determine length of joined line.
+        if spos[2] + strdisplaywidth(
+            \ getline(epos[1])[epos[2] - 1:], spos[2])
+            \ <= col([spos[1], '$'])
+            " Go ahead and join
+            let ret = [spos, epos]
+        else
+            " Can't join.
+            let ret = [o.ws_s, o.ws_e]
+        endif
+    endif
+endfunction
+
+function! s:adjust_sl_ws(start, end, prefer_leading)
+    " TODO: Add logic...
+endfunction
+
+function! s:partial_ml_join(twwi)
+    let o = a:twwi
+    if o.eol
+        " Keep only the final newline. (May be only 1.)
+        if o.eflags.eol
+            let start = o.ws_vs
+            if o.eflags.real
+                " Final whitespace is real char
+                let end = o.ws_e
+            else
+                " When blank line at end, you have to back up one to
+                " avoid a join.
+                let end = [0, o.ws_e[1] - 1, col([o.ws_e[1] - 1, '$']) - 1]
+            endif
+        else
+            " Last real ws not at end of line.
+            " Note: o.eol is relative to last selected element, not
+            " its trailing ws.
+            " Need to keep newline at start (since there's not one
+            " to keep at end); also, give back the trailing ws for
+            " reasons outlined earlier.
+            let end = s:offset_pos(end, 1)
+            if s:compare_pos(end, o.ws_e) > 1
+                " No space between el and subsequent el
+                let end = o.ws_e
+            endif
+            " Assumption: This is not first line.
+            " Leave any ws including newline on first line.
+            let start = [0, o.ws_vs[1] + 1, 1, 0]
+        endif
+    else
+        " Subsequent element on same line as last selected element:
+        " keep all trailing ws.
+        " Rationale: May be needed for separation, but if not, looks
+        " better to avoid pulling something to bol.
+        let end = s:offset_pos(end, 1)
+        if s:compare_pos(end, o.ws_e) > 1
+            " No space between el and com
+            let end = o.ws_e
+        endif
+        " Assumption: This is not first line.
+        " Leave any ws including newline on first line.
+        let start = [0, o.ws_vs[1] + 1, 1, 0]
+    endif
+    return [start, end]
 endfunction
 
 " Given start and end positions, returns new positions [start', end']:
@@ -621,6 +772,40 @@ endfunction
 " This behavior diverges from the behavior of the native text object aw in
 " that it allows multiline whitespace selections.
 function! s:terminals_with_whitespace(start, end, ...)
+    let [start, end] = [a:start, a:end]
+    let prefer_leading = a:0 && !!a:1
+
+    let o = s:terminals_with_whitespace_info(start, end)
+
+    if !o.ml
+        " Question: Should this handle single line only?
+        let [start, end] = s:adjust_sl_ws(start, end, prefer_leading)
+    else
+        " Multiline case
+        if o.follows_com || o.precedes_com
+            " Must leave final (and possibly only) newline.
+            let [start, end] = s:partial_ml_join(o)
+        elseif o.bos || o.eos
+            " Beginning or end of sexp and we've ruled out preceding/following
+            " comment, so just clean up.
+            let [start, end] = [o.ws_vs, o.ws_ve]
+        else
+            " Consider joining...
+            let [s, e] = s:maybe_join(o)
+            if s[1]
+                let [start, end] = [s, e]
+            else
+                " Can't do full join.
+                let [start, end] = s:partial_ml_join(o)
+            endif
+        endif
+    endif
+
+    " Handle
+    return [start, end]
+endfunction
+
+function! s:terminals_with_whitespace_good(start, end, ...)
     let start = a:start
     let end = a:end
     let prefer_leading = a:0 && !!a:1

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2720,7 +2720,8 @@ function! sexp#indent(mode, top, count, clean, ...)
         " element selections as well? In that case, I tend to think that it
         " makes more sense to consider the cursor position, but that's just
         " intuition at this point...
-        let [start, end] = s:constrained_range(vi.vs, vi.ve, vi.at_end)
+        "let [start, end] = s:constrained_range(vi.vs, vi.ve, vi.at_end)
+        let [start, end] = s:super_range(vi.vs, vi.ve)
     endif
     if a:clean
         " Always force syntax update when we're modifying the buffer.
@@ -2755,8 +2756,10 @@ function! sexp#indent(mode, top, count, clean, ...)
     let win.lnum = cursor[1]
     let win.col = col([cursor[1], '$']) - cur_edist - 1
     " Restore (potentially adjusted) visual selection.
-    let start[2] = col([start[1], '$']) - s_edist - 1
-    let end[2] = col([end[1], '$']) - e_edist - 1
+    " Caveat: Unlike winrestview object members, start/end use normal
+    " (1-based) col numbers.
+    let start[2] = col([start[1], '$']) - s_edist
+    let end[2] = col([end[1], '$']) - e_edist
     call s:set_visual_marks([start, end])
     call winrestview(win)
 endfunction

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -144,11 +144,11 @@ ie                                                *<Plug>(sexp_inner_element)*
               length of the deleted portion of the earlier line)
             * pull a comment following the selection onto the end of the line
               preceding the selection
+              Rationale: End of line comments are generally line-specific.
             * pull the element following the selection into an end of line
               comment
-              Rationale: End of line comments are generally line-specific.
             * join siblings (by removing all separating whitespace)
-            * keep initially selected whitespace preceding the first
+            * spare initially selected whitespace preceding the first
               selected element (unless removing the whitespace would violate
               one of the other constraints)
         Note: The rules may sound complex, but they mostly follow the
@@ -156,19 +156,20 @@ ie                                                *<Plug>(sexp_inner_element)*
 
 
                                                        *cleanup-vs-extension*
-        These commands can be used to "clean up" the current selection and/or
-        pull additional elements into it. Cleaning up might mean toggling an
-        "inner" selection to an "outer" one (or vice versa). Or perhaps you've
-        selected elements manually using v followed by movement commands, and
-        now you wish to select the surrounding whitespace in preparation for a
-        delete or change operation. In such cases, [count] includes the
-        current element or current selection: e.g., a default [count] of 1
-        performs cleanup only, and a count of 2 would pull in 1 additional
-        element. However, if you immediately execute the same command again,
-        vim-sexp knows that the current selection is already "cleaned up", so
-        all of [count] is applied towards additional elements. Vim-sexp
-        considers a command to be a repeat application if you haven't done any
-        of the following since the previous execution:
+        These text objects can be used to "clean up" the current selection
+        and/or pull additional elements into it. Cleaning up might mean
+        toggling an "inner" selection to an "outer" one (or vice versa). Or
+        perhaps you've selected elements manually using 'v' followed by
+        movement commands, and now you wish to select the surrounding
+        whitespace in preparation for a delete or change operation. In such
+        cases, [count] includes the current element or current selection:
+        e.g., a default [count] of 1 performs cleanup only, and a count of 2
+        would pull in 1 additional element. However, if you immediately
+        execute the same command again, vim-sexp knows that the current
+        selection is already "cleaned up", so all of [count] is applied
+        towards additional elements. Vim-sexp considers a command to be a
+        repeat application if you haven't done any of the following since the
+        previous execution:
 
             * Changed visual selection (but ok to move cursor to other end if
               you want next execution to pull from the other end)
@@ -192,7 +193,7 @@ ie                                                *<Plug>(sexp_inner_element)*
         comments, the motion targets the subsequent element, if it exists.
 
                                                        *selection-adjustment*
-        These commands always select a contiguous range of one or more
+        These text objects always select a contiguous range of one or more
         complete elements at the level defined by the cursor position. If the
         original visual selection extends outside the compound form containing
         the cursor, it is pre-truncated automatically prior to command
@@ -202,6 +203,7 @@ ie                                                *<Plug>(sexp_inner_element)*
 
         Examples of pre-truncation/extension~
         Note: ^ indicates original cursor position
+              - indicates visual range.
         >
                      (a b (c d) e f)
           original:        ^----- 
@@ -414,20 +416,20 @@ CLONE COMMANDS (normal, visual)~
 
 <M-C>                                              *<Plug>(sexp_clone_before)*
 <M-c>                                               *<Plug>(sexp_clone_after)*
-        Clone current or visually selected elements [count] times before or
-        after the cloned element(s).
+        Insert [count] clones of one or more elements before or after the
+        originals.
 
         In normal mode, the element under or after the cursor is cloned. In
-        visual mode, the range of elements fully or partially selected are
-        cloned.
+        visual mode, the range of elements either fully or partially selected
+        are cloned.
 
-        If option |g:sexp_indent_after_clone| is set, indent both original and
-        cloned elements. If an indent is required, |g:sexp_indent_does_clean|
-        determines whether extra whitespace is cleaned up. (See |clean-indent|
-        for details.)
+                                                          *indent-after-clone*
+        If |g:sexp_clone_does_indent| is set (set by default), indent the
+        compound form (or range of lines at toplevel) containing the cloned
+        elements. If indent is required, |g:sexp_indent_does_clean| determines
+        whether extra whitespace is cleaned up. (See |clean-indent| for
+        details.)
 
-        TODO: Flesh this out... Document the auto-indent and decide whether to
-        make it optional...
 
 INDENT COMMANDS (normal)~
 
@@ -441,11 +443,11 @@ INDENT COMMANDS (normal)~
         command, see |g:sexp_mappings| for more information.
 
                                                                 *clean-indent*
-        If option |g:sexp_indent_does_clean| is set (unset by default),
-        vim-sexp will attempt to cleanup the indented region by removing extra
-        whitespace. The rules for determining whether whitespace is "extra"
-        obey the principle of least surprise mentioned under
-        |whitespace-cleanup-rules| in the section on sexp_outer_element.
+        If |g:sexp_indent_does_clean| is set (unset by default), attempt to
+        cleanup the indented region by removing extra whitespace. The rules
+        for determining whether whitespace is "extra" obey the principle of
+        least surprise mentioned under |whitespace-cleanup-rules| in the
+        section on sexp_outer_element.
         Note: Blank lines are generally removed; however, if a comment is
         preceded by one or more blank lines, a single blank line will be kept.
 
@@ -461,10 +463,10 @@ INDENT COMMANDS (normal)~
         Note: Unbound by default.
 
 
-        *Tip:* Users who wish to use only one of the two forms of indent
-        (cleaning or non-cleaning) can unbind the clean and no_clean command
-        variants and use |g:sexp_indent_does_clean| to select the desired
-        behavior.
+        *Tip:* Users who expect to use only one of the two forms of indent
+        (cleaning or non-cleaning) can unbind the explicit "clean" and
+        "no_clean" command variants and use |g:sexp_indent_does_clean| to
+        ensure that == and =- give the desired behavior.
 
 
 WRAP COMMANDS (normal, visual)~
@@ -668,6 +670,22 @@ at head) after using a wrap command like |<Plug>(sexp_round_head_wrap_list)|.
         " Default
         let g:sexp_insert_after_wrap = 1
 <
+                                                    *g:sexp_indent_does_clean*
+Remove "extra" whitespace before performing an indent. Affects behavior of
+indent and clone commands. For details, see sections |clean-indent| and
+|indent-after-clone|.
+>
+        " Default
+        let g:sexp_indent_does_clean = 0
+<
+
+                                                    *g:sexp_clone_does_indent*
+Indent the elements involved in a clone operation.
+TODO: Flesh this out...
+>
+        " Default
+        let g:sexp_clone_does_indent = 1
+<
                                                              *g:sexp_mappings*
 Dictionary of user vim-sexp mappings. Keys are the <Plug> names without
 "<Plug>" or the surrounding parentheses, and the values are the key sequences
@@ -715,6 +733,8 @@ not necessary to copy all the entries to change a few.
             \ 'sexp_indent_top':                '=-',
             \ 'sexp_indent_and_clean':          '<M-=>',
             \ 'sexp_indent_and_clean_top':      '<M-->',
+            \ 'sexp_indent_no_clean':           '',
+            \ 'sexp_indent_no_clean_top':       '',
             \ 'sexp_round_head_wrap_list':      '<LocalLeader>i',
             \ 'sexp_round_tail_wrap_list':      '<LocalLeader>I',
             \ 'sexp_square_head_wrap_list':     '<LocalLeader>[',

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -401,14 +401,19 @@ Leaf flow commands~
 
 CLONE COMMANDS (normal, visual)~
 
-<M-C>                                              *<Plug>(sexp_clone_before)*
-<M-c>                                               *<Plug>(sexp_clone_after)*
-        Insert [count] clones of one or more elements before or after the
-        originals.
+<M-C>                                      *<Plug>(sexp_clone_element_before)*
+<M-c>                                         *<Plug>(sexp_clone_list_before)*
+<C-M-C>                                     *<Plug>(sexp_clone_element_after)*
+<C-M-c>                                        *<Plug>(sexp_clone_list_after)*
+        Insert [count] copies of the current list (compound FORM), element or
+        visual selection before or after the originals, preserving cursor
+        position relative to the originals.
 
-        In normal mode, the element under or after the cursor is cloned. In
-        visual mode, the range of elements either fully or partially selected
-        are cloned.
+        In normal mode, the element under the cursor or the list containing
+        the cursor is cloned. If cursor is not on an element, the "clone
+        element" commands look for an adjacent element/list, on the side given
+        by the command name. In visual mode, the range of elements either
+        fully or partially selected are cloned.
 
                                                           *indent-after-clone*
         If |g:sexp_clone_does_indent| is set (set by default), indent the
@@ -420,10 +425,6 @@ CLONE COMMANDS (normal, visual)~
         If indent is required, |g:sexp_indent_does_clean| determines
         whether extra whitespace is cleaned up. (See |clean-indent| for
         details.)
-
-        *Design-Decision-Needed* Do we need to support distinct element /
-        compound form variants of the clone commands (for sake of
-        consistency)?
 
 
 INDENT COMMANDS (normal, visual)~

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -206,6 +206,14 @@ ic                                             *<Plug>(sexp_inner_child_head)*
         The meaning of the terms "inner" and "outer" are as defined for the ie
         and ae text objects. 
 
+                                                  *child-objects-vs-[e-and-]e*
+        There is overlap between the use cases for child objects and the
+        select prev/next element commands ([e and ]e). The chief difference is
+        that a child object's offset is always specified relative to the start
+        or end of a compound form, whereas [e and ]e always search relative to
+        the cursor position. Depending on the use case, one form may be
+        significantly more convenient than the other.
+
 TEXT OBJECT MOTIONS (normal, visual, operator-pending)~
 
 (                                          *<Plug>(sexp_move_to_prev_bracket)*
@@ -412,6 +420,10 @@ CLONE COMMANDS (normal, visual)~
         If indent is required, |g:sexp_indent_does_clean| determines
         whether extra whitespace is cleaned up. (See |clean-indent| for
         details.)
+
+        *Design-Decision-Needed* Do we need to support distinct element /
+        compound form variants of the clone commands (for sake of
+        consistency)?
 
 
 INDENT COMMANDS (normal, visual)~

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -426,7 +426,11 @@ CLONE COMMANDS (normal, visual)~
                                                           *indent-after-clone*
         If |g:sexp_clone_does_indent| is set (set by default), indent the
         compound form (or range of lines at toplevel) containing the cloned
-        elements. If indent is required, |g:sexp_indent_does_clean| determines
+        elements.
+        Note: Indent is never performed for clone operations affecting only a
+        single line.
+
+        If indent is required, |g:sexp_indent_does_clean| determines
         whether extra whitespace is cleaned up. (See |clean-indent| for
         details.)
 
@@ -680,8 +684,8 @@ indent and clone commands. For details, see sections |clean-indent| and
 <
 
                                                     *g:sexp_clone_does_indent*
-Indent the elements involved in a clone operation.
-TODO: Flesh this out...
+Indent the elements involved in a multi-line clone operation. For details, see
+section |indent-after-clone|.
 >
         " Default
         let g:sexp_clone_does_indent = 1

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -401,18 +401,16 @@ Leaf flow commands~
 
 CLONE COMMANDS (normal, visual)~
 
-<M-C>                                      *<Plug>(sexp_clone_element_before)*
-<M-c>                                         *<Plug>(sexp_clone_list_before)*
-<C-M-C>                                     *<Plug>(sexp_clone_element_after)*
-<C-M-c>                                        *<Plug>(sexp_clone_list_after)*
+<LocalLeader>C                             *<Plug>(sexp_clone_element_before)*
+<LocalLeader>c                                *<Plug>(sexp_clone_list_before)*
+                                            *<Plug>(sexp_clone_element_after)*
+                                               *<Plug>(sexp_clone_list_after)*
         Insert [count] copies of the current list (compound FORM), element or
-        visual selection before or after the originals, preserving cursor
-        position relative to the originals.
+        visual selection before or after the original, preserving cursor
+        position relative to the original.
 
         In normal mode, the element under the cursor or the list containing
-        the cursor is cloned. If cursor is not on an element, the "clone
-        element" commands look for an adjacent element/list, on the side given
-        by the command name. In visual mode, the range of elements either
+        the cursor is cloned. In visual mode, the range of elements either
         fully or partially selected are cloned.
 
                                                           *indent-after-clone*

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -403,25 +403,37 @@ Leaf flow commands~
 
 CLONE COMMANDS (normal, visual)~
 
-<LocalLeader>c                                *<Plug>(sexp_clone_list_before)*
-<LocalLeader>C                             *<Plug>(sexp_clone_element_before)*
-                                               *<Plug>(sexp_clone_list_after)*
-                                            *<Plug>(sexp_clone_element_after)*
+<LocalLeader>c                                       *<Plug>(sexp_clone_list)*
+<LocalLeader>C                                    *<Plug>(sexp_clone_element)*
+<LocalLeader><LocalLeader>c                       *<Plug>(sexp_clone_list_sl)*
+<LocalLeader><LocalLeader>C                    *<Plug>(sexp_clone_element_sl)*
         Insert [count] copies of the current list (compound FORM), element or
-        visual selection before or after the original, preserving cursor
-        position relative to the original.
+        visual selection (hereafter referred to as "target"), preserving
+        cursor position relative to original.
 
         In visual mode, the selection is first expanded to cover all partially
         selected lists and elements so that structural integrity is
         maintained.
 
-        If the element(s) to be cloned are all within a single line, the
-        copies will be placed on the same line, unless any of the following
-        conditions are met:
-                * The final element within the cloned text is a comment
-                * The cloned text occupies the entire line (ignoring any
-                  leading or trailing whitespace)
-                 
+                                                 *single-vs-multi-line-clone*
+        A "multi-line" clone is one in which the copies of the target are
+        separated from the target (and from each other) by a newline. The
+        default logic selects multi-line operation whenever any of the
+        following conditions are met:
+                * target is on a line by itself
+                * target is at toplevel
+                * target ends in a comment
+
+        It is always possible to override the default logic, forcing either
+        single or multi-line operation, as follows:
+                Single-line~
+                        Use sl command variants ("_sl" suffix).
+                Multi-line~
+                        Supply an explicit [count] (possibly 1) to one of the
+                        non-sl command variants.
+                        Note: Vim-sexp can tell the difference between an
+                        explicit [count]==1 and a default [count] of 1.
+
 
                                                           *indent-after-clone*
         If |g:sexp_clone_does_indent| is set (the default), indent the
@@ -757,10 +769,10 @@ not necessary to copy all the entries to change a few.
             \ 'sexp_insert_at_list_tail':       '<LocalLeader>l',
             \ 'sexp_splice_list':               '<LocalLeader>@',
             \ 'sexp_convolute':                 '<LocalLeader>?',
-            \ 'sexp_clone_list_before           '<LocalLeader>c',
-            \ 'sexp_clone_list_after            '',
-            \ 'sexp_clone_element_before':      '<LocalLeader>C',
-            \ 'sexp_clone_element_after':       '',
+            \ 'sexp_clone_list':                '<LocalLeader>c',
+            \ 'sexp_clone_list_sl':             '<LocalLeader><LocalLeader>c',
+            \ 'sexp_clone_element':             '<LocalLeader>C',
+            \ 'sexp_clone_element_sl':          '<LocalLeader><LocalLeader>C',
             \ 'sexp_raise_list':                '<LocalLeader>o',
             \ 'sexp_raise_element':             '<LocalLeader>O',
             \ 'sexp_swap_list_backward':        '<M-k>',
@@ -897,10 +909,14 @@ copy, paste, and edit this example to taste.
             xmap <silent><buffer> <M-S-g>         <Plug>(sexp_flow_to_prev_leaf_tail)
             nmap <silent><buffer> <M-S-e>         <Plug>(sexp_flow_to_next_leaf_tail)
             xmap <silent><buffer> <M-S-e>         <Plug>(sexp_flow_to_next_leaf_tail)
-            nmap <silent><buffer> <LocalLeader>c  <Plug>(sexp_clone_list_before)
-            xmap <silent><buffer> <LocalLeader>c  <Plug>(sexp_clone_list_before)
-            nmap <silent><buffer> <LocalLeader>C  <Plug>(sexp_clone_element_before)
-            xmap <silent><buffer> <LocalLeader>C  <Plug>(sexp_clone_element_before)
+            nmap <silent><buffer> <LocalLeader>c  <Plug>(sexp_clone_list)
+            xmap <silent><buffer> <LocalLeader>c  <Plug>(sexp_clone_list)
+            nmap <silent><buffer> <LocalLeader><LocalLeader>c  <Plug>(sexp_clone_list_sl)
+            xmap <silent><buffer> <LocalLeader><LocalLeader>c  <Plug>(sexp_clone_list_sl)
+            nmap <silent><buffer> <LocalLeader>C  <Plug>(sexp_clone_element)
+            xmap <silent><buffer> <LocalLeader>C  <Plug>(sexp_clone_element)
+            nmap <silent><buffer> <LocalLeader><LocalLeader>C  <Plug>(sexp_clone_element_sl)
+            xmap <silent><buffer> <LocalLeader><LocalLeader>C  <Plug>(sexp_clone_element_sl)
             nmap <silent><buffer> ==              <Plug>(sexp_indent)
             xmap <silent><buffer> =               <Plug>(sexp_indent)
             nmap <silent><buffer> =-              <Plug>(sexp_indent_top)

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -110,10 +110,15 @@ is                                                 *<Plug>(sexp_inner_string)*
 
 ae                                                *<Plug>(sexp_outer_element)*
 ie                                                *<Plug>(sexp_inner_element)*
-        In operator pending mode, selects the current element. In visual mode,
-        selects the contiguous range of elements either fully or partially
-        included in the current visual range. As with Vim's text motions,
-        repeated applications incorporate additional elements An element is defined as:
+        In operator pending mode, selects the current element and [count]-1
+        additional elements. In visual mode, selects the contiguous range of
+        elements either fully or partially included in the current visual
+        selection (or the element after cursor if between elements) and
+        incorporates [count]-1 additional elements on the cursor side of the
+        selection. Repeated applications pull additional elements into the
+        selection.
+        
+        . An element is defined as:
 
             * Current string if cursor is in a string
             * Current comment if cursor is in a comment, or in the whitespace
@@ -126,7 +131,27 @@ ie                                                *<Plug>(sexp_inner_element)*
         An element always includes leading macro characters.
 
         Inner motion does not include surrounding whitespace, but the outer
-        motion includes (ordered by priority):
+        motion attempts to include all the whitespace you would wish to delete if
+        you were deleting the selected element(s). The following guidelines
+        are used to determine how much surrounding whitespace is included in
+        an outer element motion:
+            * Sibling elements that begin on different lines should remain on
+              different lines.
+            * A comment should never be pulled onto the same line as the open
+              bracket preceding it.
+            * 
+            * Selected leading whitespace should remain selected.
+
+
+            * Never remove a newline when doing so would bring a subsequent
+              element onto the same line as a preceding sibling.
+            * Never remove a newline separating an open bracket from a
+            * subsequent comment.
+            * Never deselect leading whitespace that was already selected.
+            * Always select leading whitespace following an open bracket.
+            * Always select trailing whitespace preceding a close bracket.
+            * Never remove all whitespace separating sibling elements.
+            *
 
         BPS TODO: Rework to reflect the enhanced logic...
             * Trailing whitespace up to the next element if next element is on
@@ -138,6 +163,41 @@ ie                                                *<Plug>(sexp_inner_element)*
             * Leading whitespace up to the previous element if it exists on
               the same line as the current element and no trailing whitespace
               exists
+
+
+                                                       *cleanup-vs-extension*
+        These commands can be used to "clean up" the current selection and/or
+        to pull additional elements into it. Cleaning up might mean toggling
+        an "inner" selection to an "outer" one (or vice versa). Or perhaps
+        you've selected elements manually using v followed by movement
+        commands, and now you wish to select the surrounding whitespace in
+        preparation for a delete or change operation. In such cases, [count]
+        includes the current element or current selection: e.g., a default
+        [count] of 1 performs cleanup only, and a count of 2 would pull in 1
+        additional element. However, if you immediately execute the same
+        command again, vim-sexp knows that the current selection is already
+        "cleaned up", so all of [count] is applied towards additional
+        elements. Vim-sexp considers a command to be a repeat application if
+        you haven't done any of the following since the previous execution:
+
+            * Changed visual selection (but ok to move cursor to other end if
+              you want next execution to pull from the other end)
+            * Changed text in the buffer
+            * Executed a different sexp command (ae and ie are different
+              commands)
+
+        Examples: (spaces in key sequences shown for readability only)~
+>
+        Select current element plus the 2 following
+          v3ae
+        Same as above...
+          vae ae ae
+        Select current element plus the 2 *preceding*
+          vie o ie ie
+          Note: By moving the cursor to the start of the selection, `o'
+          changes the direction of the expansion.
+<
+
 
         Leading
                 head of sexp and not comment
@@ -155,20 +215,19 @@ ie                                                *<Plug>(sexp_inner_element)*
                 -EOL and subsequent element is comment
                 -not head/tail of sexp and !BOL
                                 
-                        
-
 
         If the cursor is on whitespace that is not in a string or between line
         comments, the motion includes the current position up to and including
         the end of the next element, if it exists.
 
-        Note: Always selects a contiguous range of one or more complete
-        elements at the level defined by the cursor position. If the original
-        visual selection extends outside the compound form containing the
-        cursor, it is pre-truncated automatically prior to command execution.
-        Similarly, if the original visual selection includes only one side of
-        a compound form, the selection is automatically pre-extended to
-        include the other end as well.
+                                                       *selection-adjustment*
+        These commands always select a contiguous range of one or more
+        complete elements at the level defined by the cursor position. If the
+        original visual selection extends outside the compound form containing
+        the cursor, it is pre-truncated automatically prior to command
+        execution. Similarly, if the original visual selection includes only
+        one side of a compound form, the selection is automatically
+        pre-extended to include the other end as well.
         Examples of pre-truncation/extension~
         >
                      (a b (c d) e f)

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -118,7 +118,7 @@ ie                                                *<Plug>(sexp_inner_element)*
         selection. Repeated applications pull additional elements into the
         selection.
         
-        . An element is defined as:
+        An element is defined as:
 
             * Current string if cursor is in a string
             * Current comment if cursor is in a comment, or in the whitespace
@@ -132,37 +132,19 @@ ie                                                *<Plug>(sexp_inner_element)*
 
         Inner motion does not include surrounding whitespace, but the outer
         motion attempts to include all the whitespace you would wish to delete if
-        you were deleting the selected element(s). The following guidelines
-        are used to determine how much surrounding whitespace is included in
-        an outer element motion:
-            * Sibling elements that begin on different lines should remain on
-              different lines.
-            * A comment should never be pulled onto the same line as the open
-              bracket preceding it.
-            * 
-            * Selected leading whitespace should remain selected.
+        you were using the text object to delete element. The algorithm is
+        complex, but can be expressed roughly as follows: select as many
+        surrounding whitespace characters (including newlines) as possible
+        without doing any of the following:
 
-
-            * Never remove a newline when doing so would bring a subsequent
-              element onto the same line as a preceding sibling.
-            * Never remove a newline separating an open bracket from a
-            * subsequent comment.
-            * Never deselect leading whitespace that was already selected.
-            * Always select leading whitespace following an open bracket.
-            * Always select trailing whitespace preceding a close bracket.
-            * Never remove all whitespace separating sibling elements.
-            *
-
-        BPS TODO: Rework to reflect the enhanced logic...
-            * Trailing whitespace up to the next element if next element is on
-              the same line
-            * Trailing whitespace up to the next element on a subsequent line
-              if the current element begins on its own line
-            * Trailing whitespace up to the end of line if the current element
-              is preceded by another element on the same line
-            * Leading whitespace up to the previous element if it exists on
-              the same line as the current element and no trailing whitespace
-              exists
+            * increasing the length of the line before the selection (by
+              combining it with the line after the selection)
+            * bringing a comment following the selection onto the end of an
+              earlier line
+            * bringing the element following the selection onto a line that
+              ends in a comment
+            * joining siblings (by removing all separating whitespace)
+            * de-selecting selected leading whitespace
 
 
                                                        *cleanup-vs-extension*
@@ -188,47 +170,30 @@ ie                                                *<Plug>(sexp_inner_element)*
 
         Examples: (spaces in key sequences shown for readability only)~
 >
-        Select current element plus the 2 following
+        Select current and 2 subsequent outer elements
           v3ae
         Same as above...
           vae ae ae
-        Select current element plus the 2 *preceding*
+        Select current and 2 *preceding* inner elements
           vie o ie ie
           Note: By moving the cursor to the start of the selection, `o'
           changes the direction of the expansion.
 <
 
-
-        Leading
-                head of sexp and not comment
-                tail of sexp
-                EOL and !BOL
-                prefer_leading and !BOL and !EOL
-
-                Note: Do we need note about pulling in newline at end of
-                preceding line? Probably not, since we need that special logic
-                only because of the way adjacent_whitespace_terminal works.
-        Trailing
-                !prefer_leading or BOL or EOL
-                Note: Don't include the final newline and any trailing
-                whitespace if any of the following conditions are true:
-                -EOL and subsequent element is comment
-                -not head/tail of sexp and !BOL
-                                
-
         If the cursor is on whitespace that is not in a string or between line
-        comments, the motion includes the current position up to and including
-        the end of the next element, if it exists.
+        comments, the motion targets the subsequent element, if it exists.
 
                                                        *selection-adjustment*
         These commands always select a contiguous range of one or more
         complete elements at the level defined by the cursor position. If the
         original visual selection extends outside the compound form containing
         the cursor, it is pre-truncated automatically prior to command
-        execution. Similarly, if the original visual selection includes only
-        one side of a compound form, the selection is automatically
-        pre-extended to include the other end as well.
+        execution. Similarly, if the selection that survives pre-truncation
+        includes only one end of a compound form, the selection is
+        automatically pre-extended to include the other end as well.
+
         Examples of pre-truncation/extension~
+        Note: ^ indicates original cursor position
         >
                      (a b (c d) e f)
           original:        ^----- 
@@ -437,6 +402,12 @@ Leaf flow commands~
         Analogous to |ge| and |e| motions.
 
 
+CLONE COMMANDS (normal, visual)~
+<M-C>                                              *<Plug>(sexp_clone_before)*
+<M-c>                                               *<Plug>(sexp_clone_after)*
+        Clone current or visually selected elements [count] times before or
+        after the cloned element(s).
+        TODO: Figure out better way to state this...
 
 INDENT COMMANDS (normal)~
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -153,6 +153,8 @@ ie                                                *<Plug>(sexp_inner_element)*
             * spare initially selected whitespace preceding the first
               selected element (unless removing the whitespace would violate
               one of the other constraints)
+            * remove all blank lines between toplevel elements initially
+              separated by at least 1 blank line.
         Note: The rules may sound complex, but they mostly follow the
         "principle of least surprise".
 
@@ -414,7 +416,7 @@ CLONE COMMANDS (normal, visual)~
         fully or partially selected are cloned.
 
                                                           *indent-after-clone*
-        If |g:sexp_clone_does_indent| is set (set by default), indent the
+        If |g:sexp_clone_does_indent| is set (the default), indent the
         compound form (or range of lines at toplevel) containing the cloned
         elements.
         Note: Indent is never performed for clone operations affecting only a
@@ -451,10 +453,11 @@ INDENT COMMANDS (normal, visual)~
         If |g:sexp_indent_does_clean| is set (unset by default), attempt to
         cleanup the indented region by removing extra whitespace. The rules
         for determining whether whitespace is "extra" obey the principle of
-        least surprise mentioned under |whitespace-cleanup-rules| in the
+        least surprise mentioned under |surrounding-whitespace-rules| in the
         section on sexp_outer_element.
-        Note: Blank lines are generally removed; however, if a comment is
-        preceded by one or more blank lines, a single blank line will be kept.
+        Note: Blank lines are generally removed; however, if a comment or
+        toplevel element is preceded by one or more blank lines, a single
+        blank line will be kept.
 
 <M-=>                                          *<Plug>(sexp_indent_and_clean)*
 <M-->                                      *<Plug>(sexp_indent_and_clean_top)*

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -113,10 +113,12 @@ ie                                                *<Plug>(sexp_inner_element)*
         In operator pending mode, selects the current element and [count]-1
         additional elements. In visual mode, selects the contiguous range of
         elements either fully or partially included in the current visual
-        selection (or the element after cursor if between elements) and
-        incorporates [count]-1 additional elements on the cursor side of the
-        selection. Repeated applications pull additional elements into the
-        selection.
+        selection and incorporates [count]-1 additional elements on the cursor
+        side of the selection. Repeated applications in visual mode pull
+        additional elements into the selection.
+
+        If the cursor is on whitespace that is not in a string or between line
+        comments, the motion targets the subsequent element, if it exists.
         
         An element is defined as:
 
@@ -189,29 +191,6 @@ ie                                                *<Plug>(sexp_inner_element)*
           changes the direction of the expansion.
 <
 
-        If the cursor is on whitespace that is not in a string or between line
-        comments, the motion targets the subsequent element, if it exists.
-
-                                                       *selection-adjustment*
-        These text objects always select a contiguous range of one or more
-        complete elements at the level defined by the cursor position. If the
-        original visual selection extends outside the compound form containing
-        the cursor, it is pre-truncated automatically prior to command
-        execution. Similarly, if the selection that survives pre-truncation
-        includes only one end of a compound form, the selection is
-        automatically pre-extended to include the other end as well.
-
-        Examples of pre-truncation/extension~
-        Note: ^ indicates original cursor position
-              - indicates visual range.
-        >
-                     (a b (c d) e f)
-          original:        ^----- 
-          truncated:       ^--
-                     (a b (c d) e f)
-          original:     ^---
-          extended:     ^------
-<
 
 aC                                             *<Plug>(sexp_outer_child_tail)*
 ac                                             *<Plug>(sexp_outer_child_head)*

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -403,17 +403,17 @@ Leaf flow commands~
 
 CLONE COMMANDS (normal, visual)~
 
-<LocalLeader>C                             *<Plug>(sexp_clone_element_before)*
 <LocalLeader>c                                *<Plug>(sexp_clone_list_before)*
-                                            *<Plug>(sexp_clone_element_after)*
+<LocalLeader>C                             *<Plug>(sexp_clone_element_before)*
                                                *<Plug>(sexp_clone_list_after)*
+                                            *<Plug>(sexp_clone_element_after)*
         Insert [count] copies of the current list (compound FORM), element or
         visual selection before or after the original, preserving cursor
         position relative to the original.
 
-        In normal mode, the element under the cursor or the list containing
-        the cursor is cloned. In visual mode, the range of elements either
-        fully or partially selected are cloned.
+        In visual mode, the selection is first expanded to cover all partially
+        selected lists and elements so that structural integrity is
+        maintained.
 
                                                           *indent-after-clone*
         If |g:sexp_clone_does_indent| is set (the default), indent the
@@ -422,9 +422,8 @@ CLONE COMMANDS (normal, visual)~
         Note: Indent is never performed for clone operations affecting only a
         single line.
 
-        If indent is required, |g:sexp_indent_does_clean| determines
-        whether extra whitespace is cleaned up. (See |clean-indent| for
-        details.)
+        If indent is required, |g:sexp_indent_does_clean| determines whether
+        extra whitespace is cleaned up. (See |clean-indent| for details.)
 
 
 INDENT COMMANDS (normal, visual)~
@@ -435,10 +434,10 @@ INDENT COMMANDS (normal, visual)~
         current top-level list without moving the cursor. If the cursor is not
         in a compound FORM, the current element is indented instead.
 
-        In visual mode, indent the range of elements either fully or partially
-        selected.
+        In visual mode, the selection is first expanded to cover all partially
+        selected lists and elements.
         Note: Visual mappings are not created for the "top" variants of indent
-        commands; such commands would be pointless since "top" implies
+        commands; such commands would be pointless because "top" implies
         ignoring the visual selection.
 
         == shadows the builtin |==| mapping. If you wish to remap this
@@ -447,14 +446,13 @@ INDENT COMMANDS (normal, visual)~
         if == were used for sexp_indent in visual mode; accordingly, if you
         have not overridden the default mapping for sexp_indent, = is used
         instead of == for visual mode sexp_indent.
-        
 
                                                                 *clean-indent*
-        If |g:sexp_indent_does_clean| is set (unset by default), attempt to
-        cleanup the indented region by removing extra whitespace. The rules
-        for determining whether whitespace is "extra" obey the principle of
-        least surprise mentioned under |surrounding-whitespace-rules| in the
-        section on sexp_outer_element.
+        If |g:sexp_indent_does_clean| is set (unset by default), the indent
+        commands also perform "cleanup" on the indented region by removing
+        extra whitespace. The rules for determining whether whitespace is
+        "extra" obey the principle of least surprise mentioned under
+        |surrounding-whitespace-rules| in the section on sexp_outer_element.
         Note: Blank lines are generally removed; however, if a comment or
         toplevel element is preceded by one or more blank lines, a single
         blank line will be kept.
@@ -751,8 +749,10 @@ not necessary to copy all the entries to change a few.
             \ 'sexp_insert_at_list_tail':       '<LocalLeader>l',
             \ 'sexp_splice_list':               '<LocalLeader>@',
             \ 'sexp_convolute':                 '<LocalLeader>?',
-            \ 'sexp_clone_before':              '<M-C>',
-            \ 'sexp_clone_after':               '<M-c>',
+            \ 'sexp_clone_list_before           '<LocalLeader>c',
+            \ 'sexp_clone_list_after            '',
+            \ 'sexp_clone_element_before':      '<LocalLeader>C',
+            \ 'sexp_clone_element_after':       '',
             \ 'sexp_raise_list':                '<LocalLeader>o',
             \ 'sexp_raise_element':             '<LocalLeader>O',
             \ 'sexp_swap_list_backward':        '<M-k>',
@@ -835,6 +835,14 @@ copy, paste, and edit this example to taste.
             omap <silent><buffer> ae              <Plug>(sexp_outer_element)
             xmap <silent><buffer> ie              <Plug>(sexp_inner_element)
             omap <silent><buffer> ie              <Plug>(sexp_inner_element)
+            xmap <silent><buffer> ac              <Plug>(sexp_outer_child_head)
+            omap <silent><buffer> ac              <Plug>(sexp_outer_child_head)
+            xmap <silent><buffer> ic              <Plug>(sexp_inner_child_head)
+            omap <silent><buffer> ic              <Plug>(sexp_inner_child_head)
+            xmap <silent><buffer> aC              <Plug>(sexp_outer_child_tail)
+            omap <silent><buffer> aC              <Plug>(sexp_outer_child_tail)
+            xmap <silent><buffer> iC              <Plug>(sexp_inner_child_tail)
+            omap <silent><buffer> iC              <Plug>(sexp_inner_child_tail)
             nmap <silent><buffer> (               <Plug>(sexp_move_to_prev_bracket)
             xmap <silent><buffer> (               <Plug>(sexp_move_to_prev_bracket)
             omap <silent><buffer> (               <Plug>(sexp_move_to_prev_bracket)
@@ -865,8 +873,32 @@ copy, paste, and edit this example to taste.
             nmap <silent><buffer> ]e              <Plug>(sexp_select_next_element)
             xmap <silent><buffer> ]e              <Plug>(sexp_select_next_element)
             omap <silent><buffer> ]e              <Plug>(sexp_select_next_element)
+            nmap <silent><buffer> <M-]>           <Plug>(sexp_flow_to_next_open)
+            xmap <silent><buffer> <M-]>           <Plug>(sexp_flow_to_next_open)
+            nmap <silent><buffer> <M-[>           <Plug>(sexp_flow_to_prev_close)
+            xmap <silent><buffer> <M-[>           <Plug>(sexp_flow_to_prev_close)
+            nmap <silent><buffer> <M-{>           <Plug>(sexp_flow_to_prev_open)
+            xmap <silent><buffer> <M-{>           <Plug>(sexp_flow_to_prev_open)
+            nmap <silent><buffer> <M-}>           <Plug>(sexp_flow_to_next_close)
+            xmap <silent><buffer> <M-}>           <Plug>(sexp_flow_to_next_close)
+            nmap <silent><buffer> <M-S-b>         <Plug>(sexp_flow_to_prev_leaf_head)
+            xmap <silent><buffer> <M-S-b>         <Plug>(sexp_flow_to_prev_leaf_head)
+            nmap <silent><buffer> <M-S-w>         <Plug>(sexp_flow_to_next_leaf_head)
+            xmap <silent><buffer> <M-S-w>         <Plug>(sexp_flow_to_next_leaf_head)
+            nmap <silent><buffer> <M-S-g>         <Plug>(sexp_flow_to_prev_leaf_tail)
+            xmap <silent><buffer> <M-S-g>         <Plug>(sexp_flow_to_prev_leaf_tail)
+            nmap <silent><buffer> <M-S-e>         <Plug>(sexp_flow_to_next_leaf_tail)
+            xmap <silent><buffer> <M-S-e>         <Plug>(sexp_flow_to_next_leaf_tail)
+            nmap <silent><buffer> <LocalLeader>c  <Plug>(sexp_clone_list_before)
+            xmap <silent><buffer> <LocalLeader>c  <Plug>(sexp_clone_list_before)
+            nmap <silent><buffer> <LocalLeader>C  <Plug>(sexp_clone_element_before)
+            xmap <silent><buffer> <LocalLeader>C  <Plug>(sexp_clone_element_before)
             nmap <silent><buffer> ==              <Plug>(sexp_indent)
+            xmap <silent><buffer> =               <Plug>(sexp_indent)
             nmap <silent><buffer> =-              <Plug>(sexp_indent_top)
+            nmap <silent><buffer> <M-=>           <Plug>(sexp_indent_and_clean)
+            xmap <silent><buffer> <M-=>           <Plug>(sexp_indent_and_clean)
+            nmap <silent><buffer> <M-->           <Plug>(sexp_indent_and_clean_top)
             nmap <silent><buffer> <LocalLeader>i  <Plug>(sexp_round_head_wrap_list)
             xmap <silent><buffer> <LocalLeader>i  <Plug>(sexp_round_head_wrap_list)
             nmap <silent><buffer> <LocalLeader>I  <Plug>(sexp_round_tail_wrap_list)
@@ -894,6 +926,7 @@ copy, paste, and edit this example to taste.
             nmap <silent><buffer> <LocalLeader>h  <Plug>(sexp_insert_at_list_head)
             nmap <silent><buffer> <LocalLeader>l  <Plug>(sexp_insert_at_list_tail)
             nmap <silent><buffer> <LocalLeader>@  <Plug>(sexp_splice_list)
+            nmap <silent><buffer> <LocalLeader>?  <Plug>(sexp_convolute)
             nmap <silent><buffer> <LocalLeader>o  <Plug>(sexp_raise_list)
             xmap <silent><buffer> <LocalLeader>o  <Plug>(sexp_raise_list)
             nmap <silent><buffer> <LocalLeader>O  <Plug>(sexp_raise_element)

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -110,7 +110,10 @@ is                                                 *<Plug>(sexp_inner_string)*
 
 ae                                                *<Plug>(sexp_outer_element)*
 ie                                                *<Plug>(sexp_inner_element)*
-        Select the current element. An element is defined as:
+        In operator pending mode, selects the current element. In visual mode,
+        selects the contiguous range of elements either fully or partially
+        included in the current visual range. As with Vim's text motions,
+        repeated applications incorporate additional elements An element is defined as:
 
             * Current string if cursor is in a string
             * Current comment if cursor is in a comment, or in the whitespace
@@ -125,6 +128,7 @@ ie                                                *<Plug>(sexp_inner_element)*
         Inner motion does not include surrounding whitespace, but the outer
         motion includes (ordered by priority):
 
+        BPS TODO: Rework to reflect the enhanced logic...
             * Trailing whitespace up to the next element if next element is on
               the same line
             * Trailing whitespace up to the next element on a subsequent line
@@ -135,9 +139,59 @@ ie                                                *<Plug>(sexp_inner_element)*
               the same line as the current element and no trailing whitespace
               exists
 
+        Leading
+                head of sexp and not comment
+                tail of sexp
+                EOL and !BOL
+                prefer_leading and !BOL and !EOL
+
+                Note: Do we need note about pulling in newline at end of
+                preceding line? Probably not, since we need that special logic
+                only because of the way adjacent_whitespace_terminal works.
+        Trailing
+                !prefer_leading or BOL or EOL
+                Note: Don't include the final newline and any trailing
+                whitespace if any of the following conditions are true:
+                -EOL and subsequent element is comment
+                -not head/tail of sexp and !BOL
+                                
+                        
+
+
         If the cursor is on whitespace that is not in a string or between line
         comments, the motion includes the current position up to and including
         the end of the next element, if it exists.
+
+        Note: Always selects a contiguous range of one or more complete
+        elements at the level defined by the cursor position. If the original
+        visual selection extends outside the compound form containing the
+        cursor, it is pre-truncated automatically prior to command execution.
+        Similarly, if the original visual selection includes only one side of
+        a compound form, the selection is automatically pre-extended to
+        include the other end as well.
+        Examples of pre-truncation/extension~
+        >
+                     (a b (c d) e f)
+          original:        ^----- 
+          truncated:       ^--
+                     (a b (c d) e f)
+          original:     ^----
+          extended:     ^------
+<
+
+aC                                        *<Plug>(sexp_outer_child_backward)*
+ac                                         *<Plug>(sexp_outer_child_forward)*
+iC                                        *<Plug>(sexp_inner_child_backward)*
+ic                                         *<Plug>(sexp_inner_child_forward)*
+        Select the [count]th "child" element from the head (lowercase c) or
+        tail (uppercase C) of the current compound form. If cursor is not on
+        the macro chars or paired bracket of a compound form, the containing
+        form is used. If there is no containing form (cursor at toplevel), it
+        is as though a virtual form encloses the file itself (i.e., [count]th
+        toplevel element from beginning or end of file).
+
+        The meaning of the terms "inner" and "outer" are as defined for the ie
+        and ae commands. 
 
 TEXT OBJECT MOTIONS (normal, visual, operator-pending)~
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -450,17 +450,11 @@ INDENT COMMANDS (normal, visual)~
         Like == (|sexp_indent)| and =- (|sexp_indent_top|), but ALWAYS removes
         extra whitespace, ignoring option |g:sexp_indent_does_clean|.
 
-                                                *<Plug>(sexp_indent_no_clean)*
-                                            *<Plug>(sexp_indent_no_clean_top)*
-        Like == (|sexp_indent)| and =- (|sexp_indent_top|), but NEVER removes
-        extra whitespace, ignoring option |g:sexp_indent_does_clean|.
-        Note: Unbound by default.
-
 
         *Tip:* Users who expect to use only one of the two forms of indent
-        (cleaning or non-cleaning) can unbind the explicit "clean" and
-        "no_clean" command variants and use |g:sexp_indent_does_clean| to
-        ensure that == and =- give the desired behavior.
+        (cleaning or non-cleaning) can unbind <M-=> and <M--> and use
+        |g:sexp_indent_does_clean| to ensure that == and =- give the desired
+        behavior.
 
 
 WRAP COMMANDS (normal, visual)~
@@ -727,8 +721,6 @@ not necessary to copy all the entries to change a few.
             \ 'sexp_indent_top':                '=-',
             \ 'sexp_indent_and_clean':          '<M-=>',
             \ 'sexp_indent_and_clean_top':      '<M-->',
-            \ 'sexp_indent_no_clean':           '',
-            \ 'sexp_indent_no_clean_top':       '',
             \ 'sexp_round_head_wrap_list':      '<LocalLeader>i',
             \ 'sexp_round_tail_wrap_list':      '<LocalLeader>I',
             \ 'sexp_square_head_wrap_list':     '<LocalLeader>[',

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -415,6 +415,14 @@ CLONE COMMANDS (normal, visual)~
         selected lists and elements so that structural integrity is
         maintained.
 
+        If the element(s) to be cloned are all within a single line, the
+        copies will be placed on the same line, unless any of the following
+        conditions are met:
+                * The final element within the cloned text is a comment
+                * The cloned text occupies the entire line (ignoring any
+                  leading or trailing whitespace)
+                 
+
                                                           *indent-after-clone*
         If |g:sexp_clone_does_indent| is set (the default), indent the
         compound form (or range of lines at toplevel) containing the cloned

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -403,6 +403,7 @@ Leaf flow commands~
 
 
 CLONE COMMANDS (normal, visual)~
+
 <M-C>                                              *<Plug>(sexp_clone_before)*
 <M-c>                                               *<Plug>(sexp_clone_after)*
         Clone current or visually selected elements [count] times before or
@@ -419,6 +420,13 @@ INDENT COMMANDS (normal)~
 
         == shadows the builtin |==| mapping. If you wish to remap this
         command, see |g:sexp_mappings| for more information.
+
+<M-=>                                          *<Plug>(sexp_indent_and_clean)*
+<M-->                                      *<Plug>(sexp_indent_and_clean_top)*
+        Like == (|sexp_indent)| and =- (|sexp_indent_top|), but also removes
+        blank lines and extra whitespace within the indented region.
+        TODO: Add description of whitespace cleanup.
+
 
 WRAP COMMANDS (normal, visual)~
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -130,21 +130,28 @@ ie                                                *<Plug>(sexp_inner_element)*
 
         An element always includes leading macro characters.
 
+                                               *surrounding-whitespace-rules*
         Inner motion does not include surrounding whitespace, but the outer
         motion attempts to include all the whitespace you would wish to delete if
-        you were using the text object to delete element. The algorithm is
+        you were using the text object to delete element(s). The algorithm is
         complex, but can be expressed roughly as follows: select as many
-        surrounding whitespace characters (including newlines) as possible
-        without doing any of the following:
+        surrounding whitespace characters (including newlines) as possible,
+        while ensuring that a subsequent deletion will not do any of the
+        following...
 
-            * increasing the length of the line before the selection (by
-              combining it with the line after the selection)
-            * bringing a comment following the selection onto the end of an
+            * increase the length of the line preceding the selection
+              (by combining it with a later line whose length exceeds the
+              length of the deleted portion of the earlier line)
+            * pull a comment following the selection onto the end of the line
+              preceding the selection
               earlier line
-            * bringing the element following the selection onto a line that
+            * pull the element following the selection onto a line that
               ends in a comment
-            * joining siblings (by removing all separating whitespace)
-            * de-selecting selected leading whitespace
+            * join siblings (by removing all separating whitespace)
+            * de-select initially selected whitespace preceding the first
+              selected element
+        Note: The rules may sound complex, but they mostly follow the
+        "principle of least surprise".
 
 
                                                        *cleanup-vs-extension*
@@ -424,8 +431,10 @@ INDENT COMMANDS (normal)~
 <M-=>                                          *<Plug>(sexp_indent_and_clean)*
 <M-->                                      *<Plug>(sexp_indent_and_clean_top)*
         Like == (|sexp_indent)| and =- (|sexp_indent_top|), but also removes
-        blank lines and extra whitespace within the indented region.
-        TODO: Add description of whitespace cleanup.
+        blank lines and extra whitespace within the indented region. The rules
+        for determining whether whitespace is "extra" obey the principle of
+        least surprise mentioned under |whitespace-cleanup-rules| in the
+        documentation for sexp_outer_element.
 
 
 WRAP COMMANDS (normal, visual)~

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -435,16 +435,27 @@ CLONE COMMANDS (normal, visual)~
         details.)
 
 
-INDENT COMMANDS (normal)~
+INDENT COMMANDS (normal, visual)~
 
 ==                                                       *<Plug>(sexp_indent)*
 =-                                                   *<Plug>(sexp_indent_top)*
-        Indent [count] surrounding lists (compound FORMs) or current top-level
-        list without moving the cursor. If the cursor is not in a compound
-        FORM, the current element is indented instead.
+        In normal mode, indent [count] surrounding lists (compound FORMs) or
+        current top-level list without moving the cursor. If the cursor is not
+        in a compound FORM, the current element is indented instead.
+
+        In visual mode, indent the range of elements either fully or partially
+        selected.
+        Note: Visual mappings are not created for the "top" variants of indent
+        commands; such commands would be pointless since "top" implies
+        ignoring the visual selection.
 
         == shadows the builtin |==| mapping. If you wish to remap this
         command, see |g:sexp_mappings| for more information.
+        Note: The presence of builtin = would result in an undesirable delay
+        if == were used for sexp_indent in visual mode; accordingly, if you
+        have not overridden the default mapping for sexp_indent, = is used
+        instead of == for visual mode sexp_indent.
+        
 
                                                                 *clean-indent*
         If |g:sexp_indent_does_clean| is set (unset by default), attempt to

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -136,38 +136,39 @@ ie                                                *<Plug>(sexp_inner_element)*
         you were using the text object to delete element(s). The algorithm is
         complex, but can be expressed roughly as follows: select as many
         surrounding whitespace characters (including newlines) as possible,
-        while ensuring that a subsequent deletion will not do any of the
-        following...
+        while ensuring that a subsequent deletion of the selection will not do
+        any of the following:
 
             * increase the length of the line preceding the selection
               (by combining it with a later line whose length exceeds the
               length of the deleted portion of the earlier line)
             * pull a comment following the selection onto the end of the line
               preceding the selection
-              earlier line
-            * pull the element following the selection onto a line that
-              ends in a comment
+            * pull the element following the selection into an end of line
+              comment
+              Rationale: End of line comments are generally line-specific.
             * join siblings (by removing all separating whitespace)
-            * de-select initially selected whitespace preceding the first
-              selected element
+            * keep initially selected whitespace preceding the first
+              selected element (unless removing the whitespace would violate
+              one of the other constraints)
         Note: The rules may sound complex, but they mostly follow the
         "principle of least surprise".
 
 
                                                        *cleanup-vs-extension*
         These commands can be used to "clean up" the current selection and/or
-        to pull additional elements into it. Cleaning up might mean toggling
-        an "inner" selection to an "outer" one (or vice versa). Or perhaps
-        you've selected elements manually using v followed by movement
-        commands, and now you wish to select the surrounding whitespace in
-        preparation for a delete or change operation. In such cases, [count]
-        includes the current element or current selection: e.g., a default
-        [count] of 1 performs cleanup only, and a count of 2 would pull in 1
-        additional element. However, if you immediately execute the same
-        command again, vim-sexp knows that the current selection is already
-        "cleaned up", so all of [count] is applied towards additional
-        elements. Vim-sexp considers a command to be a repeat application if
-        you haven't done any of the following since the previous execution:
+        pull additional elements into it. Cleaning up might mean toggling an
+        "inner" selection to an "outer" one (or vice versa). Or perhaps you've
+        selected elements manually using v followed by movement commands, and
+        now you wish to select the surrounding whitespace in preparation for a
+        delete or change operation. In such cases, [count] includes the
+        current element or current selection: e.g., a default [count] of 1
+        performs cleanup only, and a count of 2 would pull in 1 additional
+        element. However, if you immediately execute the same command again,
+        vim-sexp knows that the current selection is already "cleaned up", so
+        all of [count] is applied towards additional elements. Vim-sexp
+        considers a command to be a repeat application if you haven't done any
+        of the following since the previous execution:
 
             * Changed visual selection (but ok to move cursor to other end if
               you want next execution to pull from the other end)
@@ -206,14 +207,14 @@ ie                                                *<Plug>(sexp_inner_element)*
           original:        ^----- 
           truncated:       ^--
                      (a b (c d) e f)
-          original:     ^----
+          original:     ^---
           extended:     ^------
 <
 
-aC                                        *<Plug>(sexp_outer_child_backward)*
-ac                                         *<Plug>(sexp_outer_child_forward)*
-iC                                        *<Plug>(sexp_inner_child_backward)*
-ic                                         *<Plug>(sexp_inner_child_forward)*
+aC                                             *<Plug>(sexp_outer_child_tail)*
+ac                                             *<Plug>(sexp_outer_child_head)*
+iC                                             *<Plug>(sexp_inner_child_tail)*
+ic                                             *<Plug>(sexp_inner_child_head)*
         Select the [count]th "child" element from the head (lowercase c) or
         tail (uppercase C) of the current compound form. If cursor is not on
         the macro chars or paired bracket of a compound form, the containing
@@ -222,7 +223,7 @@ ic                                         *<Plug>(sexp_inner_child_forward)*
         toplevel element from beginning or end of file).
 
         The meaning of the terms "inner" and "outer" are as defined for the ie
-        and ae commands. 
+        and ae text objects. 
 
 TEXT OBJECT MOTIONS (normal, visual, operator-pending)~
 
@@ -415,7 +416,18 @@ CLONE COMMANDS (normal, visual)~
 <M-c>                                               *<Plug>(sexp_clone_after)*
         Clone current or visually selected elements [count] times before or
         after the cloned element(s).
-        TODO: Figure out better way to state this...
+
+        In normal mode, the element under or after the cursor is cloned. In
+        visual mode, the range of elements fully or partially selected are
+        cloned.
+
+        If option |g:sexp_indent_after_clone| is set, indent both original and
+        cloned elements. If an indent is required, |g:sexp_indent_does_clean|
+        determines whether extra whitespace is cleaned up. (See |clean-indent|
+        for details.)
+
+        TODO: Flesh this out... Document the auto-indent and decide whether to
+        make it optional...
 
 INDENT COMMANDS (normal)~
 
@@ -428,13 +440,31 @@ INDENT COMMANDS (normal)~
         == shadows the builtin |==| mapping. If you wish to remap this
         command, see |g:sexp_mappings| for more information.
 
+                                                                *clean-indent*
+        If option |g:sexp_indent_does_clean| is set (unset by default),
+        vim-sexp will attempt to cleanup the indented region by removing extra
+        whitespace. The rules for determining whether whitespace is "extra"
+        obey the principle of least surprise mentioned under
+        |whitespace-cleanup-rules| in the section on sexp_outer_element.
+        Note: Blank lines are generally removed; however, if a comment is
+        preceded by one or more blank lines, a single blank line will be kept.
+
 <M-=>                                          *<Plug>(sexp_indent_and_clean)*
 <M-->                                      *<Plug>(sexp_indent_and_clean_top)*
-        Like == (|sexp_indent)| and =- (|sexp_indent_top|), but also removes
-        blank lines and extra whitespace within the indented region. The rules
-        for determining whether whitespace is "extra" obey the principle of
-        least surprise mentioned under |whitespace-cleanup-rules| in the
-        documentation for sexp_outer_element.
+        Like == (|sexp_indent)| and =- (|sexp_indent_top|), but ALWAYS removes
+        extra whitespace, ignoring option |g:sexp_indent_does_clean|.
+
+                                                *<Plug>(sexp_indent_no_clean)*
+                                            *<Plug>(sexp_indent_no_clean_top)*
+        Like == (|sexp_indent)| and =- (|sexp_indent_top|), but NEVER removes
+        extra whitespace, ignoring option |g:sexp_indent_does_clean|.
+        Note: Unbound by default.
+
+
+        *Tip:* Users who wish to use only one of the two forms of indent
+        (cleaning or non-cleaning) can unbind the clean and no_clean command
+        variants and use |g:sexp_indent_does_clean| to select the desired
+        behavior.
 
 
 WRAP COMMANDS (normal, visual)~
@@ -659,6 +689,10 @@ not necessary to copy all the entries to change a few.
             \ 'sexp_inner_string':              'is',
             \ 'sexp_outer_element':             'ae',
             \ 'sexp_inner_element':             'ie',
+            \ 'sexp_outer_child_tail':          'aC',
+            \ 'sexp_outer_child_head':          'ac',
+            \ 'sexp_inner_child_tail':          'iC',
+            \ 'sexp_inner_child_head':          'ic',
             \ 'sexp_move_to_prev_bracket':      '(',
             \ 'sexp_move_to_next_bracket':      ')',
             \ 'sexp_move_to_prev_element_head': '<M-b>',
@@ -679,6 +713,8 @@ not necessary to copy all the entries to change a few.
             \ 'sexp_select_next_element':       ']e',
             \ 'sexp_indent':                    '==',
             \ 'sexp_indent_top':                '=-',
+            \ 'sexp_indent_and_clean':          '<M-=>',
+            \ 'sexp_indent_and_clean_top':      '<M-->',
             \ 'sexp_round_head_wrap_list':      '<LocalLeader>i',
             \ 'sexp_round_tail_wrap_list':      '<LocalLeader>I',
             \ 'sexp_square_head_wrap_list':     '<LocalLeader>[',
@@ -695,6 +731,8 @@ not necessary to copy all the entries to change a few.
             \ 'sexp_insert_at_list_tail':       '<LocalLeader>l',
             \ 'sexp_splice_list':               '<LocalLeader>@',
             \ 'sexp_convolute':                 '<LocalLeader>?',
+            \ 'sexp_clone_before':              '<M-C>',
+            \ 'sexp_clone_after':               '<M-c>',
             \ 'sexp_raise_list':                '<LocalLeader>o',
             \ 'sexp_raise_element':             '<LocalLeader>O',
             \ 'sexp_swap_list_backward':        '<M-k>',

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -213,8 +213,8 @@ ic                                             *<Plug>(sexp_inner_child_head)*
         select prev/next element commands ([e and ]e). The chief difference is
         that a child object's offset is always specified relative to the start
         or end of a compound form, whereas [e and ]e always search relative to
-        the cursor position. Depending on the use case, one form may be
-        significantly more convenient than the other.
+        the cursor position. Depending on the use case, one set of commands
+        may be significantly more convenient than the other.
 
 TEXT OBJECT MOTIONS (normal, visual, operator-pending)~
 
@@ -424,15 +424,15 @@ CLONE COMMANDS (normal, visual)~
                 * target is at toplevel
                 * target ends in a comment
 
-        It is always possible to override the default logic, forcing either
+        It is generally possible to override the default logic, forcing either
         single or multi-line operation, as follows:
                 Single-line~
                         Use sl command variants ("_sl" suffix).
                 Multi-line~
                         Supply an explicit [count] (possibly 1) to one of the
                         non-sl command variants.
-                        Note: Vim-sexp can tell the difference between an
-                        explicit [count]==1 and a default [count] of 1.
+                        Note: Vim-sexp can tell the difference between
+                        explicit and default [count]==1.
 
 
                                                           *indent-after-clone*
@@ -443,7 +443,7 @@ CLONE COMMANDS (normal, visual)~
         single line.
 
         If indent is required, |g:sexp_indent_does_clean| determines whether
-        extra whitespace is cleaned up. (See |clean-indent| for details.)
+        extra whitespace is removed. (See |clean-indent| for details.)
 
 
 INDENT COMMANDS (normal, visual)~
@@ -451,8 +451,9 @@ INDENT COMMANDS (normal, visual)~
 ==                                                       *<Plug>(sexp_indent)*
 =-                                                   *<Plug>(sexp_indent_top)*
         In normal mode, indent [count] surrounding lists (compound FORMs) or
-        current top-level list without moving the cursor. If the cursor is not
-        in a compound FORM, the current element is indented instead.
+        visual selection (==) or current top-level list (=-) without moving
+        the cursor. If the cursor is not in a compound FORM, the current
+        element is indented instead.
 
         In visual mode, the selection is first expanded to cover all partially
         selected lists and elements.
@@ -471,8 +472,8 @@ INDENT COMMANDS (normal, visual)~
         If |g:sexp_indent_does_clean| is set (unset by default), the indent
         commands also perform "cleanup" on the indented region by removing
         extra whitespace. The rules for determining whether whitespace is
-        "extra" obey the principle of least surprise mentioned under
-        |surrounding-whitespace-rules| in the section on sexp_outer_element.
+        "extra" obey the "principle of least surprise" mentioned under
+        |surrounding-whitespace-rules| (in the section on sexp_outer_element).
         Note: Blank lines are generally removed; however, if a comment or
         toplevel element is preceded by one or more blank lines, a single
         blank line will be kept.

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -32,8 +32,8 @@ if !exists('g:sexp_insert_after_wrap')
     let g:sexp_insert_after_wrap = 1
 endif
 
-if !exists('g:sexp_indent_does_clone')
-    let g:sexp_indent_does_clone = 1
+if !exists('g:sexp_indent_does_clean')
+    let g:sexp_indent_does_clean = 1
 endif
 
 if !exists('g:sexp_clone_does_indent')
@@ -233,7 +233,9 @@ function! s:sexp_create_mappings()
     endfor
 
     for plug in ['sexp_insert_at_list_head', 'sexp_insert_at_list_tail',
-               \ 'sexp_convolute',           'sexp_splice_list']
+               \ 'sexp_convolute',           'sexp_splice_list',
+               \ 'sexp_indent_top',          'sexp_indent_and_clean_top',
+               \ 'sexp_indent_no_clean_top']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -256,15 +258,15 @@ function! s:sexp_create_mappings()
                \ 'sexp_flow_to_prev_leaf_head',   'sexp_flow_to_next_leaf_head',
                \ 'sexp_flow_to_prev_leaf_tail',   'sexp_flow_to_next_leaf_tail',
                \ 'sexp_clone_before',             'sexp_clone_after',
-               \ 'sexp_indent',                   'sexp_indent_top',
-               \ 'sexp_indent_and_clean',         'sexp_indent_and_clean_top',
-               \ 'sexp_indent_no_clean',          'sexp_indent_no_clean_top']
+               \ 'sexp_indent',                   'sexp_indent_and_clean',
+               \ 'sexp_indent_no_clean']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
             if plug =~ '^sexp_indent' && lhs == '=='
                 " Special Case: Just as == overrides Vim's default normal mode
                 " command, = must override Vim's default visual mode command.
+                " Rationale: Prevents ambiguity that leads to map delay.
                 let lhs = '='
             endif
             execute 'xmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -70,6 +70,8 @@ let s:sexp_mappings = {
     \ 'sexp_indent_top':                '=-',
     \ 'sexp_indent_and_clean':          '<M-=>',
     \ 'sexp_indent_and_clean_top':      '<M-->',
+    \ 'sexp_indent_no_clean':           '',
+    \ 'sexp_indent_no_clean_top':       '',
     \ 'sexp_round_head_wrap_list':      '<LocalLeader>i',
     \ 'sexp_round_tail_wrap_list':      '<LocalLeader>I',
     \ 'sexp_square_head_wrap_list':     '<LocalLeader>[',

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -78,8 +78,6 @@ let s:sexp_mappings = {
     \ 'sexp_indent_top':                '=-',
     \ 'sexp_indent_and_clean':          '<M-=>',
     \ 'sexp_indent_and_clean_top':      '<M-->',
-    \ 'sexp_indent_no_clean':           '',
-    \ 'sexp_indent_no_clean_top':       '',
     \ 'sexp_round_head_wrap_list':      '<LocalLeader>i',
     \ 'sexp_round_tail_wrap_list':      '<LocalLeader>I',
     \ 'sexp_square_head_wrap_list':     '<LocalLeader>[',
@@ -233,8 +231,7 @@ function! s:sexp_create_mappings()
 
     for plug in ['sexp_insert_at_list_head', 'sexp_insert_at_list_tail',
                \ 'sexp_convolute',           'sexp_splice_list',
-               \ 'sexp_indent_top',          'sexp_indent_and_clean_top',
-               \ 'sexp_indent_no_clean_top']
+               \ 'sexp_indent_top',          'sexp_indent_and_clean_top']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -257,8 +254,7 @@ function! s:sexp_create_mappings()
                \ 'sexp_flow_to_prev_leaf_head',   'sexp_flow_to_next_leaf_head',
                \ 'sexp_flow_to_prev_leaf_tail',   'sexp_flow_to_next_leaf_tail',
                \ 'sexp_clone_before',             'sexp_clone_after',
-               \ 'sexp_indent',                   'sexp_indent_and_clean',
-               \ 'sexp_indent_no_clean']
+               \ 'sexp_indent',                   'sexp_indent_and_clean']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -403,9 +399,6 @@ Defplug! nnoremap sexp_indent_top            sexp#indent('n', 1, v:count, -1)
 Defplug! nnoremap sexp_indent_and_clean      sexp#indent('n', 0, v:count, 1)
 Defplug  xnoremap sexp_indent_and_clean      sexp#indent('x', 0, v:count, 1)
 Defplug! nnoremap sexp_indent_and_clean_top  sexp#indent('n', 1, v:count, 1)
-Defplug! nnoremap sexp_indent_no_clean       sexp#indent('n', 0, v:count, 0)
-Defplug  xnoremap sexp_indent_no_clean       sexp#indent('x', 0, v:count, 0)
-Defplug! nnoremap sexp_indent_no_clean_top   sexp#indent('n', 1, v:count, 0)
 
 " Wrap list
 Defplug! nnoremap sexp_round_head_wrap_list  sexp#wrap('f', '(', ')', 0, g:sexp_insert_after_wrap)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -149,12 +149,13 @@ function! s:defplug(flags, mapmode, name, ...)
     "   returns to its original position after an = command.
     let prefix = lhs . ' '
                  \ . ':<C-u>let b:sexp_count = v:count \| '
+                 \ . 'call sexp#pre_op("' . a:mapmode[0] . '", "' . a:name . '") \| '
                  \ . (nojump ? '' : 'execute "normal! ' . (opmode ? 'vv' : '') . 'm`" \| ')
                  \ . 'call ' . substitute(rhs, '\v<v:count>', 'b:sexp_count', 'g')
-
+    let postfix = ' \| call sexp#post_op("' . a:mapmode[0] . '", "' . a:name . '")'
     " Expression, non-repeating
     if !repeat || (repeat && !s:have_repeat_set)
-        execute prefix . '<CR>'
+        execute prefix . postfix . '<CR>'
     " Expression, repeating, operator-pending mode
     elseif opmode
         execute prefix . ' \| '
@@ -162,10 +163,12 @@ function! s:defplug(flags, mapmode, name, ...)
                 \ . '  call <SID>repeat_set(v:operator . "\<Plug>(' . a:name . ')\<lt>C-r>.\<lt>C-Bslash>\<lt>C-n>", b:sexp_count) \| '
                 \ . 'else \| '
                 \ . '  call <SID>repeat_set(v:operator . "\<Plug>(' . a:name . ')", b:sexp_count) \| '
-                \ . 'endif<CR>'
+                \ . 'endif'
+                \ . postfix . '<CR>'
     " Expression, repeating, non-operator-pending mode
     else
-        execute prefix . ' \| call <SID>repeat_set("\<Plug>(' . a:name . ')", b:sexp_count)<CR>'
+        execute prefix . ' \| call <SID>repeat_set("\<Plug>(' . a:name . ')", b:sexp_count)'
+                \ . postfix . '<CR>'
     endif
 endfunction
 
@@ -275,10 +278,10 @@ Defplug  xnoremap sexp_inner_string sexp#select_current_string('v', 1)
 Defplug! onoremap sexp_inner_string sexp#select_current_string('o', 1)
 
 " Current element
-Defplug  xnoremap sexp_outer_element sexp#select_current_element('v', 0, 1)
-Defplug! onoremap sexp_outer_element sexp#select_current_element('o', 0, 1)
-Defplug  xnoremap sexp_inner_element sexp#select_current_element('v', 1, 1)
-Defplug! onoremap sexp_inner_element sexp#select_current_element('o', 1, 1)
+Defplug  xnoremap sexp_outer_element sexp#select_current_element('v', 0, 1, v:count)
+Defplug! onoremap sexp_outer_element sexp#select_current_element('o', 0, 1, v:count)
+Defplug  xnoremap sexp_inner_element sexp#select_current_element('v', 1, 1, v:count)
+Defplug! onoremap sexp_inner_element sexp#select_current_element('o', 1, 1, v:count)
 
 Defplug  xnoremap sexp_outer_child_forward sexp#select_child('v', v:count, 1, 0)
 Defplug! onoremap sexp_outer_child_forward sexp#select_child('o', v:count, 1, 0)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -94,8 +94,10 @@ let s:sexp_mappings = {
     \ 'sexp_insert_at_list_tail':       '<LocalLeader>l',
     \ 'sexp_splice_list':               '<LocalLeader>@',
     \ 'sexp_convolute':                 '<LocalLeader>?',
-    \ 'sexp_clone_before':              '<M-C>',
-    \ 'sexp_clone_after':               '<M-c>',
+    \ 'sexp_clone_list_before':         '<LocalLeader>c',
+    \ 'sexp_clone_list_after':          '',
+    \ 'sexp_clone_element_before':      '<LocalLeader>C',
+    \ 'sexp_clone_element_after':       '',
     \ 'sexp_raise_list':                '<LocalLeader>o',
     \ 'sexp_raise_element':             '<LocalLeader>O',
     \ 'sexp_swap_list_backward':        '<M-k>',
@@ -253,7 +255,8 @@ function! s:sexp_create_mappings()
                \ 'sexp_flow_to_prev_open',        'sexp_flow_to_next_close',
                \ 'sexp_flow_to_prev_leaf_head',   'sexp_flow_to_next_leaf_head',
                \ 'sexp_flow_to_prev_leaf_tail',   'sexp_flow_to_next_leaf_tail',
-               \ 'sexp_clone_before',             'sexp_clone_after',
+               \ 'sexp_clone_list_before',        'sexp_clone_list_after',
+               \ 'sexp_clone_element_before',     'sexp_clone_element_after',
                \ 'sexp_indent',                   'sexp_indent_and_clean']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
@@ -442,12 +445,17 @@ Defplug  xnoremap sexp_raise_element sexp#docount(v:count, 'sexp#raise', 'v', ''
 " Note: convolute takes pains to preserve cursor position: hence, 'nojump'.
 DefplugN! nnoremap sexp_convolute sexp#convolute(v:count, 'n')
 
-" Clone
-DefplugN  nnoremap sexp_clone_before sexp#clone('n', v:count, 1)
-DEFPLUG   xnoremap sexp_clone_before <Esc>:<C-u>call sexp#clone('v', v:prevcount, 1)<CR>
-DefplugN  nnoremap sexp_clone_after sexp#clone('n', v:count, 0)
-DEFPLUG   xnoremap sexp_clone_after <Esc>:<C-u>call sexp#clone('v', v:prevcount, 0)<CR>
+" Clone list
+DefplugN  nnoremap sexp_clone_list_before sexp#clone('n', v:count, 1, 0)
+DEFPLUG   xnoremap sexp_clone_list_before <Esc>:<C-u>call sexp#clone('v', v:prevcount, 1, 0)<CR>
+DefplugN  nnoremap sexp_clone_list_after sexp#clone('n', v:count, 1, 1)
+DEFPLUG   xnoremap sexp_clone_list_after <Esc>:<C-u>call sexp#clone('v', v:prevcount, 1, 1)<CR>
 
+" Clone element
+DefplugN  nnoremap sexp_clone_element_before sexp#clone('n', v:count, 0, 0)
+DEFPLUG   xnoremap sexp_clone_element_before <Esc>:<C-u>call sexp#clone('v', v:prevcount, 0, 0)<CR>
+DefplugN  nnoremap sexp_clone_element_after sexp#clone('n', v:count, 0, 1)
+DEFPLUG   xnoremap sexp_clone_element_after <Esc>:<C-u>call sexp#clone('v', v:prevcount, 0, 1)<CR>
 
 " Splice list
 Defplug! nnoremap sexp_splice_list sexp#splice_list(v:count)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -94,10 +94,10 @@ let s:sexp_mappings = {
     \ 'sexp_insert_at_list_tail':       '<LocalLeader>l',
     \ 'sexp_splice_list':               '<LocalLeader>@',
     \ 'sexp_convolute':                 '<LocalLeader>?',
-    \ 'sexp_clone_list_before':         '<LocalLeader>c',
-    \ 'sexp_clone_list_after':          '',
-    \ 'sexp_clone_element_before':      '<LocalLeader>C',
-    \ 'sexp_clone_element_after':       '',
+    \ 'sexp_clone_list':                '<LocalLeader>c',
+    \ 'sexp_clone_list_sl':             '<LocalLeader><LocalLeader>c',
+    \ 'sexp_clone_element':             '<LocalLeader>C',
+    \ 'sexp_clone_element_sl':          '<LocalLeader><LocalLeader>C',
     \ 'sexp_raise_list':                '<LocalLeader>o',
     \ 'sexp_raise_element':             '<LocalLeader>O',
     \ 'sexp_swap_list_backward':        '<M-k>',
@@ -258,8 +258,8 @@ function! s:sexp_create_mappings()
                \ 'sexp_flow_to_prev_open',        'sexp_flow_to_next_close',
                \ 'sexp_flow_to_prev_leaf_head',   'sexp_flow_to_next_leaf_head',
                \ 'sexp_flow_to_prev_leaf_tail',   'sexp_flow_to_next_leaf_tail',
-               \ 'sexp_clone_list_before',        'sexp_clone_list_after',
-               \ 'sexp_clone_element_before',     'sexp_clone_element_after',
+               \ 'sexp_clone_list',               'sexp_clone_list_sl',
+               \ 'sexp_clone_element',            'sexp_clone_element_sl',
                \ 'sexp_indent',                   'sexp_indent_and_clean']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
@@ -449,16 +449,16 @@ Defplug  xnoremap sexp_raise_element sexp#docount(v:count, 'sexp#raise', 'v', ''
 DefplugN! nnoremap sexp_convolute sexp#convolute(v:count, 'n')
 
 " Clone list
-DefplugN  nnoremap sexp_clone_list_before sexp#clone('n', v:count, 1, 0)
-DEFPLUG   xnoremap sexp_clone_list_before <Esc>:<C-u>call sexp#clone('v', v:prevcount, 1, 0)<CR>
-DefplugN  nnoremap sexp_clone_list_after sexp#clone('n', v:count, 1, 1)
-DEFPLUG   xnoremap sexp_clone_list_after <Esc>:<C-u>call sexp#clone('v', v:prevcount, 1, 1)<CR>
+DefplugN  nnoremap sexp_clone_list    sexp#clone('n', v:count, 1, 0, 0)
+DEFPLUG   xnoremap sexp_clone_list    <Esc>:<C-u>call sexp#clone('v', v:prevcount, 1, 0, 0)<CR>
+DefplugN  nnoremap sexp_clone_list_sl sexp#clone('n', v:count, 1, 0, 1)
+DEFPLUG   xnoremap sexp_clone_list_sl <Esc>:<C-u>call sexp#clone('v', v:prevcount, 1, 0, 1)<CR>
 
 " Clone element
-DefplugN  nnoremap sexp_clone_element_before sexp#clone('n', v:count, 0, 0)
-DEFPLUG   xnoremap sexp_clone_element_before <Esc>:<C-u>call sexp#clone('v', v:prevcount, 0, 0)<CR>
-DefplugN  nnoremap sexp_clone_element_after sexp#clone('n', v:count, 0, 1)
-DEFPLUG   xnoremap sexp_clone_element_after <Esc>:<C-u>call sexp#clone('v', v:prevcount, 0, 1)<CR>
+DefplugN  nnoremap sexp_clone_element    sexp#clone('n', v:count, 0, 0, 0)
+DEFPLUG   xnoremap sexp_clone_element    <Esc>:<C-u>call sexp#clone('v', v:prevcount, 0, 0, 0)<CR>
+DefplugN  nnoremap sexp_clone_element_sl sexp#clone('n', v:count, 0, 0, 1)
+DEFPLUG   xnoremap sexp_clone_element_sl <Esc>:<C-u>call sexp#clone('v', v:prevcount, 0, 0, 1)<CR>
 
 " Splice list
 Defplug! nnoremap sexp_splice_list sexp#splice_list(v:count)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -222,11 +222,8 @@ function! s:sexp_create_mappings()
         endif
     endfor
 
-    for plug in ['sexp_indent',              'sexp_indent_top',
-               \ 'sexp_indent_and_clean',    'sexp_indent_and_clean_top',
-               \ 'sexp_insert_at_list_head', 'sexp_insert_at_list_tail',
-               \ 'sexp_convolute',           'sexp_splice_list',
-               \ 'sexp_cleanup_around_element']
+    for plug in ['sexp_insert_at_list_head', 'sexp_insert_at_list_tail',
+               \ 'sexp_convolute',           'sexp_splice_list']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -248,7 +245,9 @@ function! s:sexp_create_mappings()
                \ 'sexp_flow_to_prev_open',        'sexp_flow_to_next_close',
                \ 'sexp_flow_to_prev_leaf_head',   'sexp_flow_to_next_leaf_head',
                \ 'sexp_flow_to_prev_leaf_tail',   'sexp_flow_to_next_leaf_tail',
-               \ 'sexp_clone_before',             'sexp_clone_after']
+               \ 'sexp_clone_before',             'sexp_clone_after',
+               \ 'sexp_indent',                   'sexp_indent_top',
+               \ 'sexp_indent_and_clean',         'sexp_indent_and_clean_top']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -377,10 +376,17 @@ Defplug! onoremap sexp_select_next_element sexp#docount(v:count, 'sexp#select_ad
 """ Commands {{{1
 
 " Indent S-Expression
-Defplug! nnoremap sexp_indent                sexp#indent(0, v:count, 0)
-Defplug! nnoremap sexp_indent_top            sexp#indent(1, v:count, 0)
-Defplug! nnoremap sexp_indent_and_clean      sexp#indent(0, v:count, 1)
-Defplug! nnoremap sexp_indent_and_clean_top  sexp#indent(1, v:count, 1)
+" TODO: Check the added visual versions - eg, correct version of Defplug?
+Defplug! nnoremap sexp_indent                sexp#indent('n', 0, v:count, 0)
+Defplug! xnoremap sexp_indent                sexp#indent('x', 0, v:count, 0)
+Defplug! nnoremap sexp_indent_top            sexp#indent('n', 1, v:count, 0)
+Defplug! xnoremap sexp_indent_top            sexp#indent('x', 1, v:count, 0)
+Defplug! nnoremap sexp_indent_and_clean      sexp#indent('n', 0, v:count, 1)
+Defplug! xnoremap sexp_indent_and_clean      sexp#indent('x', 0, v:count, 1)
+Defplug! nnoremap sexp_indent_and_clean_top  sexp#indent('n', 1, v:count, 1)
+Defplug! xnoremap sexp_indent_and_clean_top  sexp#indent('x', 1, v:count, 1)
+
+
 " TODO: Consider supporting visual mode.
 Defplug! nnoremap sexp_cleanup_around_element sexp#cleanup_around_element(v:count, 'n')
 Defplug! xnoremap sexp_cleanup_around_element sexp#cleanup_around_element(v:count, 'v')

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -153,11 +153,11 @@ function! s:defplug(flags, mapmode, name, ...)
         " Wrap in pre/post-op calls.
         let rhs = substitute(rhs, '\v%(<call>)@=',
             \   'call sexp#pre_op("' . a:mapmode[0] . '", "' . a:name . '")'
-            \ . '\\| try \\| ', '')
-        let rhs = substitute(rhs, '\v%(\<cr\>)@=',
-            \   '\\| finally'
-            \ . '\\| call sexp#post_op("' . a:mapmode[0] . '", "' . a:name . '")'
-            \ . '\\| endtry', '')
+            \ . ' \\| try \\| ', '')
+        let rhs = substitute(rhs, '\c\v%(\<cr\>)@=',
+            \   ' \\| finally'
+            \ . ' \\| call sexp#post_op("' . a:mapmode[0] . '", "' . a:name . '")'
+            \ . ' \\| endtry', '')
         execute lhs . ' ' . rhs
         return 1
     endif

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -152,9 +152,12 @@ function! s:defplug(flags, mapmode, name, ...)
         " TODO: Factor the pre/post-op call text into variables.
         " Wrap in pre/post-op calls.
         let rhs = substitute(rhs, '\v%(<call>)@=',
-            \ 'call sexp#pre_op("' . a:mapmode[0] . '", "' . a:name . '") \\| ', '')
+            \   'call sexp#pre_op("' . a:mapmode[0] . '", "' . a:name . '")'
+            \ . '\\| try \\| ', '')
         let rhs = substitute(rhs, '\v%(\<cr\>)@=',
-            \ ' \\| call sexp#post_op("' . a:mapmode[0] . '", "' . a:name . '")', '')
+            \   '\\| finally'
+            \ . '\\| call sexp#post_op("' . a:mapmode[0] . '", "' . a:name . '")'
+            \ . '\\| endtry', '')
         execute lhs . ' ' . rhs
         return 1
     endif

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -19,6 +19,7 @@ let g:sexp_loaded = 1
 
 """ Global State {{{1
 
+" TODO: More concise way...
 if !exists('g:sexp_filetypes')
     let g:sexp_filetypes = 'clojure,scheme,lisp,timl'
 endif
@@ -29,6 +30,14 @@ endif
 
 if !exists('g:sexp_insert_after_wrap')
     let g:sexp_insert_after_wrap = 1
+endif
+
+if !exists('g:sexp_indent_does_clone')
+    let g:sexp_indent_does_clone = 1
+endif
+
+if !exists('g:sexp_clone_does_indent')
+    let g:sexp_clone_does_indent = 1
 endif
 
 if !exists('g:sexp_mappings')
@@ -248,10 +257,16 @@ function! s:sexp_create_mappings()
                \ 'sexp_flow_to_prev_leaf_tail',   'sexp_flow_to_next_leaf_tail',
                \ 'sexp_clone_before',             'sexp_clone_after',
                \ 'sexp_indent',                   'sexp_indent_top',
-               \ 'sexp_indent_and_clean',         'sexp_indent_and_clean_top']
+               \ 'sexp_indent_and_clean',         'sexp_indent_and_clean_top',
+               \ 'sexp_indent_no_clean',          'sexp_indent_no_clean_top']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
+            if plug =~ '^sexp_indent' && lhs == '=='
+                " Special Case: Just as == overrides Vim's default normal mode
+                " command, = must override Vim's default visual mode command.
+                let lhs = '='
+            endif
             execute 'xmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
         endif
     endfor
@@ -377,15 +392,19 @@ Defplug! onoremap sexp_select_next_element sexp#docount(v:count, 'sexp#select_ad
 """ Commands {{{1
 
 " Indent S-Expression
-" TODO: Check the added visual versions - eg, correct version of Defplug?
-Defplug! nnoremap sexp_indent                sexp#indent('n', 0, v:count, 0)
-Defplug! xnoremap sexp_indent                sexp#indent('x', 0, v:count, 0)
-Defplug! nnoremap sexp_indent_top            sexp#indent('n', 1, v:count, 0)
-Defplug! xnoremap sexp_indent_top            sexp#indent('x', 1, v:count, 0)
+" Question: Would 'repeat' make any sense for visual variants?
+Defplug! nnoremap sexp_indent                sexp#indent('n', 0, v:count, -1)
+Defplug  xnoremap sexp_indent                sexp#indent('x', 0, v:count, -1)
+Defplug! nnoremap sexp_indent_top            sexp#indent('n', 1, v:count, -1)
+Defplug  xnoremap sexp_indent_top            sexp#indent('x', 1, v:count, -1)
 Defplug! nnoremap sexp_indent_and_clean      sexp#indent('n', 0, v:count, 1)
-Defplug! xnoremap sexp_indent_and_clean      sexp#indent('x', 0, v:count, 1)
+Defplug  xnoremap sexp_indent_and_clean      sexp#indent('x', 0, v:count, 1)
 Defplug! nnoremap sexp_indent_and_clean_top  sexp#indent('n', 1, v:count, 1)
-Defplug! xnoremap sexp_indent_and_clean_top  sexp#indent('x', 1, v:count, 1)
+Defplug  xnoremap sexp_indent_and_clean_top  sexp#indent('x', 1, v:count, 1)
+Defplug! nnoremap sexp_indent_no_clean       sexp#indent('n', 0, v:count, 0)
+Defplug  xnoremap sexp_indent_no_clean       sexp#indent('x', 0, v:count, 0)
+Defplug! nnoremap sexp_indent_no_clean_top   sexp#indent('n', 1, v:count, 0)
+Defplug  xnoremap sexp_indent_no_clean_top   sexp#indent('x', 1, v:count, 0)
 
 " Wrap list
 Defplug! nnoremap sexp_round_head_wrap_list  sexp#wrap('f', '(', ')', 0, g:sexp_insert_after_wrap)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -19,7 +19,6 @@ let g:sexp_loaded = 1
 
 """ Global State {{{1
 
-" TODO: More concise way...
 if !exists('g:sexp_filetypes')
     let g:sexp_filetypes = 'clojure,scheme,lisp,timl'
 endif
@@ -395,18 +394,18 @@ Defplug! onoremap sexp_select_next_element sexp#docount(v:count, 'sexp#select_ad
 
 " Indent S-Expression
 " Question: Would 'repeat' make any sense for visual variants?
+" Answer: I think it would, but for some reason, vim-sexp has historically not
+" supported repeat for visual operations, so I guess I'll be consistent for
+" now.
 Defplug! nnoremap sexp_indent                sexp#indent('n', 0, v:count, -1)
 Defplug  xnoremap sexp_indent                sexp#indent('x', 0, v:count, -1)
 Defplug! nnoremap sexp_indent_top            sexp#indent('n', 1, v:count, -1)
-Defplug  xnoremap sexp_indent_top            sexp#indent('x', 1, v:count, -1)
 Defplug! nnoremap sexp_indent_and_clean      sexp#indent('n', 0, v:count, 1)
 Defplug  xnoremap sexp_indent_and_clean      sexp#indent('x', 0, v:count, 1)
 Defplug! nnoremap sexp_indent_and_clean_top  sexp#indent('n', 1, v:count, 1)
-Defplug  xnoremap sexp_indent_and_clean_top  sexp#indent('x', 1, v:count, 1)
 Defplug! nnoremap sexp_indent_no_clean       sexp#indent('n', 0, v:count, 0)
 Defplug  xnoremap sexp_indent_no_clean       sexp#indent('x', 0, v:count, 0)
 Defplug! nnoremap sexp_indent_no_clean_top   sexp#indent('n', 1, v:count, 0)
-Defplug  xnoremap sexp_indent_no_clean_top   sexp#indent('x', 1, v:count, 0)
 
 " Wrap list
 Defplug! nnoremap sexp_round_head_wrap_list  sexp#wrap('f', '(', ')', 0, g:sexp_insert_after_wrap)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -68,6 +68,7 @@ let s:sexp_mappings = {
     \ 'sexp_select_next_element':       ']e',
     \ 'sexp_indent':                    '==',
     \ 'sexp_indent_top':                '=-',
+    \ 'sexp_cleanup_around_element':    '<LocalLeader>c',
     \ 'sexp_round_head_wrap_list':      '<LocalLeader>i',
     \ 'sexp_round_tail_wrap_list':      '<LocalLeader>I',
     \ 'sexp_square_head_wrap_list':     '<LocalLeader>[',
@@ -221,7 +222,8 @@ function! s:sexp_create_mappings()
 
     for plug in ['sexp_indent',              'sexp_indent_top',
                \ 'sexp_insert_at_list_head', 'sexp_insert_at_list_tail',
-               \ 'sexp_convolute',           'sexp_splice_list']
+               \ 'sexp_convolute',           'sexp_splice_list',
+               \ 'sexp_cleanup_around_element']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -372,8 +374,10 @@ Defplug! onoremap sexp_select_next_element sexp#docount(v:count, 'sexp#select_ad
 """ Commands {{{1
 
 " Indent S-Expression
-Defplug! nnoremap sexp_indent     sexp#indent(0, v:count)
-Defplug! nnoremap sexp_indent_top sexp#indent(1, v:count)
+Defplug! nnoremap sexp_indent             sexp#indent(0, v:count)
+Defplug! nnoremap sexp_indent_top         sexp#indent(1, v:count)
+" TODO: Consider supporting visual mode.
+Defplug! nnoremap sexp_cleanup_whitespace sexp#cleanup_around_element(v:count)
 
 " Wrap list
 Defplug! nnoremap sexp_round_head_wrap_list  sexp#wrap('f', '(', ')', 0, g:sexp_insert_after_wrap)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -377,7 +377,8 @@ Defplug! onoremap sexp_select_next_element sexp#docount(v:count, 'sexp#select_ad
 Defplug! nnoremap sexp_indent             sexp#indent(0, v:count)
 Defplug! nnoremap sexp_indent_top         sexp#indent(1, v:count)
 " TODO: Consider supporting visual mode.
-Defplug! nnoremap sexp_cleanup_around_element sexp#cleanup_around_element(v:count)
+Defplug! nnoremap sexp_cleanup_around_element sexp#cleanup_around_element(v:count, 'n')
+Defplug! xnoremap sexp_cleanup_around_element sexp#cleanup_around_element(v:count, 'v')
 
 " Wrap list
 Defplug! nnoremap sexp_round_head_wrap_list  sexp#wrap('f', '(', ')', 0, g:sexp_insert_after_wrap)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -377,7 +377,7 @@ Defplug! onoremap sexp_select_next_element sexp#docount(v:count, 'sexp#select_ad
 Defplug! nnoremap sexp_indent             sexp#indent(0, v:count)
 Defplug! nnoremap sexp_indent_top         sexp#indent(1, v:count)
 " TODO: Consider supporting visual mode.
-Defplug! nnoremap sexp_cleanup_whitespace sexp#cleanup_around_element(v:count)
+Defplug! nnoremap sexp_cleanup_around_element sexp#cleanup_around_element(v:count)
 
 " Wrap list
 Defplug! nnoremap sexp_round_head_wrap_list  sexp#wrap('f', '(', ')', 0, g:sexp_insert_after_wrap)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -68,6 +68,8 @@ let s:sexp_mappings = {
     \ 'sexp_select_next_element':       ']e',
     \ 'sexp_indent':                    '==',
     \ 'sexp_indent_top':                '=-',
+    \ 'sexp_indent_and_clean':          '<M-=>',
+    \ 'sexp_indent_and_clean_top':      '<M-->',
     \ 'sexp_cleanup_around_element':    '<LocalLeader>c',
     \ 'sexp_round_head_wrap_list':      '<LocalLeader>i',
     \ 'sexp_round_tail_wrap_list':      '<LocalLeader>I',
@@ -221,6 +223,7 @@ function! s:sexp_create_mappings()
     endfor
 
     for plug in ['sexp_indent',              'sexp_indent_top',
+               \ 'sexp_indent_and_clean',    'sexp_indent_and_clean_top',
                \ 'sexp_insert_at_list_head', 'sexp_insert_at_list_tail',
                \ 'sexp_convolute',           'sexp_splice_list',
                \ 'sexp_cleanup_around_element']
@@ -374,8 +377,10 @@ Defplug! onoremap sexp_select_next_element sexp#docount(v:count, 'sexp#select_ad
 """ Commands {{{1
 
 " Indent S-Expression
-Defplug! nnoremap sexp_indent             sexp#indent(0, v:count)
-Defplug! nnoremap sexp_indent_top         sexp#indent(1, v:count)
+Defplug! nnoremap sexp_indent                sexp#indent(0, v:count, 0)
+Defplug! nnoremap sexp_indent_top            sexp#indent(1, v:count, 0)
+Defplug! nnoremap sexp_indent_and_clean      sexp#indent(0, v:count, 1)
+Defplug! nnoremap sexp_indent_and_clean_top  sexp#indent(1, v:count, 1)
 " TODO: Consider supporting visual mode.
 Defplug! nnoremap sexp_cleanup_around_element sexp#cleanup_around_element(v:count, 'n')
 Defplug! xnoremap sexp_cleanup_around_element sexp#cleanup_around_element(v:count, 'v')

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -278,10 +278,10 @@ Defplug  xnoremap sexp_inner_string sexp#select_current_string('v', 1)
 Defplug! onoremap sexp_inner_string sexp#select_current_string('o', 1)
 
 " Current element
-Defplug  xnoremap sexp_outer_element sexp#select_current_element('v', 0, 1, v:count)
-Defplug! onoremap sexp_outer_element sexp#select_current_element('o', 0, 1, v:count)
-Defplug  xnoremap sexp_inner_element sexp#select_current_element('v', 1, 1, v:count)
-Defplug! onoremap sexp_inner_element sexp#select_current_element('o', 1, 1, v:count)
+Defplug  xnoremap sexp_outer_element sexp#select_current_element('v', 0, v:count)
+Defplug! onoremap sexp_outer_element sexp#select_current_element('o', 0, v:count)
+Defplug  xnoremap sexp_inner_element sexp#select_current_element('v', 1, v:count)
+Defplug! onoremap sexp_inner_element sexp#select_current_element('o', 1, v:count)
 
 Defplug  xnoremap sexp_outer_child_forward sexp#select_child('v', v:count, 1, 0)
 Defplug! onoremap sexp_outer_child_forward sexp#select_child('o', v:count, 1, 0)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -44,10 +44,10 @@ let s:sexp_mappings = {
     \ 'sexp_inner_string':              'is',
     \ 'sexp_outer_element':             'ae',
     \ 'sexp_inner_element':             'ie',
-    \ 'sexp_outer_child_backward':      'aC',
-    \ 'sexp_outer_child_forward':       'ac',
-    \ 'sexp_inner_child_backward':      'iC',
-    \ 'sexp_inner_child_forward':       'ic',
+    \ 'sexp_outer_child_tail':          'aC',
+    \ 'sexp_outer_child_head':          'ac',
+    \ 'sexp_inner_child_tail':          'iC',
+    \ 'sexp_inner_child_head':          'ic',
     \ 'sexp_move_to_prev_bracket':      '(',
     \ 'sexp_move_to_next_bracket':      ')',
     \ 'sexp_move_to_prev_element_head': '<M-b>',
@@ -70,7 +70,6 @@ let s:sexp_mappings = {
     \ 'sexp_indent_top':                '=-',
     \ 'sexp_indent_and_clean':          '<M-=>',
     \ 'sexp_indent_and_clean_top':      '<M-->',
-    \ 'sexp_cleanup_around_element':    '<LocalLeader>c',
     \ 'sexp_round_head_wrap_list':      '<LocalLeader>i',
     \ 'sexp_round_tail_wrap_list':      '<LocalLeader>I',
     \ 'sexp_square_head_wrap_list':     '<LocalLeader>[',
@@ -200,8 +199,8 @@ function! s:sexp_create_mappings()
                \ 'sexp_outer_top_list',       'sexp_inner_top_list',
                \ 'sexp_outer_string',         'sexp_inner_string',
                \ 'sexp_outer_element',        'sexp_inner_element',
-               \ 'sexp_outer_child_backward', 'sexp_outer_child_forward',
-               \ 'sexp_inner_child_backward', 'sexp_inner_child_forward']
+               \ 'sexp_outer_child_tail',     'sexp_outer_child_head',
+               \ 'sexp_inner_child_tail',     'sexp_inner_child_head']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'xmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -293,15 +292,15 @@ Defplug! onoremap sexp_outer_element sexp#select_current_element('o', 0, v:count
 Defplug  xnoremap sexp_inner_element sexp#select_current_element('v', 1, v:count)
 Defplug! onoremap sexp_inner_element sexp#select_current_element('o', 1, v:count)
 
-Defplug  xnoremap sexp_outer_child_forward sexp#select_child('v', v:count, 1, 0)
-Defplug! onoremap sexp_outer_child_forward sexp#select_child('o', v:count, 1, 0)
-Defplug  xnoremap sexp_inner_child_forward sexp#select_child('v', v:count, 1, 1)
-Defplug! onoremap sexp_inner_child_forward sexp#select_child('o', v:count, 1, 1)
+Defplug  xnoremap sexp_outer_child_head sexp#select_child('v', v:count, 1, 0)
+Defplug! onoremap sexp_outer_child_head sexp#select_child('o', v:count, 1, 0)
+Defplug  xnoremap sexp_inner_child_head sexp#select_child('v', v:count, 1, 1)
+Defplug! onoremap sexp_inner_child_head sexp#select_child('o', v:count, 1, 1)
 
-Defplug  xnoremap sexp_outer_child_backward sexp#select_child('v', v:count, 0, 0)
-Defplug! onoremap sexp_outer_child_backward sexp#select_child('o', v:count, 0, 0)
-Defplug  xnoremap sexp_inner_child_backward sexp#select_child('v', v:count, 0, 1)
-Defplug! onoremap sexp_inner_child_backward sexp#select_child('o', v:count, 0, 1)
+Defplug  xnoremap sexp_outer_child_tail sexp#select_child('v', v:count, 0, 0)
+Defplug! onoremap sexp_outer_child_tail sexp#select_child('o', v:count, 0, 0)
+Defplug  xnoremap sexp_inner_child_tail sexp#select_child('v', v:count, 0, 1)
+Defplug! onoremap sexp_inner_child_tail sexp#select_child('o', v:count, 0, 1)
 """ Text Object Motions {{{1
 
 " Nearest bracket
@@ -385,11 +384,6 @@ Defplug! nnoremap sexp_indent_and_clean      sexp#indent('n', 0, v:count, 1)
 Defplug! xnoremap sexp_indent_and_clean      sexp#indent('x', 0, v:count, 1)
 Defplug! nnoremap sexp_indent_and_clean_top  sexp#indent('n', 1, v:count, 1)
 Defplug! xnoremap sexp_indent_and_clean_top  sexp#indent('x', 1, v:count, 1)
-
-
-" TODO: Consider supporting visual mode.
-Defplug! nnoremap sexp_cleanup_around_element sexp#cleanup_around_element(v:count, 'n')
-Defplug! xnoremap sexp_cleanup_around_element sexp#cleanup_around_element(v:count, 'v')
 
 " Wrap list
 Defplug! nnoremap sexp_round_head_wrap_list  sexp#wrap('f', '(', ')', 0, g:sexp_insert_after_wrap)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -137,6 +137,12 @@ function! s:defplug(flags, mapmode, name, ...)
 
     " Key sequence
     if !asexpr
+        " TODO: Factor the pre/post-op call text into variables.
+        " Wrap in pre/post-op calls.
+        let rhs = substitute(rhs, '\v%(<call>)@=',
+            \ 'call sexp#pre_op("' . a:mapmode[0] . '", "' . a:name . '") \\| ', '')
+        let rhs = substitute(rhs, '\v%(\<cr\>)@=',
+            \ ' \\| call sexp#post_op("' . a:mapmode[0] . '", "' . a:name . '")', '')
         execute lhs . ' ' . rhs
         return 1
     endif


### PR DESCRIPTION
# Flow motions

Unlike the standard sexp motions, *flow* motions are completely unconstrained by list structure, permitting the cursor to move freely in and out of compound forms. There are 2 types:
1. "List" motions land on brackets.
2. "Leaf" motions land on non-list elements.

# Clone commands

Copy (clone) the current list or element either before or after the cursor, with distinct command variants for selecting single or multi-line behavior. Options make it possible to enable auto-reindent with excess whitespace cleanup for all elements involved in the clone.

# Indent Commands supporting whitespace cleanup

A new set of indent commands removes excess whitespace in addition to performing the indent.  
**Motivation:** Editing often introduces unsightly extra whitespace *around* elements, but the standard indent commands affect only *leading* indent.  
**Note:** By default, separate indent commands are created, but there's an option to enable whitespace cleanup for the default indent commands.

# "Child" text objects

Select the Nth inner/outer child from head or tail of the current compound form. Lets you skip navigation when you know exactly which element of the list you want to select: e.g., `viC` to select the final element in a list; `vic` to select the head.

# Convolution command

An occasionally useful (but always cool) *Paredit* command, which splices the tail of the current list into the current list's parent and moves the head of the current list to the head of a new list containing the parent of the current list.

# ELEMENT text objects now take a count

Useful for expanding the selection. Count logic takes whitespace cleanup into account.
