### PR TITLE
Changes to OUTER ELEMENT selection logic

### DIFF
--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -803,7 +803,8 @@ endfunction
 " completely characterize it, with the goal of supporting the logic in
 " s:terminals_with_whitespace() that determines the optimal visual selection for an outer
 " element.
-" TODO: Remove this!!!!!!
+" !!! Obsolete function !!!
+" TODO: Remove this after verifying it will no longer be needed!
 function! s:terminals_with_whitespace_info(start, end, leading)
     let cursor = getpos('.')
     let o = {}
@@ -1144,7 +1145,7 @@ function! s:terminals_with_whitespace(start, end)
         \ || s:is_list_terminal(end, 1) && !s:is_adjacent_to_comment(start, 0)
         " Full join: select everything between open or close bracket and the nearest
         " non-ws, which we've already determined can be safely juxtaposed to the bracket.
-        " Extra logic is needed to pull in a newline adjacent to the open/close.
+        " Extra logic is needed to pull in a newline adjacent to (and inside) the bracket.
         let start = ws_start[2] == 1 && ws_start[1] > 1
             \ ? [0, ws_start[1] - 1, col([ws_start[1] - 1, '$']), 0]
             \ : ws_start

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -183,21 +183,23 @@ Outer Element whitespace selection logic ~
 
         Algorithm Description:  ~
         Select as much surrounding whitespace as possible without violating
-        any of the following constraints, some of which are user
-        configurable:
+        the following constraints, some of which are user configurable.
+        Note: The constraints are applied to the hypothetical buffer state
+        that would be produced by deleting the outer element selection.
 
-            * increase the length of the line preceding the selection beyond a
-              configurable limit (by combining it with the line past the
-              selection)
-              See |g:sexp_cleanup_join_textwidth| to configure line length.
+            * increase the length of the line containing the start of the
+              selection beyond a configurable limit.
+              See |g:sexp_cleanup_join_textwidth| to configure limit.
               See |g:sexp_cleanup_join_affinity| to enable join selectively.
+            * select whitespace on lines above the first element of the
+              selection (unless |g:sexp_cleanup_join_backwards| is set).
             * pull a comment onto the end of an earlier line (unless
               |g:sexp_cleanup_join_comments| is set).
-              Rationale: Comments are often line/element-specific.
+              Rationale: Comments are often element-specific.
             * pull the element following the selection into an end of line
               comment
             * remove all whitespace separating adjacent siblings
-            * remove all blank lines between elements when
+            * leave trailing blank lines unless
               |g:sexp_cleanup_keep_empty_lines| is set to a value >= 1,
               representing the maximum number of blanks you'd like to keep.
 
@@ -1081,6 +1083,7 @@ second element of a list: e.g., with the default setting...
 <
 ...dae on "foo" would pull "bar baz" onto the start
 line, but dae on "baz" would *not* pull "blammo" onto the same line as "bar".
+
 Related options: ~
         |g:sexp_cleanup_join_textwidth|, |g:sexp_cleanup_join_multiline|
 >
@@ -1090,10 +1093,18 @@ Related options: ~
                                                *g:sexp_cleanup_join_textwidth*
 Line length constraint applied to outer selection cleanup logic, which avoids
 making selections whose deletion would result in a line longer than the
-specified length.
+specified length. The value can take either of the following forms:
+Integer:  ~
   -1  use &tw
    0  ignore line length
   >0  max line width to create with join
+Float:  ~
+  >0  Fraction of original line length used to validate join.
+      For instance, a value of 1.5 would prohibit joins that increased line
+      length by more than 50%.
+
+Note: This option has no effect if |g:sexp_cleanup_join_affinity| is 0.
+
 Related options ~
         |g:sexp_cleanup_join_affinity|, |g:sexp_cleanup_join_multiline|
 >

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -1053,14 +1053,19 @@ When there are multiple consecutive empty lines, preserve up to this many.
         " Default
         let g:sexp_cleanup_keep_empty_lines = 1
 <
