### PR TITLE
Fix for issue #43: vaf not working with anon functions (Treesitter only)

### DIFF
--- a/lua/sexp/ts.lua
+++ b/lua/sexp/ts.lua
@@ -444,7 +444,13 @@ function M.nearest_bracket(closing, open_re, close_re)
         end
         -- Check for macro chars.
         if vim.fn['sexp#is_macro_char'](ch) ~= 0 then
+          -- Move to macro char for call to sexp#current_macro_character_terminal().
+          vim.fn.setpos('.', {0, r+1, c+1, 0})
+          -- FIXME: I don't like this approach: should just test macro chars directly
+          -- without calling slow legacy method.
           local macro_end = vim.fn['sexp#current_macro_character_terminal'](1)
+          -- Restore position.
+          vim.fn.setpos('.', pos:to_vim4())
           -- Get the char just *past* the end of the leading macro, which will be bracket
           -- if this is some sort of special form.
           c = macro_end[3]


### PR DESCRIPTION
Fixes issue #43.
**Issue:** Forms with leading macro chars (e.g., `#( ... )`) were not being recognized as lists when Treesitter was used.
**Root Cause:** Failure to position *on* macro chars before calling legacy function to find the end of the macro char sequence.

**Note:** This is intended as a stopgap measure, as I'd really like to remove the call to `sexp#current_macro_character_terminal()` altogether, most likely replacing it with a pattern search of the buffer text directly.
