### PR TITLE
Make macro characters configurable

### DIFF
--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -47,7 +47,14 @@ let s:string_region = '\vstring|regex|pattern'
 let s:ignored_region = s:string_region . '|comment|character'
 let s:match_ignored_region_fn = 's:is_rgn_type("str_com_chr", line("."), col("."))'
 let s:nomatch_ignored_region_fn = '!s:is_rgn_type("str_com_chr", line("."), col("."))'
-let s:default_macro_characters = g:sexp_filetype_macro_characters['scheme']
+let s:filetype_macro_characters = {
+    \ 'clojure': "#'`~@^_=",
+    \ 'scheme':  "#'`,@",
+    \ 'lisp':    "#'`,@",
+    \ 'timl':    "#'`~@^_*",
+    \ 'fennel':  "#'`,@",
+    \ }
+let s:default_macro_characters = s:filetype_macro_characters['scheme']
 let s:pairs = {
     \ '(': ')',
     \ '[': ']',
@@ -94,13 +101,9 @@ let s:use_setpos_for_visual_marks = 1
 " Return macro characters for current filetype. Defaults to Scheme's macro
 " characters if 'lisp' is set, invalid characters otherwise.
 function! s:macro_chars()
-    if has_key(g:sexp_filetype_macro_characters, &filetype)
-        return g:sexp_filetype_macro_characters[&filetype]
-    elseif &lisp
-        return s:default_macro_characters
-    else
-        return ''
-    endif
+    get(g:sexp_filetype_macro_characters, &filetype,
+        \ get(s:filetype_macro_characters, &filetype,
+              \ &lisp ? s:default_macro_characters : ''))
 endfunction
 
 " Make a 'very magic' character class from input characters.

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -47,14 +47,7 @@ let s:string_region = '\vstring|regex|pattern'
 let s:ignored_region = s:string_region . '|comment|character'
 let s:match_ignored_region_fn = 's:is_rgn_type("str_com_chr", line("."), col("."))'
 let s:nomatch_ignored_region_fn = '!s:is_rgn_type("str_com_chr", line("."), col("."))'
-let s:macro_filetype_characters = {
-    \ 'clojure': "#'`~@^_=",
-    \ 'scheme':  "#'`,@",
-    \ 'lisp':    "#'`,@",
-    \ 'timl':    "#'`~@^_*",
-    \ 'fennel':  "#'`,@",
-    \ }
-let s:default_macro_characters = s:macro_filetype_characters['scheme']
+let s:default_macro_characters = g:sexp_filetype_macro_characters['scheme']
 let s:pairs = {
     \ '(': ')',
     \ '[': ']',
@@ -101,8 +94,8 @@ let s:use_setpos_for_visual_marks = 1
 " Return macro characters for current filetype. Defaults to Scheme's macro
 " characters if 'lisp' is set, invalid characters otherwise.
 function! s:macro_chars()
-    if has_key(s:macro_filetype_characters, &filetype)
-        return s:macro_filetype_characters[&filetype]
+    if has_key(g:sexp_filetype_macro_characters, &filetype)
+        return g:sexp_filetype_macro_characters[&filetype]
     elseif &lisp
         return s:default_macro_characters
     else

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -101,9 +101,9 @@ let s:use_setpos_for_visual_marks = 1
 " Return macro characters for current filetype. Defaults to Scheme's macro
 " characters if 'lisp' is set, invalid characters otherwise.
 function! s:macro_chars()
-    get(g:sexp_filetype_macro_characters, &filetype,
-        \ get(s:filetype_macro_characters, &filetype,
-              \ &lisp ? s:default_macro_characters : ''))
+    return get(g:sexp_filetype_macro_characters, &filetype,
+              \ get(s:filetype_macro_characters, &filetype,
+                    \ &lisp ? s:default_macro_characters : ''))
 endfunction
 
 " Make a 'very magic' character class from input characters.

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -101,9 +101,12 @@ let s:use_setpos_for_visual_marks = 1
 " Return macro characters for current filetype. Defaults to Scheme's macro
 " characters if 'lisp' is set, invalid characters otherwise.
 function! s:macro_chars()
-    return get(g:sexp_filetype_macro_characters, &filetype,
-              \ get(s:filetype_macro_characters, &filetype,
-                    \ &lisp ? s:default_macro_characters : ''))
+    " Caveat: Allow for possibility that g:sexp_filetype_macro_characters does not exist.
+    return get(
+        \ get(g:, 'sexp_filetype_macro_characters', {}),
+        \ &filetype,
+        \ get(s:filetype_macro_characters, &filetype,
+        \   &lisp ? s:default_macro_characters : ''))
 endfunction
 
 " Make a 'very magic' character class from input characters.

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -973,6 +973,20 @@ wish to activate vim-sexp mappings.
 >
         " Default
         let g:sexp_filetypes = 'clojure,scheme,lisp,timl,fennel'
+
+<
+                                            *g:sexp_filetype_macro_characters*
+A dictionary listing the macro characters as a string for each of the
+supported |FileTypes|.
+>
+        " Default
+        let g:sexp_filetype_macro_characters = {
+                \ 'clojure': "#'`~@^_=",
+                \ 'scheme':  "#'`,@",
+                \ 'lisp':    "#'`,@",
+                \ 'timl':    "#'`~@^_*",
+                \ 'fennel':  "#'`,@",
+                \ }
 <
                                           *g:sexp_enable_insert_mode_mappings*
 Toggle insert mode mappings in |g:sexp_filetypes|.

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -977,8 +977,8 @@ wish to activate vim-sexp mappings.
 <
                                             *g:sexp_filetype_macro_characters*
 A dictionary listing the macro characters as a string for each of the
-|FileTypes| that the user wants to configure. The default values for the
-built-in supported |FileTypes| are effectively:
+|FileTypes| you wish to configure. The default values for filetypes with
+builtin support are as follows:
 >
         " Default
         let g:sexp_filetype_macro_characters = {
@@ -989,6 +989,11 @@ built-in supported |FileTypes| are effectively:
                 \ 'fennel':  "#'`,@",
                 \ }
 <
+Note: It is best to override only unsupported filetypes (or supported
+filetypes with defaults you believe to be incorrect); copying the default
+dictionary in its entirety could mask future changes to the defaults for
+supported filetypes.
+
                                           *g:sexp_enable_insert_mode_mappings*
 Toggle insert mode mappings in |g:sexp_filetypes|.
 >

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -977,7 +977,8 @@ wish to activate vim-sexp mappings.
 <
                                             *g:sexp_filetype_macro_characters*
 A dictionary listing the macro characters as a string for each of the
-supported |FileTypes|.
+|FileTypes| that the user wants to configure. The default values for the
+built-in supported |FileTypes| are effectively:
 >
         " Default
         let g:sexp_filetype_macro_characters = {

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -64,16 +64,6 @@ if !exists('g:sexp_filetypes')
     let g:sexp_filetypes = 'clojure,scheme,lisp,timl,fennel'
 endif
 
-if !exists('g:sexp_filetype_macro_characters')
-    let g:sexp_filetype_macro_characters = {
-        \ 'clojure': "#'`~@^_=",
-        \ 'scheme':  "#'`,@",
-        \ 'lisp':    "#'`,@",
-        \ 'timl':    "#'`~@^_*",
-        \ 'fennel':  "#'`,@",
-        \ }
-endif
-
 if !exists('g:sexp_enable_insert_mode_mappings')
     let g:sexp_enable_insert_mode_mappings = 1
 endif

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -64,6 +64,16 @@ if !exists('g:sexp_filetypes')
     let g:sexp_filetypes = 'clojure,scheme,lisp,timl,fennel'
 endif
 
+if !exists('g:sexp_filetype_macro_characters')
+    let g:sexp_filetype_macro_characters = {
+        \ 'clojure': "#'`~@^_=",
+        \ 'scheme':  "#'`,@",
+        \ 'lisp':    "#'`,@",
+        \ 'timl':    "#'`~@^_*",
+        \ 'fennel':  "#'`,@",
+        \ }
+endif
+
 if !exists('g:sexp_enable_insert_mode_mappings')
     let g:sexp_enable_insert_mode_mappings = 1
 endif


### PR DESCRIPTION
> [!NOTE]
> This post has been updated since the original creation of the PR. The text below is the updated post and describes the current situation after subsequent commits were made.

vim-sexp currently hard codes the macro characters that it understands. This means that if a user-defined Lisp uses different macro characters to the default Lisp (i.e. Scheme), then features of vim-sexp that depend on macro characters will not work correctly.

An alternative approach is to allow a user to configure the macro characters, similar to how a user can configure supported filetypes. To achieve this, a global variable `g:sexp_filetype_macro_characters` is checked first, then the script-local variable `s:filetype_macro_characters` (renamed to be consistent with the global variable) is checked, before falling back to the `s:default_macro_characters` if `&lisp` is set (current behaviour).