-
                                           *g:sexp_cleanup_collapse_whitespace*
 Collapse all adjacent whitespace between elements to a single space, provided
 it's not within a comment or string or immediately preceding a comment.
 >
         " Default
         let g:sexp_cleanup_collapse_whitespace = 0
-
+<
+                                         *g:sexp_cleanup_never_append_comment*
+When performing cleanup or outer element selection, allow a comment to joined
+to an earlier line, provided other conditions for the join are met.
+>
+        " Default
+        let g:sexp_cleanup_never_append_comment = 0
 <
                                                 *g:sexp_cleanup_join_affinity*
 Determines scenarios in which outer selection attempts to ensure that a
@@ -1109,78 +1114,7 @@ Related options: ~
         " Default
         let g:sexp_cleanup_join_multiline = 0
 <
-                                              *g:sexp_cleanup_lineshift_limit*
-Threshold at which outer element cleanup logic switches from preserving
-leading indent to prioritizing the removal of leading empty lines. (Takes
-|g:sexp_cleanup_keep_empty_lines| into account.)
-   0  Allow any number of leading empty lines to be left behind by cleanup, if
-      required to preserve leading indent: i.e., whether to preserve leading
-      indent or remove leading blanks is determined solely by the colshift
-      options described below.
- >=1  Prioritize removal of leading whitespace if doing so would remove at
-      least this many empty lines.
-      Note: This option is considered an upper limit, which takes precedence
-      over the colshift options below.
 
-Example: >
-        (foo
-
-
-          bar baz)
-<
-With cursor on bar, the value of this option determines whether 'dae' cleans
-up the leading blank lines or preserves the leading indent on the final line.
-
-        g:sexp_cleanup_lineshift_limit == 0: ~
-        (foo
-
-
-          baz)
-<
-        g:sexp_cleanup_lineshift_limit == 1: ~
-        (foo
- baz)
-<
->
-        " Default
-        let g:sexp_cleanup_lineshift_limit = 2
-<
-                                                     *g:sexp_cleanup_colshift*
-The number of columns of leading indent that can be sacrificed to clean up
-leading blank lines is calculated by the following expression...
->
-  columns = (leading_blanks - 1) * sexp_cleanup_colshift_slope + sexp_cleanup_colshift
-<
-...where leading_blanks is the number of blank lines the normal cleanup logic
-would remove if unconstrained by the need to preserve leading indent.
-*Rationale*: For the type of outer element selection to which this option
-applies, it is impossible both to preserve leading indent *and* to remove
-leading blank lines: a choice must be made, and the relevant "opportunity
-cost" is highly subjective. This and the subsequent option permit the user to
-customize the behavior to his preference.
-  0            Leading indent threshold depends only on the number of blank
-               lines susceptible to cleanup in leading whitespace.
-  1..v:maxcol  If sexp_cleanup_colshift_slope == 0, sets a constant leading
-               indent threshold; if sexp_cleanup_colshift_slope > 0, sets the
-               minimum leading indent threshold, with the actual value
-               increasing linearly with the number of leading blank lines
-               susceptible to removal.
->
-        " Default
-        let g:sexp_cleanup_colshift = 4
-<
-                                               *g:sexp_cleanup_colshift_slope*
-The rate at which the leading indent threshold (see |g:sexp_cleanup_colshift|)
-increases with the number of empty lines susceptible to removal.
-  0            Leading indent threshold is constant, given by
-               g:sexp_cleanup_colshift.
-  1..v:maxcol  Rate at which leading indent threshold grows with number of
-               blank lines in leading whitespace.
-               (For details, see |g:sexp_cleanup_colshift|.)
->
-        " Default
-        let g:sexp_cleanup_colshift_slope = 8
-<
                                                *g:sexp_indent_aligns_comments*
 Align end-of-line comments automatically after performing an indent.
 >

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -178,27 +178,31 @@ ie                                                *<Plug>(sexp_inner_element)*
 Outer Element whitespace selection logic ~
                                            *sexp-surrounding-whitespace-rules*
         Inner motion does not include surrounding whitespace, but the outer
