### PR TITLE
Fix for issue #49: convolute broken

### DIFF
--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -4757,9 +4757,10 @@ fu! sexp#convolute(count, ...)
     " Note: Not using sexp#splice because it doesn't preserve macro
     " chars/brackets.
     " Note: Work backwards since deletions invalidate positions.
-    let ket = s:yankdel_range(tpos_i, tpos_i, 1, 1)
-    let del = s:yankdel_range(bpos_i, pos, 1, [0, 0])
-    let bra = s:yankdel_range(spos_i, bpos_i, 1, 1)
+    " FIXME: Refactor yankdel_range() take optional args dict!!!
+    let ket = s:yankdel_range(tpos_i, tpos_i, 1, 1, [], 1)
+    let del = s:yankdel_range(bpos_i, pos, 1, [0, 0], [], 1)
+    let bra = s:yankdel_range(spos_i, bpos_i, 1, 1, [], 1)
 
     " Since the deleted text is going to be prepended to a list, make sure
     " that if it contains non-whitespace, it ends with whitespace. Normally,


### PR DESCRIPTION
**Root Cause:** sexp#convolute() was never updated to account for the 'failsafe override' mechanism added to `s:yankdel_range()`. Thus, the bracket deletions required by convolution were failing and returning 0 (in lieu of the empty string, which would have been more appropriate).
At some point, this off-nominal path should be analyzed and refactored, but this PR simply fixes the bug by setting the missing failsafe_override arg in the calls to `s:yankdel_range()`.