-        motion attempts to include all the whitespace you would wish to delete if
-        you were using the text object to delete element(s). The algorithm is
-        complex, but can be expressed roughly as follows: select as many
-        surrounding whitespace characters (including newlines) as possible,
-        while ensuring that a subsequent deletion of the selection will not do
-        any of the following:
+        motion attempts to include all the whitespace you would wish to delete
+        if you were using the text object to delete element(s).
+
+        Algorithm Description:  ~
+        Select as much surrounding whitespace as possible without violating
+        any of the following constraints, some of which are user
+        configurable:
 
             * increase the length of the line preceding the selection beyond a
               configurable limit (by combining it with the line past the
               selection)
-            * pull a comment onto the end of an earlier line
+              See |g:sexp_cleanup_join_textwidth| to configure line length.
+              See |g:sexp_cleanup_join_affinity| to enable join selectively.
+            * pull a comment onto the end of an earlier line (unless
+              |g:sexp_cleanup_join_comments| is set).
+              Rationale: Comments are often line/element-specific.
             * pull the element following the selection into an end of line
               comment
-              Rationale: Comments are often line/element-specific.
             * remove all whitespace separating adjacent siblings
             * remove all blank lines between elements when
               |g:sexp_cleanup_keep_empty_lines| is set to a value >= 1,
               representing the maximum number of blanks you'd like to keep.
-        Note: The rules may sound complex, but they mostly follow Ruby's
-        "Principle of Least Surprise" and Perl's "Do What I Mean"...
 
+        The rules may sound complex, but the results mostly obey Ruby's
+        "Principle of Least Surprise" and Perl's "Do What I Mean"...
 
                                                    *sexp-cleanup-vs-extension*
         These text objects can be used to "clean up" the current selection
@@ -1060,13 +1064,6 @@ it's not within a comment or string or immediately preceding a comment.
         " Default
         let g:sexp_cleanup_collapse_whitespace = 0
 <
-                                         *g:sexp_cleanup_never_append_comment*
-When performing cleanup or outer element selection, allow a comment to joined
-to an earlier line, provided other conditions for the join are met.
->
-        " Default
-        let g:sexp_cleanup_never_append_comment = 0
-<
                                                 *g:sexp_cleanup_join_affinity*
 Determines scenarios in which outer selection attempts to ensure that a
 subsequent delete would pull element following selection onto end of line
@@ -1114,7 +1111,21 @@ Related options: ~
         " Default
         let g:sexp_cleanup_join_multiline = 0
 <
-
+                                                *g:sexp_cleanup_join_comments*
+When all other join conditions are met, allow an outer element selection whose
+deletion would result in a comment being appended to a non-empty line.
+>
+        " Default
+        let g:sexp_cleanup_join_comments = 1
+<
+                                               *g:sexp_cleanup_join_backwards*
+When all other join conditions are met, allow an outer element selection whose
+deletion would remove one or more preceding newlines, thereby moving the
+cursor to an earlier line.
+>
+        " Default
+        let g:sexp_cleanup_join_backwards = 1
+<
                                                *g:sexp_indent_aligns_comments*
 Align end-of-line comments automatically after performing an indent.
 >

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -176,35 +176,40 @@ ie                                                *<Plug>(sexp_inner_element)*
         An element always includes leading macro characters.
 
 Outer Element whitespace selection logic ~
+                                          *sexp-outer-element-selection-logic*
                                            *sexp-surrounding-whitespace-rules*
-        Inner motion does not include surrounding whitespace, but the outer
-        motion attempts to include all the whitespace you would wish to delete
-        if you were using the text object to delete element(s).
+        Inner element/motion does not include surrounding whitespace, but the
+        outer element/motion attempts to include all the whitespace you would
+        wish to delete if you were using the text object to delete element(s).
 
         Algorithm Description:  ~
         Select as much surrounding whitespace as possible without violating
-        the following constraints, some of which are user configurable.
+        the following constraints, some of which are user-configurable.
         Note: The constraints are applied to the hypothetical buffer state
-        that would be produced by deleting the outer element selection.
+        produced by deletion of the outer element selection.
 
+            * append element following selection to line containing the
+              element preceding the selection.
+              (See |g:sexp_cleanup_join_affinity| to enable such joins in
+              certain scenarios.)
             * increase the length of the line containing the start of the
-              selection beyond a configurable limit.
-              See |g:sexp_cleanup_join_textwidth| to configure limit.
-              See |g:sexp_cleanup_join_affinity| to enable join selectively.
+              selection beyond a limit determined by
+              |g:sexp_cleanup_join_textwidth|.
             * select whitespace on lines above the first element of the
               selection (unless |g:sexp_cleanup_join_backwards| is set).
-            * pull a comment onto the end of an earlier line (unless
-              |g:sexp_cleanup_join_comments| is set).
+            * append a comment to the line containing the element preceding
+              the selection (unless |g:sexp_cleanup_join_comments| is set).
               Rationale: Comments are often element-specific.
             * pull the element following the selection into an end of line
               comment
             * remove all whitespace separating adjacent siblings
             * leave trailing blank lines unless
               |g:sexp_cleanup_keep_empty_lines| is set to a value >= 1,
-              representing the maximum number of blanks you'd like to keep.
+              representing the maximum number of blanks to keep.
 
         The rules may sound complex, but the results mostly obey Ruby's
-        "Principle of Least Surprise" and Perl's "Do What I Mean"...
+        "Principle of Least Surprise" and Perl's "Do What I Mean"
+        philosophy.
 
                                                    *sexp-cleanup-vs-extension*
         These text objects can be used to "clean up" the current selection
@@ -1054,7 +1059,11 @@ thus, please report any issues you believe are fixed by setting this option.
         let g:sexp_prefer_legacy_syntax = 0
 <
                                              *g:sexp_cleanup_keep_empty_lines*
-When there are multiple consecutive empty lines, preserve up to this many.
+Determines the number of consecutive empty lines to keep when performing any
+sort of cleanup. (Applies to both whitespace cleanup and OUTER ELEMENT
+selection.)
+  -1   never delete empty lines
+  >=0  maximum number of consecutive empty lines to keep
 >
         " Default
         let g:sexp_cleanup_keep_empty_lines = 1
@@ -1083,13 +1092,13 @@ second element of a list: e.g., with the default setting...
 <
 ...dae on "foo" would pull "bar baz" onto the start
 line, but dae on "baz" would *not* pull "blammo" onto the same line as "bar".
-
-Related options: ~
-        |g:sexp_cleanup_join_textwidth|, |g:sexp_cleanup_join_multiline|
 >
         " Default
         let g:sexp_cleanup_join_affinity = 1
 <
+Related options: ~
+        |g:sexp_cleanup_join_textwidth|, |g:sexp_cleanup_join_multiline|
+
                                                *g:sexp_cleanup_join_textwidth*
 Line length constraint applied to outer selection cleanup logic, which avoids
 making selections whose deletion would result in a line longer than the
@@ -1127,7 +1136,7 @@ When all other join conditions are met, allow an outer element selection whose
 deletion would result in a comment being appended to a non-empty line.
 >
         " Default
-        let g:sexp_cleanup_join_comments = 1
+        let g:sexp_cleanup_join_comments = 0
 <
                                                *g:sexp_cleanup_join_backwards*
 When all other join conditions are met, allow an outer element selection whose

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -75,10 +75,6 @@ if !exists('g:sexp_cleanup_collapse_whitespace')
     let g:sexp_cleanup_collapse_whitespace = 0
 endif
 
-if !exists('g:sexp_cleanup_never_append_comment')
-    let g:sexp_cleanup_never_append_comment = 0
-endif
-
 if !exists('g:sexp_cleanup_join_affinity')
     let g:sexp_cleanup_join_affinity = 1
 endif
@@ -89,6 +85,14 @@ endif
 
 if !exists('g:sexp_cleanup_join_multiline')
     let g:sexp_cleanup_join_multiline = 0
+endif
+
+if !exists('g:sexp_cleanup_join_comments')
+    let g:sexp_cleanup_join_comments = 1
+endif
+
+if !exists('g:sexp_cleanup_join_backwards')
+    let g:sexp_cleanup_join_backwards = 1
 endif
 
 " TODO: Consider encapsulating related options in a dict.

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -75,6 +75,10 @@ if !exists('g:sexp_cleanup_collapse_whitespace')
     let g:sexp_cleanup_collapse_whitespace = 0
 endif
 
+if !exists('g:sexp_cleanup_never_append_comment')
+    let g:sexp_cleanup_never_append_comment = 0
+endif
+
 if !exists('g:sexp_cleanup_join_affinity')
     let g:sexp_cleanup_join_affinity = 1
 endif
@@ -85,18 +89,6 @@ endif
 
 if !exists('g:sexp_cleanup_join_multiline')
     let g:sexp_cleanup_join_multiline = 0
-endif
-
-if !exists('g:sexp_cleanup_lineshift_limit')
-    let g:sexp_cleanup_lineshift_limit = 2
-endif
-
-if !exists('g:sexp_cleanup_colshift')
-    let g:sexp_cleanup_colshift = 4
-endif
-
-if !exists('g:sexp_cleanup_colshift_slope')
-    let g:sexp_cleanup_colshift_slope = 8
 endif
 
 " TODO: Consider encapsulating related options in a dict.

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -17,6 +17,47 @@ if exists('g:sexp_loaded')
 endif
 let g:sexp_loaded = 1
 
+""" Helper functions {{{1
+" Echo warning to message history if any of the option variables in the input list have
+" been set globally.
+"   optnames: list of option names without the g: prefix
+"   obsolete: 1=obsolete, 0=deprecated
+"   helphint: help hint to display after the warning
+function! s:deprecate_options(optnames, obsolete, helphint)
+    " Build list of opts requiring warning.
+    let opts = []
+    for opt in a:optnames
+        if exists('g:' . opt)
+            call add(opts, opt)
+        endif
+    endfor
+    if len(opts)
+        " Warn!
+        echohl ErrorMsg
+        echomsg printf("Warning: The following sexp option%s been %s:",
+            \ len(opts) > 1 ? "s have" : " has",
+            \ a:obsolete ? "removed" : "deprecated")
+        echomsg "  " . join(map(opts, "'g:' . v:val"), ", ")
+        echomsg printf("Remove the corresponding assignment%s"
+                    \ . " (e.g., from your vimrc) to disable this warning.",
+                    \ len(opts) > 1 ? "s" : "")
+        if len(a:helphint)
+            " Display the provided help hint.
+            echomsg "  " . a:helphint
+        endif
+        echohl None
+    endif
+endfunction
+
+" Note: The following options were introduced by PR #34 and removed in PR #51. Hopefully,
+" not many users have overridden them, but just in case...
+" TODO: Remove this after a few releases.
+call s:deprecate_options([
+            \ 'sexp_cleanup_lineshift_limit',
+            \ 'sexp_cleanup_colshift',
+            \ 'sexp_cleanup_colshift_slope'],
+            \ 1, ":help sexp-outer-element-selection-logic")
+
 """ Global State {{{1
 
 if !exists('g:sexp_filetypes')


### PR DESCRIPTION
## The Problem
PR #34 introduced changes that resulted in more aggressive selection of whitespace surrounding _OUTER ELEMENT_ text objects. These changes were by design but produced some unintended (and in the opinion of at least one user, undesirable) side-effects, particularly with respect to post-operation cursor positioning. For details, see issue #45.

## The Solution
This PR reverts the outer element selection logic to something more aggressive than the original, but significantly less aggressive than PR #34. In fact, a user can achieve something very close to the original behavior by tailoring the following options:


| Option | Default | Description |
| --------|----------|------------- |
| `g:sexp_cleanup_join_affinity` | 1 | Value between 0 and 3 determining scenarios in which to permit selection of trailing whitespace whose deletion would append element following selection to the line containing the start of the outer element selection. (Applies only when the first element of the outer element selection is not the first element on its line.) |
| `g:sexp_cleanup_join_textwidth` | -1 | Used to prevent selections whose deletion would result in a line that's "too long". Value can be either an integer representing screen columns or a float representing fraction of original line length (e.g., 1.25 to permit line length to grow by 25%). |
| `g:sexp_cleanup_join_comments` | 0 | Whether to permit whitespace selections whose deletion would append a comment to a line containing a non-comment element. |
| `g:sexp_cleanup_join_backwards` | 1 | Whether to permit whitespace selections to extend backwards to earlier lines (e.g., when the first element of the outer selection is the head of a list whose open bracket is at the end of an earlier line). |
| `g:sexp_cleanup_join_multiline` | 0 | Whether to permit whitespace selections whose deletion would join multiline elements. |
| `g:sexp_cleanup_keep_empty_lines` | 1 | The maximum number of trailing blank lines to exclude from the selection. |

## Examples
The following examples illustrate several ways in which the new behavior differs (or can be made to differ via option configuration) from the original behavior. All examples assume the _Old_ (pre-PR #34) and _New_ (current PR) end states are produced by a `dae` command applied to the starting state. Cursor position indicated by `|`.

### Selecting lines _above_ OUTER ELEMENT
The original logic never selected leading whitespace on lines _above_ the OUTER ELEMENT. The new logic is governed by `g:sexp_cleanup_join_backwards`.

```
(
|foo bar)
```
**Old:**
```
(
 |bar)
```
**New**: `g:sexp_cleanup_join_backwards == 1`
```
(|bar)
```

### Joining elements on both sides of the OUTER ELEMENT selection
The original logic never selected surrounding whitespace whose deletion would append elements following the selection to the line containing the last element before the selection. The new logic uses the options in the table above to decide.

#### Example 1 (append to head element)
```
(foo |(bar 42)
     (baz 43))
```
**Old:**
```
(foo|
     (baz 43))
```
**New**: `g:sexp_cleanup_join_affinity >= 1`
```
(foo |(baz 43))
```

#### Example 2 (append to non-head element)
```
(foo bar |baz
     blammo)
```
**Old:**
```
(foo bar|
     blammo)
```
**New**: `g:sexp_cleanup_join_affinity == 1`
```
(foo bar|
     blammo)
```
**New**: `g:sexp_cleanup_join_affinity >= 2`
```
(foo bar |blammo)
```
**Rationale:** The default join affinity of 1 treats the head element of a list specially, just as lisp itself does.

### Cleaning up trailing blank lines
The original logic always left trailing blank lines unless the subsequent element could be pulled up to the outer element selection line. The new logic selects such lines, taking care both to preserve the indent of the subsequent element and to leave up to `g:sexp_cleanup_keep_empty_lines` empty lines. (Note that if the original behavior is desired, the option can be set to a very large number. Also, I'm considering treating `-1` as infinity.)

```
(foo (bar 42)
     x y |z


     (foobar))
```
***Old:***
```
(foo (bar 42)
     x y|


     (foobar))
```
***New*** `g:sexp_cleanup_keep_empty_lines == 0`
```
(foo (bar 42)
     x y|
     (foobar))
```
***New:*** `g:sexp_cleanup_keep_empty_lines == 1`
```
(foo (bar 42)
     x y|

     (foobar))
```
***New:*** `g:sexp_cleanup_keep_empty_lines == 2`
```
(foo (bar 42)
     x y|


     (foobar))
```
