### PR TITLE
Sexp-aware register paste commands

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -16,7 +16,7 @@ Vim-sexp brings the Vim philosophy of _precision editing_ to S-expressions.
 
 ## Requirements
 
-* Vim 7.3+
+* Vim 8.0+
 
 * [vim-repeat][] (optional)
 

--- a/README.markdown
+++ b/README.markdown
@@ -203,15 +203,8 @@ The following examples illustrate just a few of the possibilities...
 | `>p3<M-e>`  | Put after the second element beyond the current element |
 
 #### "Telescopic" Mode Example
-The preceding examples work with the default options.
-The following example (borrowed from the help) requires the following option settings:
 
 ```
-" Enable telescopic motion for motions outside current level.
-let g:sexp_regput_tele_motion = 1
-" Put/replace operators preserve original cursor position.
-let g:sexp_regput_curpos_op == 2
-
           (foo (bar)
                (|baz))
 

--- a/README.markdown
+++ b/README.markdown
@@ -133,6 +133,47 @@ If `g:sexp_indent_aligns_comments` is set (false by default), the `==` and `=-` 
 
 :help sexp-comment-alignment
 
+### Smart Paste Commands (normal, visual)
+
+A family of register put (paste) commands, optimized for use with S-Expressions.
+The following functionality is supported:
+
+- Put register before/after element at cursor
+- Replace element at cursor or visually-selected element(s) with register
+- Put register before/after `[count]`th child from head/tail of current list
+- Replace `[count]`th child of current list with register
+
+Although most of the commands are mapped to `<Leader>` keybindings, you may wish to remap a few of the builtin put operators for convenience.
+For details...
+```
+:help sexp-regput-overriding-builtins
+```
+
+#### Put register before/after (normal)
+* ["x] `<LocalLeader>p` puts `[count]` copies of register `x` after the current element.
+* ["x] `<LocalLeader>P` puts `[count]` copies of register `x` before the current element.
+
+**Note:** It is possible to configure whether these commands puts _into_ or _around_ a list whose bracket is _under_ the cursor.
+```
+:help sexp-regput-behavior-on-bracket
+```
+
+#### Replace element/selection with register (normal, visual)
+* ["x] `<M-p>` replaces the current element or visual selection with `[count]` copies of register `x`.
+* ["x] `<M-P>` idem, but doesn't update the unnamed register
+
+**Note:** In visual mode, the selection is first expanded to include all of any partially-selected forms.
+
+#### Put register into list (normal)
+* ["x] `<LocalLeader><p` puts register into current list, just before the `[count]`th child from head.
+* ["x] `<LocalLeader>>p` puts register into current list, just after the `[count]`th child from tail.
+
+#### Replace child with register (normal)
+* ["x] `<LocalLeader>[p` replaces the `[count]`th child from head of current list with register `x`.
+* ["x] `<LocalLeader>[P` idem, but doesn't update the unnamed register
+* ["x] `<LocalLeader>]p` replaces the `[count]`th child from tail of current list with register `x`.
+* ["x] `<LocalLeader>]P` idem, but doesn't update the unnamed register
+
 ### Clone Commands (normal, visual)
 
 * `<LocalLeader>c` inserts copy(s) of current list or visual selection before cursor without moving cursor

--- a/README.markdown
+++ b/README.markdown
@@ -165,8 +165,8 @@ Feel free to give these commands more convenient mappings if you find them usefu
 ```
 
 #### Replace selection with register (visual)
-* ["x] `<M-p>` replaces the visual selection with `[count]` copies of register `x`.
-* ["x] `<M-P>` idem, but doesn't update the unnamed register
+* ["x] `<LocalLeader>p` replaces the visual selection with `[count]` copies of register `x`.
+* ["x] `<LocalLeader>P` idem, but doesn't update the unnamed register
 
 #### Replace current element with register (normal)
 * ["x] `<LocalLeader><LocalLeader>p` replaces the current element with `[count]` copies of register `x`.

--- a/README.markdown
+++ b/README.markdown
@@ -135,19 +135,25 @@ If `g:sexp_indent_aligns_comments` is set (false by default), the `==` and `=-` 
 
 ### Smart Paste Commands (normal, visual)
 
-A family of register put (paste) commands, optimized for use with S-Expressions.
-The following functionality is supported:
-
-- Put register before/after element at cursor
-- Replace element at cursor or visually-selected element(s) with register
-- Put register before/after `[count]`th child from head/tail of current list
-- Replace `[count]`th child of current list with register
-
-Although most of the commands are mapped to `<Leader>` keybindings, you may wish to remap a few of the builtin put operators for convenience.
-For details...
+A family of commands and operators for pasting or replacing from registers, optimized for use with _S-expressions_.
+Unlike builtin put operators such as `p` and `P`, these commands will keep your Lisp code properly formatted and will never create unbalanced forms.
+In fact, you should rarely need to make any adjustments at all after a smart put.
+This is because the smart paste engine analyzes the target context to determine whether to insert a newline at each end of the put text, and performs an automatic re-indent after the put on the smallest range guaranteed to preserve correct indentation.
+Once you've used the smart paste commands, you will probably not have much use for Vim's builtin put commands in your Lisp buffers, and thus, may wish to replace the default `<LocalLeader>` keybindings with more convenient bindings that override the builtins.
+For an easy way to accomplish this...
 ```
 :help sexp-regput-overriding-builtins
 ```
+
+The smart-paste commands come in two varieties:
+* Normal and visual mode commands that target the element or list at the cursor position.
+* Normal mode _operators_ whose targets are remote S-expressions, selected with one of the following:
+  * a builtin or sexp _object_
+  * a builtin or sexp _motion_
+  * a target specified with a _telescopic motion_ (`:help sexp-operator-telescopic-motion`)
+
+**Note:** A few of the commands listed below are given intentionally long (3 character) default mappings because they are essentially shortcuts for something that can be accomplished with the more general put/replace operators.
+Feel free to give these commands more convenient mappings if you find them useful, or unmap them altogether if you prefer the operators.
 
 #### Put register before/after (normal)
 * ["x] `<LocalLeader>p` puts `[count]` copies of register `x` after the current element.
@@ -158,21 +164,70 @@ For details...
 :help sexp-regput-behavior-on-bracket
 ```
 
-#### Replace element/selection with register (normal, visual)
-* ["x] `<M-p>` replaces the current element or visual selection with `[count]` copies of register `x`.
+#### Replace selection with register (visual)
+* ["x] `<M-p>` replaces the visual selection with `[count]` copies of register `x`.
 * ["x] `<M-P>` idem, but doesn't update the unnamed register
 
-**Note:** In visual mode, the selection is first expanded to include all of any partially-selected forms.
+#### Replace current element with register (normal)
+* ["x] `<LocalLeader><LocalLeader>p` replaces the current element with `[count]` copies of register `x`.
+* ["x] `<LocalLeader><LocalLeader>P` idem, but doesn't update the unnamed register
 
-#### Put register into list (normal)
-* ["x] `<LocalLeader><p` puts register into current list, just before the `[count]`th child from head.
-* ["x] `<LocalLeader>>p` puts register into current list, just after the `[count]`th child from tail.
+**Note:** Syntactic sugar for applying the replace operator to the current element: e.g., `<LocalLeader><LocalLeader>p` = `<M-p>ie`
 
-#### Replace child with register (normal)
-* ["x] `<LocalLeader>[p` replaces the `[count]`th child from head of current list with register `x`.
-* ["x] `<LocalLeader>[P` idem, but doesn't update the unnamed register
-* ["x] `<LocalLeader>]p` replaces the `[count]`th child from tail of current list with register `x`.
-* ["x] `<LocalLeader>]P` idem, but doesn't update the unnamed register
+#### Put register into current list (normal)
+* ["x] `<LocalLeader>[p` puts register into current list, just before the `[count]`th child from head.
+* ["x] `<LocalLeader>]p` puts register into current list, just after the `[count]`th child from tail.
+
+**Note:** Syntactic sugar for applying the put operator to an _inner child_ object with a `[count]`: e.g., `3<LocalLeader>]p` = `<p2iC`
+
+#### Replace operator (normal)
+* ["x] `<M-p>` replaces the S-expression(s) selected by the operator's motion/object with register `x`.
+* ["x] idem, but doesn't update the unnamed register
+
+#### Put operator (normal)
+* ["x] `<p` puts register `x` before the element selected by the operator's motion/object
+* ["x] `>p` puts register `x` after the element selected by the operator's motion/object
+
+#### Put/Replace Operator Examples
+Although `<LocalLeader>p` and `<LocalLeader>P` will probably be your go-to commands for the most typical use cases, the put/replace _operators_ provide a powerful mechanism for putting and replacing forms _at a distance_.
+The following examples illustrate just a few of the possibilities...
+
+| Command | Result |
+| ------- | ------ |
+| `<M-p>af`  | Replace current list |
+| `<M-P>ie`  | Replace current element without updating unnamed register (`@"`) |
+| `<M-p>2ic` | Replace second child of current list |
+| `<M-p>3E`  | Replace current and next two elements |
+| `<piC`  | Put before final element of current list (equivalent to `2<LocalLeader>]p`) |
+| `>p3E`  | Put after the second element beyond the current element |
+
+#### "Telescopic" Mode Example
+The preceding examples work with the default options.
+The following example (borrowed from the help) requires the following option settings:
+
+```
+" Enable telescopic motion for motions outside current level.
+let g:sexp_regput_tele_motion = 1
+" Put/replace operators preserve original cursor position.
+let g:sexp_regput_curpos_op == 2
+```
+
+          (foo (bar)
+               (|baz))
+
+To swap "foo" and "baz" without moving the cursor (indicated by `|`), execute the following sequence of commands...
+
+| Command | Result |
+| ------- | ------ |
+| yie            | copy current element into unnamed register (`@"`)|
+| <M-p>?foo<CR>  | replace target of backwards search, updating unnamed register (`@"`) |
+| <M-p>ie        | replace current element with unnamed register (`@"`) |
+
+Although use of the unnamed register to swap words is idiomatic Vim, telescopic motions streamline the pattern by obviating the need to move the cursor back and forth between the elements being swapped and by handling any required re-indentation.
+
+```
+:help sexp-operator-telescopic-motion
+```
 
 ### Clone Commands (normal, visual)
 

--- a/README.markdown
+++ b/README.markdown
@@ -23,6 +23,25 @@ Vim-sexp brings the Vim philosophy of _precision editing_ to S-expressions.
   Enables use of the `.` command for repeating change operations in vim-sexp,
   as well as repeating builtin operations with vim-sexp's text objects.
 
+## Installation
+
+### Traditional Approach
+
+Download the plugin into your 'runtimepath' (or use a plugin manager that handles this for you).
+```
+:help sexp-installation
+```
+
+### Neovim
+
+Although the traditional plugin load approach can work with Neovim, some Nvim-only plugin managers may require a different approach.
+An example configuration for the popular `Lazy.nvim` plugin manager is provided in the help:
+```
+:help sexp-lazy-install
+```
+If you're using a plugin manager other than `Lazy.nvim`, this configuration might still provide a useful starting point.
+Feel free to report an issue if you encounter any plugin load issues.
+
 ## Treesitter Support
 
 Although Treesitter is not a requirement, vim-sexp will use it to achieve significant performance gains if it's available.

--- a/README.markdown
+++ b/README.markdown
@@ -175,10 +175,10 @@ Feel free to give these commands more convenient mappings if you find them usefu
 **Note:** Syntactic sugar for applying the replace operator to the current element: e.g., `<LocalLeader><LocalLeader>p` = `<M-p>ie`
 
 #### Put register into current list (normal)
-* ["x] `<LocalLeader>[p` puts register into current list, just before the `[count]`th child from head.
-* ["x] `<LocalLeader>]p` puts register into current list, just after the `[count]`th child from tail.
+* ["x] `<LocalLeader><p` puts register into current list, just before the `[count]`th child from head.
+* ["x] `<LocalLeader>>p` puts register into current list, just after the `[count]`th child from tail.
 
-**Note:** Syntactic sugar for applying the put operator to an _inner child_ object with a `[count]`: e.g., `3<LocalLeader>]p` = `<p2iC`
+**Note:** Syntactic sugar for applying the put operator to an _inner child_ object with a `[count]`: e.g., `3<LocalLeader>>p` = `<p2iC`
 
 #### Replace operator (normal)
 * ["x] `<M-p>` replaces the S-expression(s) selected by the operator's motion/object with register `x`.
@@ -198,7 +198,7 @@ The following examples illustrate just a few of the possibilities...
 | `<M-P>ie`  | Replace current element without updating unnamed register (`@"`) |
 | `<M-p>2ic` | Replace second child of current list |
 | `<M-p>3E`  | Replace current and next two elements |
-| `<piC`  | Put before final element of current list (equivalent to `2<LocalLeader>]p`) |
+| `<piC`  | Put before final element of current list (equivalent to `2<LocalLeader>>p`) |
 | `>p3E`  | Put after the second element beyond the current element |
 
 #### "Telescopic" Mode Example

--- a/README.markdown
+++ b/README.markdown
@@ -153,7 +153,7 @@ For details...
 * ["x] `<LocalLeader>p` puts `[count]` copies of register `x` after the current element.
 * ["x] `<LocalLeader>P` puts `[count]` copies of register `x` before the current element.
 
-**Note:** It is possible to configure whether these commands puts _into_ or _around_ a list whose bracket is _under_ the cursor.
+**Note:** It is possible to configure whether these commands put _into_ or _around_ a list whose bracket is _under_ the cursor.
 ```
 :help sexp-regput-behavior-on-bracket
 ```

--- a/README.markdown
+++ b/README.markdown
@@ -139,10 +139,11 @@ A family of commands and operators for pasting or replacing from registers, opti
 Unlike builtin put operators such as `p` and `P`, these commands will keep your Lisp code properly formatted and will never create unbalanced forms.
 In fact, you should rarely need to make any adjustments at all after a smart put.
 This is because the smart paste engine analyzes the target context to determine whether to insert a newline at each end of the put text, and performs an automatic re-indent after the put on the smallest range guaranteed to preserve correct indentation.
-Once you've used the smart paste commands, you will probably not have much use for Vim's builtin put commands in your Lisp buffers, and thus, may wish to replace the default `<LocalLeader>` keybindings with more convenient bindings that override the builtins.
-For an easy way to accomplish this...
+By default, vim-sexp overrides the following builtin put commands: `p`, `P`, `gp`, `gP`.
+Once you've used the smart paste commands, you will probably not have much use for Vim's builtin put commands in your Lisp buffers.
+However, if you wish to preserve access to the builtin commands, the help file outlines two distinct approaches you can take, depending on your expected use case:
 ```
-:help sexp-regput-overriding-builtins
+:help sexp-regput-builtin-overrides
 ```
 
 The smart-paste commands come in two varieties:
@@ -150,14 +151,14 @@ The smart-paste commands come in two varieties:
 * Normal mode _operators_ whose targets are remote S-expressions, selected with one of the following:
   * a builtin or sexp _object_
   * a builtin or sexp _motion_
-  * a target specified with a _telescopic motion_ (`:help sexp-operator-telescopic-motion`)
+  * a target specified with a _telescopic motion_ (`:help sexp-regput-telescopic-motion`)
 
 **Note:** A few of the commands listed below are given intentionally long (3 character) default mappings because they are essentially shortcuts for something that can be accomplished with the more general put/replace operators.
 Feel free to give these commands more convenient mappings if you find them useful, or unmap them altogether if you prefer the operators.
 
 #### Put register before/after (normal)
-* ["x] `<LocalLeader>p` puts `[count]` copies of register `x` after the current element.
-* ["x] `<LocalLeader>P` puts `[count]` copies of register `x` before the current element.
+* ["x] `p` puts `[count]` copies of register `x` after the current element.
+* ["x] `P` puts `[count]` copies of register `x` before the current element.
 
 **Note:** It is possible to configure whether these commands put _into_ or _around_ a list whose bracket is _under_ the cursor.
 ```
@@ -165,14 +166,14 @@ Feel free to give these commands more convenient mappings if you find them usefu
 ```
 
 #### Replace selection with register (visual)
-* ["x] `<LocalLeader>p` replaces the visual selection with `[count]` copies of register `x`.
-* ["x] `<LocalLeader>P` idem, but doesn't update the unnamed register
+* ["x] `p` replaces the visual selection with `[count]` copies of register `x`.
+* ["x] `P` idem, but doesn't update the unnamed register
 
 #### Replace current element with register (normal)
-* ["x] `<LocalLeader><LocalLeader>p` replaces the current element with `[count]` copies of register `x`.
-* ["x] `<LocalLeader><LocalLeader>P` idem, but doesn't update the unnamed register
+* ["x] `gp` replaces the current element with `[count]` copies of register `x`.
+* ["x] `gP` idem, but doesn't update the unnamed register
 
-**Note:** Syntactic sugar for applying the replace operator to the current element: e.g., `<LocalLeader><LocalLeader>p` = `<M-p>ie`
+**Note:** Syntactic sugar for applying the replace operator to the current element: e.g., `gp` = `<M-p>ie`
 
 #### Put register into current list (normal)
 * ["x] `<LocalLeader><p` puts register into current list, just before the `[count]`th child from head.
@@ -189,7 +190,7 @@ Feel free to give these commands more convenient mappings if you find them usefu
 * ["x] `>p` puts register `x` after the element selected by the operator's motion/object
 
 #### Put/Replace Operator Examples
-Although `<LocalLeader>p` and `<LocalLeader>P` will probably be your go-to commands for the most typical use cases, the put/replace _operators_ provide a powerful mechanism for putting and replacing forms _at a distance_.
+Although `p` and `P` will probably be your go-to commands for the most common use cases, the put/replace _operators_ provide a powerful mechanism for putting and replacing forms _at a distance_.
 The following examples illustrate just a few of the possibilities...
 
 | Command | Result |
@@ -197,9 +198,9 @@ The following examples illustrate just a few of the possibilities...
 | `<M-p>af`  | Replace current list |
 | `<M-P>ie`  | Replace current element without updating unnamed register (`@"`) |
 | `<M-p>2ic` | Replace second child of current list |
-| `<M-p>3E`  | Replace current and next two elements |
+| `<M-p>3<M-e>`  | Replace current and next two elements |
 | `<piC`  | Put before final element of current list (equivalent to `2<LocalLeader>>p`) |
-| `>p3E`  | Put after the second element beyond the current element |
+| `>p3<M-e>`  | Put after the second element beyond the current element |
 
 #### "Telescopic" Mode Example
 The preceding examples work with the default options.
@@ -210,10 +211,11 @@ The following example (borrowed from the help) requires the following option set
 let g:sexp_regput_tele_motion = 1
 " Put/replace operators preserve original cursor position.
 let g:sexp_regput_curpos_op == 2
-```
 
           (foo (bar)
                (|baz))
+
+```
 
 To swap "foo" and "baz" without moving the cursor (indicated by `|`), execute the following sequence of commands...
 
@@ -226,7 +228,7 @@ To swap "foo" and "baz" without moving the cursor (indicated by `|`), execute th
 Although use of the unnamed register to swap words is idiomatic Vim, telescopic motions streamline the pattern by obviating the need to move the cursor back and forth between the elements being swapped and by handling any required re-indentation.
 
 ```
-:help sexp-operator-telescopic-motion
+:help sexp-regput-telescopic-motion
 ```
 
 ### Clone Commands (normal, visual)

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2948,6 +2948,59 @@ function! s:stackop_emit(last, spos, bpos)
     return a:last ? [nextpos, a:bpos] : [a:spos, nextpos]
 endfunction
 
+function! sexp#put_into(count, dir)
+endfunction
+
+" Return true iff a put in indicated direction at specified location of the contents of
+" register indicated by v:register should be multiline.
+" Note: Decision is not final: a check for paste ending in comment
+" Note: Ignore multi-line nature of the register itself, considering only whether it
+" contains *internal* newlines.
+" -- Logic - adapted from clone --
+" * either register or target is multiline
+" * register ends with a comment
+"   TODO: Decide best way to determine: direct analysis with heuristics or paste then
+"   check, adjusting afterwards if necessary? I don't like embedding expression parser.
+" * target is a comment
+" * target is on a line by itself, possibly followed by a trailing comment
+" * target is the first or last element of a list whose open and close brackets are not
+"   colinear, and none of the target's sibling elements (ignoring any trailing comment)
+"   are colinear with target
+" * target is at toplevel
+function! s:is_multiline_put(loc, dir)
+    let reg = getreg(v:register)
+    let ml_reg = reg =~ '\S.\{-}\n.\{-}\S'
+
+endfunction
+
+function! sexp#put_at(count, dir)
+    let [empty_list, empty_buffer] = [0, 0]
+    " Determine the target element.
+    let t = sexp#current_element_terminal(a:dir)
+    if !t[1]
+        " See if there's a next element.
+        let t = s:nearest_element_terminal(1, a:dir)
+        if !t[1]
+            " Fall back to prev element.
+            let t = s:nearest_element_terminal(0, a:dir)
+            if !t[1]
+                " Must be empty list; treat like put after with cursor on virtual element
+                " located at open bracket.
+                let t = s:nearest_bracket(0)
+                if t[1]
+                    let empty_list = 1
+                else
+                    " Empty buffer?
+                    let no_buffer = 1
+                    let t = getcurpos()
+                endif
+            endif
+        endif
+    endif
+    " Determine single vs multi-line context.
+
+endfunction
+
 " Swap current visual selection with adjacent element. If pairwise is true,
 " swaps with adjacent pair of elements. If mode is 'v', the newly moved
 " selection is reselected.

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2988,7 +2988,17 @@ function! s:put__get_seps(tail, ctx, reg)
 
     " -- Interior separator
     " Note: We don't need to know count yet, since interior_sep is ignored if [count]=1.
-    let ret.interior_sep = reg.is_ml || reg.has_com ? NL : SPC
+    " Separate the [count] register copies from each other with NL if any of the following
+    " conditions are met:
+    " * register contents multiline
+    "   Rationale: Stacking many multiline forms horizontally could be problematic.
+    " * register *contains* comment
+    "   Rationale: For multiline register, comments are irrelevant, but we definitely
+    "   don't want multiple single line placed on the same line.
+    " * near sep is NL
+    "   Rationale: The logic that determined a NL should separate tgt from put text would
+    "   quite naturally extend to subsequent copies of the put text.
+    let ret.interior_sep = reg.is_ml || reg.has_com || ret.near_sep == NL ? NL : SPC
     return ret
 endfunction
 

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3329,13 +3329,13 @@ function! sexp#put(count, tail)
     call s:set_visual_marks([vs, ve])
 endfunction
 
+function! sexp#replace(mode, count, pvar)
+endfunction
+
 function! sexp#put_child(count, tail)
 endfunction
 
-function! sexp#replace(mode, count, tail)
-endfunction
-
-function! sexp#replace_child(count, dir)
+function! sexp#replace_child(count, dir, pvar)
 endfunction
 
 " Swap current visual selection with adjacent element. If pairwise is true,

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3118,7 +3118,7 @@ function! s:yankdel_range__preadjust_positions(op, ps)
         " Assumption: We have a non-empty range.
         " Note: Use position *past* end to account for bytes in final char of range.
         let ret.delta -=
-            \ (s:pos2byte(s:offset_char(a:op.end, 1)) - s:pos2byte(a:op.start))
+            \ (s:pos2byte(s:offset_char(a:op.end, 1, 1)) - s:pos2byte(a:op.start))
     endif
     " Calculate and store offsets of positions of interest wrt start of range.
     for p in a:ps

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2438,19 +2438,20 @@ endfunction
 " list_info        If not empty or omitted, use to skip call to s:list_info()
 " exact_count      If the requested child does not exist, return nullpos pair: i.e., don't
 "                  simply return the terminal element.
+" inner_only       pass-through to s:list_info()
 " TODO: Add option that won't consider a list whose brackets/macros we're on.
 " TODO: Probably accept position other than curpos.
 function! s:child_range(count, tail, inner, ...)
     let cursor = getpos('.')
     let ret = {'range': [s:nullpos, s:nullpos], 'missing': a:count}
     try
-        if a:0
-            let top_is_list = get(a:1, 'top_is_list', 0)
-            let li = get(a:1, 'list_info', {})
-            let exact_count = get(a:1, 'exact_count', 0)
-        endif
+        " Extract optional flags
+        let top_is_list = a:0 ? get(a:1, 'top_is_list', 0) : 0
+        let li = a:0 ? get(a:1, 'list_info', {}) : {}
+        let exact_count = a:0 ? get(a:1, 'exact_count', 0) : 0
+        let inner_only = a:0 ? get(a:1, 'inner_only', 0) : 0
         " Get relevant info about current list, including desired terminal.
-        let li = empty(li) ? s:list_info(a:tail) : li
+        let li = empty(li) ? s:list_info(a:tail, {'inner_only': inner_only}) : li
         " Attempt to get non-null terminal range as starting point for search.
         " Caveat: Don't update return dict till desired child is found.
         let range = li.terminal_range
@@ -3665,7 +3666,8 @@ function! s:replace_mode__get_tgt(put_mode, mode, count, tail, P)
             endif
         else " 'replace_child'
             let ret.tail = a:tail
-            let cr = s:child_range(a:count, a:tail, 1, {'exact_count': 1})
+            let cr = s:child_range(a:count, a:tail, 1,
+                \ {'exact_count': 1, 'inner_only': g:sexp_regput_bracket_is_child})
             if cr.missing
                 " Requested child doesn't exist!
                 throw "sexp-warning: 'replace_child': the requested child does not exist!"
@@ -3742,7 +3744,7 @@ function! s:put_child__get_tgt(count, tail)
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
         \ 'tail': a:tail, 'force_nl': [0, 0]}
     try
-        let li = s:list_info(a:tail) 
+        let li = s:list_info(a:tail, {'inner_only': g:sexp_regput_bracket_is_child}) 
         if li.terminal_range[0][1]
             " Non-empty list
             let r = ret.range
@@ -5520,16 +5522,22 @@ function! s:adjust_positions(start, end, splice, delta, ps)
     endfor
 endfunction
 
-" Calculate and return a dict describing the current list: i.e., the list within or on
-" which the cursor lies.
+" Calculate and return a dict describing the current list, defined as the smallest list
+" containing the test position, where the containment test is exclusive of brackets/macro
+" chars iff optional 'inner_only' flag is set.
 " Design Decision: Macro chars considered part of the list, just like brackets.
 " -- Args --
-" tail:   determines whether terminal_range should reflect head (0) or tail (1)
+"   tail:   determines whether terminal_range should reflect head (0) or tail (1)
+" -- Optional Dict --
+"   pos                position to test, defaults to curpos
+"   inner_only         if set, current list must contain (in bracket-exclusive sense) the
+"                      test position; defaults to 0
 " Return Dict:
 "   macro:           position of start of macro chars, else nullpos
 "   brackets[]:      [open, close], else [s:nullpos, s:nullpos] if no list
 "   terminal_range:  pos pair representing extents of terminal element requested by
 "                    a:tail, else nullpos_pair
+"   fallback:        1 iff caller wanted parent of the list represented by brackets[]
 " Exception Handling: Bare returns inside try/finally used to short-circuit remainder of
 " function, with cleanup and return value construction assured by the finally block.
 " TODO: Consider allowing caller to provide count to get non-terminal; let this be a
@@ -5538,44 +5546,62 @@ endfunction
 " duplication as it is now.
 " Partial Solution: child_range() accepts this function's return as optional arg, thereby
 " avoiding most of the duplication.
-" TODO: Consider having this accept a position.
-function! s:list_info(tail)
-    let cursor = getpos('.')
+function! s:list_info(tail, ...)
+    let save_cursor = getpos('.')
     let ret = {
         \ 'macro': s:nullpos, 'brackets': [s:nullpos, s:nullpos],
-        \ 'terminal_range': s:nullpos_pair
+        \ 'terminal_range': s:nullpos_pair,
+        \ 'fallback': 0,
     \ }
     try
-        " Make sure we get macro chars if they exist.
+        " Extract optional flags.
+        let inner_only = a:0 ? get(a:1, 'inner_only', 0) : 0
+        " Has caller specified a (non-cursor) position to test?
+        let pos = a:0 ? get(a:1, 'pos', s:nullpos) : s:nullpos
+        if pos[1] | call s:setcursor(pos) | endif
+        " Assumption: We're on test position.
+        " Move to its head, which is a safe place from which to search for containing open
+        " bracket if necessary.
         let p = s:move_to_current_element_terminal(0)
-        " Are we on a list?
         let isl = p[1] ? s:is_list(p[1], p[2]) : 0
-        if !isl
-            " Not *on* list brackets or macro chars. Move to parent list bracket in
-            " desired direction.
-            let p = s:move_to_nearest_bracket(a:tail)
-            if p[1]
-                " Update isl to allow downstream logic to work naturally.
-                " Note: 2=open 3=close
-                let isl = a:tail + 2
+        if !isl || inner_only
+            " Either not on list structure, or we are, but want its parent list.
+            " Look for nearest open bracket.
+            let pb = s:move_to_nearest_bracket(0)
+            if pb[1]
+                " Found parent open, but we need to know if there are macro chars.
+                let p = s:move_to_current_element_terminal(0)
+                if p != pb
+                    " Must be macro chars.
+                    let ret.macro = p
+                    " Move to open.
+                    call s:setcursor(pb)
+                endif
+                " Ensure subsequent macro char handling is skipped.
+                let isl = 2
+            elseif isl
+                " No parent, but we're on either open or macros of original list, which
+                " will have to suffice for current.
+                let ret.fallback = 1
             else
-                " No current or parent list!
+                " No current or parent list.
                 return
             endif
-        elseif isl == 1
-            " On macro chars preceding list.
+        endif
+        " Assumption: Arrival here guarantees we're on either open bracket or macro chars,
+        " as indicated by isl.
+        " Note: The following 'if' can be entered only if we started on macro chars and
+        " didn't look for (or looked for and failed to find) containing open.
+        if isl == 1
+            " On start of macro chars preceding list.
             " Save macro char start pos and move to open bracket.
             let ret.macro = p
             call s:setcursor(s:current_macro_character_terminal(1))
             call s:move_char(1)
-            " Update isl to simplify downstream logic.
-            let isl = 2
         endif
-        " We're on open or close bracket.
-        let i = isl - 2
-        let ret.brackets[i] = getpos('.')
-        " Find the opposite bracket.
-        let ret.brackets[!i] = s:nearest_bracket(!i)
+        " We're on open bracket. Save it and find close.
+        let ret.brackets[0] = getpos('.')
+        let ret.brackets[1] = s:nearest_bracket(1)
         " Begin search for list terminal from bracket indicated by a:tail.
         call s:setcursor(ret.brackets[a:tail])
         " Look *inward* for first non-whitespace.
@@ -5590,7 +5616,7 @@ function! s:list_info(tail)
         endif
     finally
         " Restore original position.
-        call s:setcursor(cursor)
+        call s:setcursor(save_cursor)
         return ret
     endtry
 endfunction
@@ -5618,11 +5644,14 @@ endfunction
 " if not on or within a non-empty list.
 " -- Args --
 " tail:  0=head 1=tail
+" -- Optional Args --
+"   pos                position to test, defaults to curpos
+"   inner_only         if set, current list must contain (in bracket-exclusive sense) the
+"                      test position; defaults to 0
 " Note: This is really just a convenience wrapper around s:list_info(); alternatively,
 " could use s:child_range() with count of 0 or 1.
-" FIXME!!!! This is broken, which breaks cleanup_ws()!!!
 function! s:list_terminal(tail, ...)
-    let li = s:list_info(a:tail)
+    let li = s:list_info(a:tail, a:0 ? a:1 : {})
     return li.terminal_range
 endfunction
 

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2868,8 +2868,14 @@ endfunction
 " buffer to have it parsed by legacy syntax engine.
 function! s:analyze_codestr_legacy(codestr, filetype)
     " Note: Processed text added later.
+    " TODO: Some of these fields won't be set properly until we're creating a hidden
+    " buffer in which to perform the analysis.
     let ret = {
-        \ 'reg_s_is_com': 0, 'reg_e_is_com': 0, 'reg_is_com': 0, 'reg_is_ml': 0,
+        \ 'err_count': 0, 'elem_count': 1, 'is_ml': 0,
+        \ 'has_com': 0, 's_is_com': 0, 'e_is_com': 0,
+        \ 'node_ranges': [],
+        \ 'error_ranges': [],
+        \ 'text': ''
     \ }
     " Caveat: Vim =~ operator treats rhs like a single line; thus, literal NL ("\n") (not
     " '\n') must be used to match interior NLs. Also, ^ and $ work only at beginning/end
@@ -2901,8 +2907,7 @@ function! s:regput__get_reginfo()
     let regstr = getreg(v:register)
     if regstr =~ '^\s*$'
         " No-op!
-        let ret.text = ''
-        return ret
+        return {}
     endif
     let ret = s:invoke('analyze_codestr', regstr, &ft)
     "echomsg string(ret)
@@ -2933,7 +2938,7 @@ endfunction
 "                    for which it has no meaning: make sure it can be set to -1 safely.
 "   force_nl[]:      1 iff subsequent processing should force use of NL separator.
 "                    Currently, used only for a normal (targeted) put when cursor is not
-"                    on an element.
+"                    *on* an element, but just before or after it.
 "   --]] End of merged-in tgt_info Dict
 "   empty_list:      putting into empty list
 "   empty_buffer:    putting into empty buffer
@@ -2941,40 +2946,14 @@ endfunction
 "   alone[]:         1 iff element at corresponding range endpoint is alone on its line,
 "                    with possible exception of open or close, but not both
 "   colinear[]:      1 iff element at corresponding range endpoint is colinear with its
-"                    adjacent (in the direction of the other range endpoint)
-"                    Implication: For non-replacement put modes, both values in the pair
-"                    will be identical, since the same 2 elements are used for both
-"                    comparisons; for replacement put modes, the values can differ because
-"                    opposite sides of the form(s) being replaced are used for the
-"                    comparisons.
+"                    adjacent element (in the direction of the other range endpoint). For
+"                    non-replacement put modes, both values in the pair will be identical,
+"                    since the same 2 elements are used for both comparisons; for
+"                    replacement put modes, however, the values can differ because each
+"                    comparison involves a range endpoint and its nearest inner range
+"                    endpoint.
+"                    Design Decision: Only elements (not brackets) can be colinear.
 " Cursor Preservation: Caller handles.
-" Special Logic: There are 3 distinct scenarios in which cursor is not *on* an element:
-"   1. cursor inside (not on brackets of) empty list
-"   2. cursor in empty (apart from whitespace) buffer
-"   3. cursor in whitespace adjacent to one or more elements
-" In the interest of simplifying downstream logic, we attempt to make the special cases
-" look somewhat like the nominal case (e.g., by allowing tgt to be a bracket or a special
-" BOF/EOF sentinel), but we also set flags (e.g., empty_{list,buffer}, force_nl[]) that
-" allow downstream logic to discriminate when necessary.
-" The handling of case 3 depends on the colinearity of cursor pos with whatever comes
-" before/after (i.e., effective prev/next, which can be either element or bracket, or even
-" BOF/EOF) and is outlined below:
-"
-" If cursor colinear with both effective prev/next
-"   p = put after effective prev
-"   P = put before effective next
-" ElseIf cursor colinear with effective prev
-"   put after effective prev
-"   force NL between effective prev and put text iff op == 'p'
-" ElseIf cursor colinear with effective next
-"   put before effective next
-"   force NL between effective next and put text iff op == 'P'
-" Else
-"   p = put after effective prev
-"   P = put before effective next
-" Design Decision: Although we could handle p and P the same way in the 2 ElseIf's above,
-" treating the one that puts *away from* the colinear target as a request for extra
-" separation seems intuitive and gives extra flexibility.
 function! s:regput__get_context(tgt_info)
     " Merge target information into return dict.
     let ret = extend({
@@ -2991,10 +2970,10 @@ function! s:regput__get_context(tgt_info)
     if !ret.empty_buffer && !ret.empty_list
         " Set side-specific 'alone' flags in loop.
         for i in range(2)
+
             if ret.put_mode == 'replace'
-                " TODO - take inner range into account
-                " TODO: Consider cacheing either inner range ends or adj so that alone
-                " logic can be shared.
+                " Cache range comprising the current outer range endpoint and the inner
+                " range endpoint closest to it.
                 let range = i
                     \ ? [ret.inner_range[1], ret.range[1]]
                     \ : [ret.range[0], ret.inner_range[0]]
@@ -3006,9 +2985,13 @@ function! s:regput__get_context(tgt_info)
                 let range = ret.range
                 let [is_ele, is_bra] = [ret.is_ele, ret.is_bra]
             endif
-            " Note: For non-replace modes, colinear[] is effectively a scalar.
-            let ret.colinear[i] = is_ele[i] && range[0][1] == range[1][1]
+            " Note: For non-replace modes, colinear[] is effectively a scalar, but this
+            " assignment is kept within the loop because in the 'replace' modes, is_ele[]
+            " can change from one iteration to the next.
+            let ret.colinear[i] = is_ele[0] && is_ele[1] && range[0][1] == range[1][1]
 
+            " 'outer' refers to the element or bracket just outside the range on current
+            " side. May be nullpos if current range endpoint is at buffer extremity.
             let [outer, outer_is_bra] = [s:nullpos, 0]
             if !ret.is_bra[i]
                 " Attempt to find outer adjacent.
@@ -3033,12 +3016,19 @@ function! s:regput__get_context(tgt_info)
     return ret
 endfunction
 
-" TODO: Comment this!!!!!
+" If context indicates a put into first, second or third position of a list satisfying all
+" of the conditions required for the list position special case (see below), return index
+" indicating the 1-based insert position, else return 0.
+" List Position Special Case Conditions: (all must be met)
+" * First element is single-line (most likely name of function).
+" * First and second element are colinear.
+" * Third element is either nonexistent or non-colinear with second element.
+" * (optional) List is not a 'let' form.
+"   TODO: The 'reg' parameter, currently unused, was added to support this.
+" Rationale: This function is used to determine whether calculated separators may require
+" modification to ensure we don't destroy the following pattern at the start of a function
+" call: '(' <func-name> <arg1> '\n'
 function! s:regput__check_list_context(ctx, reg)
-    " Initialize return value to special list containing "don't care" values for sep at
-    " both ends. If list position logic applies, one or both of the values may be changed
-    " to NL or SPC.
-    let ret = ['', '']
     let [ctx, reg] = [a:ctx, a:reg]
     let [sidx, ps] = [0, []]
     if !ctx.is_bra[0]
@@ -3066,7 +3056,7 @@ function! s:regput__check_list_context(ctx, reg)
         if sidx > 2
             " Start of range was not within 1st 2 elements of list (and possibly not even
             " within list).
-            return ret
+            return 0
         endif
         " Since list was built moving backwards...
         call reverse(ps)
@@ -3107,30 +3097,34 @@ function! s:regput__check_list_context(ctx, reg)
             " head element, which can't be accomplished with separators around the put
             " text. Keep it simple. Users don't often paste the name of a function
             " anyways...
+            return 1
         elseif sidx == 1
-            return [s:SPC, s:NL]
+            return 2
         elseif sidx == 2
-            return [s:NL, '']
+            return 3
         endif
     endif
-    return ret
+    " Nothing special.
+    return 0
 endfunction
 
-" Return a list containing 3 types of separators required for the put indicated by the
+" Return a list containing 4 types of separators required for the put indicated by the
 " inputs.
 " Args:
 "   ctx:  put context dict
 "   reg:  register characterization dict
 " Return List:
-"   [0]:  separator needed before register contents
-"   [1]:  separator needed after register contents
-"   [2]:  separator used to join the individual instances of register contents in case of
-"         a [count]
+"   [0]:  separator needed before put text
+"   [1]:  separator needed after put text
+"   [2]:  separator used to join the individual instances of register contents when
+"         [count] > 1 is used.
+"   [3]:  1st interior separator, left as empty string if all separators should be the
+"         same
 function! s:regput__get_seps(ctx, reg)
     " Default start/end sep to NL; overrides below.
     let [ctx, reg] = [a:ctx, a:reg]
     let tail = ctx.tail
-    let ret = [s:NL, s:NL, s:NL]
+    let ret = [s:NL, s:NL, s:NL, '']
     " TODO: Make global option for this?
     let g:append_sl_comment = get(g:, 'append_sl_comment', 1)
     " Override the NL separators as needed.
@@ -3151,15 +3145,14 @@ function! s:regput__get_seps(ctx, reg)
         " 'force_nl' flag is set only on the target side, and the colinearity check
         " reflects our unwillingness to make put text colinear with adj unless adj was
         " already colinear with target.
-        let has_tgt = ctx.put_mode == 'put'
+        " Build want_spc array to support interior sep computation after loop.
         for i in range(2)
             " Note: The ternary's first branch either inhibits SPC (ensuring default to
             " NL) or requests SPC explicitly (subject to comment constraints).
-            let want_spc = !empty(lpi[i])
-                \ ? lpi[i] == s:SPC
+            let want_spc = lpi
+                \ ? lpi == 2 && !i
                 \ : ctx.is_ele[i] && !ctx.alone[i] && !ctx.force_nl[i] && !reg.is_ml
-                \   && (!has_tgt || i != tail || ctx.colinear[i])
-
+                \   && (tail == -1 || i != tail || ctx.colinear[i])
             " Override NL (if necessary).
             " TODO: Change {e,s}_is_com to is_com[] to obviate need for this.
             let is_com = i ? reg.e_is_com : reg.s_is_com
@@ -3174,6 +3167,15 @@ function! s:regput__get_seps(ctx, reg)
             elseif want_spc && (i == 0 && g:append_sl_comment || !is_com)
                 let ret[i] = s:SPC
             endif
+            if ctx.put_mode =~ 'replace'
+                " Replace Mode Separator Adjustment: Inhibit separator unless it's a NL
+                " and we're currently colinear at this end.
+                if ret[i] != s:NL
+                    let ret[i] = s:EMPTY
+                elseif ctx.range[i] != ctx.inner_range[i]
+                    let ret[i] = s:EMPTY
+                endif
+            endif
         endfor
     endif
 
@@ -3187,10 +3189,23 @@ function! s:regput__get_seps(ctx, reg)
     "   Rationale: For multiline register, previous condition makes this one irrelevant,
     "   but we definitely don't want multiple single line comments placed on the same
     "   line.
-    " * near sep is NL
-    "   Rationale: The logic that determined a NL should separate tgt from put text would
-    "   quite naturally extend to subsequent copies of the put text.
-    let ret[2] = reg.is_ml || reg.has_com || ret[!tail] == s:NL ? s:NL : s:SPC
+    " * register contains multiple toplevel forms
+    " * put is targeted and near side sep is NL
+    "   Rationale: Testing has shown that failing to separate the clones from each other
+    "   when the entire put was separated from the target violates POLS: i.e., extending
+    "   the NL insertion down through the clones just feels right.
+    " * (optional) register contains single toplevel form whose length (or possibly length
+    "   x count) exceeds configurable threshold.
+    " TODO: Add the textwidth condition after working out the details and adding option.
+    " Hmmm: This condition doesn't make quite as much sense now that I've re-added the
+    " previous one, with which it would be redundant when near side sep is NL. I suppose
+    " it would still make sense to keep it for the case in which we're putting onto the
+    " same line as target.
+    let ret[2] = reg.is_ml || reg.has_com || reg.elem_count > 1
+        \ || (tail != -1 && ret[!tail] == s:NL) ? s:NL : s:SPC
+    " Provide distinct separator for 1st interior separator if applicable.
+    " Note: This element will be N/A if [count] == 1
+    let ret[3] = lpi == 2 ? s:NL : ''
     return ret
 endfunction
 
@@ -3231,18 +3246,38 @@ function! s:last_colinear_sibling(tail)
     endtry
 endfunction
 
+" Build and return string consisting of count copies of text, wrapped and joined with the
+" separators in the provided list (whose layout is documented in header of
+" put__get_seps().
+function! s:build_splice_string(text, count, sep)
+    let ret = a:text
+    if a:count > 1
+        " Append first interior separator, which *may* be different from the rest.
+        let ret .= !empty(a:sep[3]) ? a:sep[3] : a:sep[2]
+        " Append any remaining copies with the normal interior separator.
+        " Note: Sep won't be used if a:count - 1 == 1.
+        let ret .= join(repeat([a:text], a:count - 1), a:sep[2])
+    endif
+    " Apply outer separators.
+    return a:sep[0] . ret . a:sep[1]
+endfunction
+
 " Return a dict that characterizes the splice (or directed put) to be performed as the set
 " of arguments to s:yankdel_range().
 function! s:regput__get_splice_info(count, ctx, reg, sep, flags)
-    let ret = { 'range': a:ctx.range, 'text': '', 'inc': [0, 0]}
+    let ret = {
+        \ 'range': a:ctx.put_mode =~ 'repl' ? a:ctx.inner_range : a:ctx.range,
+        \ 'text': '', 'inc': [0, 0]
+    \ }
     let [ctx, reg, sep] = [a:ctx, a:reg, a:sep]
     let tail = ctx.tail
-    let has_tgt = ctx.put_mode == 'put'
+    " TODO: Perhaps these flags should be added to ctx for convenience.
+    let [is_repl, has_tgt] = [ctx.put_mode =~ 'repl', ctx.put_mode == 'put']
 
     " No range/inclusivity adjustments required in empty buffer case.
     if !ctx.empty_buffer
         " TODO: Decide whether/how tail matters for replace/child put modes.
-        if has_tgt && sep[tail] == s:NL
+        if !is_repl && tail != -1 && sep[tail] == s:NL
             " Determine number of newlines needed between put text and adjacent as a
             " function of the number of blank lines *currently* between target and
             " adjacent (taking options into account).
@@ -3259,28 +3294,29 @@ function! s:regput__get_splice_info(count, ctx, reg, sep, flags)
             let num_nl = min([max([gap, 1]), g:sexp_cleanup_keep_empty_lines + 1])
             let sep[tail] = repeat("\n", num_nl)
         endif
-        " If necessary, adjust exclusion type for range end.
-        " Logic: Always use adjacent whitespace-exclusive mode at end of range when the
-        " range terminal is a bracket or element, which is not *currently* colinear with
-        " start (i.e., there's leading indent at end), and we're inserting at least 1 NL
-        " at end.
-        " Rationale: Permits earlier "clean point" for re-indent; discarding the leading
-        " indent would require inclusion of one extra element at end (tgt if !tail, adj if
-        " tail).
-        " Note: Can't use adj_colinear flag because we care about colinearity of brackets
-        " too, and adj_colinear implies both tgt/adj are elements.
-        let exc_typ = 0
-        if (ctx.is_bra[1] || ctx.is_ele[1]) && ctx.range[0] != ctx.range[1]
-            \ && sep[1][0] == s:NL
-            let exc_typ = 2
+        if is_repl
+            " For replacements, ctx.inner_range is inclusive.
+            let ret.inc = [1, 1]
+        else
+            " If necessary, adjust exclusion type for range end.
+            " Logic: Always use adjacent whitespace-exclusive mode at end of range when the
+            " range terminal is a bracket or element, which is not *currently* colinear with
+            " start (i.e., there's leading indent at end), and we're inserting at least 1 NL
+            " at end.
+            " Rationale: Permits earlier "clean point" for re-indent; discarding the leading
+            " indent would require inclusion of one extra element at end (tgt if !tail, adj if
+            " tail).
+            " Note: Can't use adj_colinear flag because we care about colinearity of brackets
+            " too, and adj_colinear implies both tgt/adj are elements.
+            let exc_typ = 0
+            if (ctx.is_bra[1] || ctx.is_ele[1]) && ctx.range[0] != ctx.range[1]
+                \ && sep[1][0] == s:NL
+                let exc_typ = 2
+            endif
+            let ret.inc = [0, exc_typ]
         endif
-        let ret.inc = [0, exc_typ]
     endif
-    " Build splice string.
-    " TODO: Refactor this into a function somehow, since something similar is used
-    " elsewhere (for cloning, I think).
-    let t = join(repeat([reg.text], a:count), sep[2])
-    let ret.text = sep[0] . t . sep[1]
+    let ret.text = s:build_splice_string(reg.text, a:count, sep)
     return ret
 endfunction
 
@@ -3294,7 +3330,7 @@ function! s:regput__impl(tgt, count, tail)
 
     " Calculate the put.
     let reg = s:regput__get_reginfo()
-    if empty(reg.text)
+    if empty(reg) || empty(reg.text)
         " Treat empty text like NOOP!
         return
     endif
@@ -3351,9 +3387,38 @@ function! s:regput__impl(tgt, count, tail)
     call s:set_visual_marks([vs, ve])
 endfunction
 
-" Calculate and return the tgt_info dict needed by s:regput__get_context() for the case of
-" a 'put' command.
+" Calculate and return the tgt_info dict needed by s:regput__get_context() for a 'put'
+" command.
 " Note: For details, see header of s:regput__get_context().
+" -- Logic --
+" Nominal Case: If cursor is *on* element, use that element as the target, and let
+" direction be determined by put command (p/P).
+" Special Case: There are 3 distinct scenarios in which cursor is not *on* an element:
+"   1. cursor inside (not on brackets of) empty list
+"   2. cursor in empty (apart from whitespace) buffer
+"   3. cursor in whitespace adjacent to one or more elements
+" In the interest of simplifying downstream logic, we attempt to make the special cases
+" look somewhat like the nominal case (e.g., by allowing tgt to be a bracket or a special
+" BOF/EOF sentinel), but we also set flags (e.g., empty_{list,buffer}, force_nl[]) that
+" allow downstream logic to discriminate when necessary.
+" The handling of case 3 depends on the colinearity of cursor pos with whatever comes
+" before/after (i.e., effective prev/next, which can be either element or bracket, or even
+" BOF/EOF) and is outlined below:
+"
+" If cursor colinear with both effective prev/next
+"   p = put after effective prev
+"   P = put before effective next
+" ElseIf cursor colinear with effective prev
+"   put after effective prev
+"   force NL between effective prev and put text iff op == 'p'
+" ElseIf cursor colinear with effective next
+"   put before effective next
+"   force NL between effective next and put text iff op == 'P'
+" Else
+"   non-directional put
+" Design Decision: Although we could handle p and P the same way in the 2 ElseIf's above,
+" treating the one that puts *away from* the colinear target as a request for extra
+" separation seems intuitive and gives extra flexibility.
 function! s:put__get_tgt(count, tail)
     let curpos = getpos('.')
     let ret = {
@@ -3404,7 +3469,10 @@ function! s:put__get_tgt(count, tail)
                 " Design Decision: The fact that we're not on the element (or even near it)
                 " implies direction change: intuitively, the direction of p or P in empty line
                 " selects the target element.
-                let ret.tail = !ret.tail
+                " FIXME: Hmm... Maybe not so intuitive. Consider changing to
+                " non-directional (tail == -1).
+                "let ret.tail = !ret.tail
+                let ret.tail = -1
             elseif curpos[1] == prev[1] && curpos[1] != next[1]
                 let [ret.force_nl[0], ret.tail] = [a:tail && ret.is_ele[0], 1]
             elseif curpos[1] == next[1] && curpos[1] != prev[1]

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -460,7 +460,7 @@ function! sexp#current_element_terminal(end)
 
     if s:is_rgn_type('string', line, col)
         let pos = s:current_string_terminal(a:end)
-    elseif s:is_comment(line, col)
+    elseif sexp#is_comment(line, col)
         let pos = s:current_comment_terminal(a:end)
     elseif char =~# s:bracket && !s:is_rgn_type('str_com_chr', line, col)
         if (a:end && char =~# s:closing_bracket) || (!a:end && char =~# s:opening_bracket)
@@ -517,15 +517,16 @@ endfunction
 " TODO: Consider impact of combining 'ignore_current' and 'nullpos_on_fail' into a single
 " flag requesting nullpos on fail.
 " Rationale: I can't think of a scenario in which we'd want ignore_current but not
-" nullpos_on_fail, and there's at least one call site (s:move_to_adjacent_element) where
-" we simply repeat the provided ignore_current arg in the call to this function.
+" nullpos_on_fail, and there's at least one call site
+" (sexp#move_to_adjacent_element_terminal) where we simply repeat the provided
+" ignore_current arg in the call to this function.
 " Implementation Note: Original version made liberal use of 'sexp-error' throws to handle
 " short-circuiting in non-error scenarios; although I never used profiling to determine
 " the performance implications of that approach, it tended to be distracting in a
 " debugger. Accordingly, I've converted the throws to bare return statements, with the
 " actual return value constructed in a finally block.
 " TODO: Convert the optional args to a (possibly optional) flags dict.
-function! s:nearest_element_terminal(next, tail, ...)
+function! sexp#nearest_element_terminal(next, tail, ...)
     let cursor = getpos('.')
     let [pos, has_adj] = [cursor, 0]
     " Cache optional flags.
@@ -534,7 +535,12 @@ function! s:nearest_element_terminal(next, tail, ...)
     try
         " Attempt to find edge of current element (if applicable).
         let pos = sexp#current_element_terminal(a:next)
-        if pos[1] > 0 && s:compare_pos(pos, cursor) != 0
+        if !pos[1] && sexp#range_has_non_ws(cursor, cursor, 1)
+            " nullpos returned by sexp#current_element_terminal() from a non-ws pos
+            " generally means unbalanced bracket!
+            return
+        endif
+        if pos[1] > 0 && sexp#compare_pos(pos, cursor) != 0
             " Cursor was on element and not already at edge in search direction.
             " We may be done: i.e.,
             " b moves to the head of the current word if not already on the
@@ -565,7 +571,7 @@ function! s:nearest_element_terminal(next, tail, ...)
                 " Assumption: Ignored ws can be found at end of element, but not
                 " beginning. TODO Should we skip this if not on ignored char or would it
                 " be slower to check?
-                let pos = s:move_to_current_element_terminal(1)
+                let pos = sexp#move_to_current_element_terminal(1)
             endif
         endif
         " We're on near side of adjacent whose existence guarantees successful return,
@@ -587,7 +593,7 @@ endfunction
 
 """ QUERIES AT POSITION {{{1
 
-" TODO: Consider performance impact of replacing calls to this with s:offset_char(), which
+" TODO: Consider performance impact of replacing calls to this with sexp#offset_char(), which
 " handles multibyte.
 function! s:pos_with_col_offset(pos, offset)
     let [b, l, c, o] = a:pos
@@ -772,11 +778,11 @@ function! s:terminals_with_whitespace_info(start, end, leading)
     let o.eol = eol_text =~ '^.\s*$'
     " Are we at beginning of sexp?
     call s:setcursor(a:start)
-    let p = s:nearest_element_terminal(0, 1)
-    " Caveat: This test assumes s:nearest_element_terminal() returns current position if no
+    let p = sexp#nearest_element_terminal(0, 1)
+    " Caveat: This test assumes sexp#nearest_element_terminal() returns current position if no
     " preceding element.
-    let o.bos = s:compare_pos(p, a:start) >= 0
-    let o.follows_com = !o.bos && s:is_comment(p[1], p[2])
+    let o.bos = sexp#compare_pos(p, a:start) >= 0
+    let o.follows_com = !o.bos && sexp#is_comment(p[1], p[2])
     let o.follows_list = !o.bos && s:is_list(p[1], p[2])
     " FIXME: Get rid of o.next_e if only o.next_s is needed.
     " Get bounds of prev or open.
@@ -797,14 +803,14 @@ function! s:terminals_with_whitespace_info(start, end, leading)
     let p = sexp#current_element_terminal(0)
     if !p[1]
         " TODO: Do we need to handle null pos here? Is it even possible?
-        let p = s:nearest_element_terminal(1, 0)
+        let p = sexp#nearest_element_terminal(1, 0)
     endif
-    let o.is_com = s:is_comment(p[1], p[2])
+    let o.is_com = sexp#is_comment(p[1], p[2])
     " Are we at end of sexp?
     call s:setcursor(a:end)
-    let p = s:nearest_element_terminal(1, 0)
-    let o.eos = s:compare_pos(p, a:end) <= 0
-    let o.precedes_com = !o.eos && s:is_comment(p[1], p[2])
+    let p = sexp#nearest_element_terminal(1, 0)
+    let o.eos = sexp#compare_pos(p, a:end) <= 0
+    let o.precedes_com = !o.eos && sexp#is_comment(p[1], p[2])
     let o.precedes_list = !o.eos && s:is_list(p[1], p[2])
     " Get next and prev element extents.
     if !o.eos
@@ -842,7 +848,7 @@ function! s:terminals_with_whitespace_info(start, end, leading)
     " Note: Logic to determine whether o.ws_e is at eol slightly complicated by
     " possibility of multi-byte whitespace.
     let ecol = col([o.ws_e[1], '$'])
-    let o.ws_ve = s:offset_char(o.ws_e, 1, 1)[2] >= ecol
+    let o.ws_ve = sexp#offset_char(o.ws_e, 1, 1)[2] >= ecol
         \ ? [0, o.ws_e[1], ecol, 0]
         \ : o.ws_e
     " Set *interior* end positions, which are pulled in a bit from the end of the
@@ -874,7 +880,8 @@ function! s:terminals_with_whitespace_info(start, end, leading)
         endif
     else
         " No newlines in leading whitespace. Exclude 1 whitespace char *if possible*.
-        let o.ws_si = s:compare_pos(o.ws_s, o.start) >= 0 ? o.start[:] : s:offset_char(o.ws_s, 0)
+        let o.ws_si = sexp#compare_pos(o.ws_s, o.start) >= 0
+            \ ? o.start[:] : sexp#offset_char(o.ws_s, 0)
     endif
 
     " Special Case: Ordinarily, ws_ve != ws_e indicates trailing whitespace ends with
@@ -915,7 +922,8 @@ function! s:terminals_with_whitespace_info(start, end, leading)
         endif
     else
         " No newlines in leading whitespace. Exclude 1 whitespace char *if possible*.
-        let o.ws_ei = s:compare_pos(o.ws_e, o.end) <= 0 ? o.end[:] : s:offset_char(o.ws_e, 0)
+        let o.ws_ei = sexp#compare_pos(o.ws_e, o.end) <= 0
+            \ ? o.end[:] : sexp#offset_char(o.ws_e, 0)
     endif
     " De-normalized multi-line flag for convenience
     " Note: Single-line context is very restrictive: any scenario in which we'll have to
@@ -966,7 +974,7 @@ function! s:is_list_terminal(pos, tail)
     try
         call s:setcursor(a:pos)
         " Attempt to find previous element.
-        let p = s:nearest_element_terminal(a:tail, !a:tail, 1)
+        let p = sexp#nearest_element_terminal(a:tail, !a:tail, 1)
         if p != a:pos
             " Previous element implies not head of list.
             " Note: In many cases, this allows short-circuiting a test for top-level.
@@ -984,8 +992,8 @@ endfunction
 function! s:is_adjacent_to_comment(pos, tail)
     let save_cursor = getpos('.')
     try
-        let p = s:nearest_element_terminal(a:tail, !a:tail, 1)
-        return p != a:pos && s:is_comment(p[1], p[2])
+        let p = sexp#nearest_element_terminal(a:tail, !a:tail, 1)
+        return p != a:pos && sexp#is_comment(p[1], p[2])
     finally
         call s:setcursor(save_cursor)
     endtry
@@ -1022,21 +1030,18 @@ function! s:can_join(start, end)
     endif
     let [affinity, ml] = [g:sexp_cleanup_join_affinity, g:sexp_cleanup_join_multiline]
     " Get prev/next.
-    " TODO: Desperately need to rework s:nearest_element_terminal() and
-    " s:move_to_adjacent_element() to support request for nullpos return if no such
-    " element. The 'ignore_current' flag was a step in the right direction, but
-    " insufficient.
     " TODO: Consider hiding this block in a function called get_surrounding_elements() or
     " perhaps get_surrounding_context() (in which case, it should put the elements and
     " more in a returned dict).
     keepjumps call s:setcursor(end)
-    let p = s:nearest_element_terminal(1, 0, 1)
+    " TODO: Take advantage of the nullpos_on_fail flag!
+    let p = sexp#nearest_element_terminal(1, 0, 1)
     let next_s = p == end ? s:nullpos : p
-    let next_e = next_s[1] ? s:nearest_element_terminal(1, 1, 1) : s:nullpos
+    let next_e = next_s[1] ? sexp#nearest_element_terminal(1, 1, 1) : s:nullpos
     keepjumps call s:setcursor(start)
-    let p = s:nearest_element_terminal(0, 0, 1)
+    let p = sexp#nearest_element_terminal(0, 0, 1)
     let prev_s = p == start ? s:nullpos : p
-    let prev_e = prev_s[1] ? s:nearest_element_terminal(0, 1, 1) : s:nullpos
+    let prev_e = prev_s[1] ? sexp#nearest_element_terminal(0, 1, 1) : s:nullpos
 
     " Note: affinity shouldn't be less than zero, but err on side of disabling...
     if affinity <= 0 || !next_s[1]
@@ -1185,12 +1190,12 @@ function! s:count_brackets(start, end, all_brackets, opening_brackets)
         " Caveat: searchpos() returns [0,0] if no bracket found before EOF.
         if line && s:is_rgn_type('str_com_chr', line, col)
             keepjumps call cursor(line, col)
-            call s:move_to_adjacent_element(1, 0, 0)
+            call sexp#move_to_adjacent_element_terminal(1, 0, 0)
             continue
         endif
 
         " Break if bracket found after end or EOF hit by searchpos (!line).
-        let cmp = !line ? 1 : s:compare_pos([0, line, col, 0], a:end)
+        let cmp = !line ? 1 : sexp#compare_pos([0, line, col, 0], a:end)
         if cmp > 0 | break | endif
 
         if getline(line)[col - 1] =~# a:opening_brackets
@@ -1225,10 +1230,10 @@ function! s:count_elements(start, end)
     call s:setcursor(pos)
 
     while 1
-        let nextpos = s:move_to_adjacent_element(1, 0, 0)
-        if s:compare_pos(nextpos, a:end) > 0 | break | endif
+        let nextpos = sexp#move_to_adjacent_element_terminal(1, 0, 0)
+        if sexp#compare_pos(nextpos, a:end) > 0 | break | endif
         let n += 1
-        if s:compare_pos(pos, nextpos) == 0 | break | endif
+        if sexp#compare_pos(pos, nextpos) == 0 | break | endif
         let pos = nextpos
     endwhile
 
@@ -1238,7 +1243,7 @@ endfunction
 
 " Return input pos offset by 1 char in requested direction
 " Note: If optional flag is set, newlines between lines count.
-function! s:offset_char(pos, dir, ...)
+function! sexp#offset_char(pos, dir, ...)
     let cursor = getpos('.')
     let inc_nl = a:0 && !!a:1
     let eol = col([a:pos[1], '$'])
@@ -1315,6 +1320,94 @@ function! s:offset_char(pos, dir, ...)
     return pos
 endfunction
 
+" See s:super_range() for function description.
+function! s:super_range_legacy(start, end)
+    let cursor = getpos('.')
+    let [start, end] = [a:start[:], a:end[:]]
+    " Find matching pair of brackets (if one exists) that contains both start and end. Set
+    " shared_close to the close position, or null if no such pair exists.
+    " Note: In this context, a bracket "contains" itself.
+    call s:setcursor(start)
+    " Seed the loop position with an open containing start (possibly start itself).
+    let shared_open = s:is_list(start[1], start[2]) == 2 ? start : s:move_to_nearest_bracket(0)
+    while shared_open[1]
+        let shared_close = s:nearest_bracket(1)
+        " Note: Null shared close implies end at top level due to unbalanced open.
+        let cmp = !shared_close[1] ? 1 : sexp#compare_pos(shared_close, end)
+        if cmp >= 0
+            " Either we found shared close or we're not going to.
+            break
+        endif
+        " Haven't yet found shared close (and haven't hit top-level trying). Adjust
+        " start to current open bracket before looking higher.
+        let start = shared_open
+        let shared_open = s:move_to_nearest_bracket(0)
+    endwhile
+    " Assumptions:
+    " * Null shared_open implies null shared_close
+    " * shared_open == start implies end equal to a *non-null* shared_close.
+    " * shared_close == end implies start equal to a *non-null* shared_open.
+    " Enforce the associated constraints, with possibly redundant assignments.
+    if !shared_open[1]
+        " We hit top level looking for shared open containing end.
+        " Note: In case of unbalanced open, this assignment will be redundant.
+        let shared_close = [0, 0, 0, 0]
+    elseif shared_open == start
+        if shared_close[1]
+            let end = shared_close
+        endif
+    elseif shared_close == end
+        if shared_open[1]
+            let start = shared_open
+        endif
+    endif
+    " If on element, find its start.
+    " Rationale: Prefer start of macro chars to open bracket.
+    call s:setcursor(start)
+    let p = sexp#current_element_terminal(0)
+    if p[1]
+        let start = p
+    endif
+    " Is it possible we need to adjust end upward?
+    if end != shared_close
+        " Special Cases:
+        "   (shared_close == null)   => shared close is top-level
+        "       Don't look up any further; just find end terminal
+        "   (shared_close == a:end)    => end requires no adjustment
+        "       The next two loops will be skipped.
+        call s:setcursor(end)
+        " Note: compare_pos() < 0 could be simplified to p != shared_close.
+        " Rationale: Prior logic guarantees that p will eventually land *on* a non-null
+        " shared_close.
+        " Seed prev position var.
+        let p = end
+        " Treat null shared close like shared close past EOF.
+        while !shared_close[1] || sexp#compare_pos(p, shared_close) < 0
+            let end = p
+            let p = s:move_to_nearest_bracket(1)
+            if !p[1]
+                " Top level is common ancestor
+                break
+            endif
+        endwhile
+        " As long as we can assume a form always ends with a closing bracket (e.g., no macro
+        " chars following close), we can skip looking for terminal whenever the preceding loop
+        " has adjusted end to a closing bracket (i.e., end != a:end).
+        if end == a:end
+            call s:setcursor(end)
+            " Ensure end is a terminal.
+            let p = sexp#current_element_terminal(1)
+            if p[1]
+                let end = p
+            endif
+        endif
+    endif
+
+    " Restore saved position.
+    call s:setcursor(cursor)
+    return [start, end]
+endfunction
+
 " Return a superset range containing no unbalanced brackets by adjusting one or both sides
 " of the input range upward till both sides are at same level (i.e., have same parent) and
 " no elements are partially included in the range.
@@ -1329,7 +1422,7 @@ endfunction
 function! s:super_range(start, end)
     " Short-circuit optimizations
     " Are both ends of selection in run of whitespace?
-    if !s:range_has_non_ws(a:start, a:end, 1)
+    if !sexp#range_has_non_ws(a:start, a:end, 1)
         " Both ends of selection in same blank/whitespace
         " TODO: Ok to return the original ends, or do we need to find some sort of
         " terminals?
@@ -1339,7 +1432,7 @@ function! s:super_range(start, end)
     " Ignore leading/trailing whitespace.
     let [start, end] = s:trim_range(a:start, a:end)
     " Are both ends of selection in same atom?
-    if !s:range_has_ws(start, end, 1)
+    if !sexp#range_has_ws(start, end, 1)
         " High probability selection within single atom, but need to check.
         let save_cursor = getpos('.')
         call s:setcursor(start)
@@ -1390,14 +1483,14 @@ function! s:constrained_range(start, end, keep_end)
     " Did we find a containing bracket?
     if ket[1]
         " Not at toplevel. Determine whether ket *could* represent a limit.
-        let cmp = s:compare_pos(that, ket)
+        let cmp = sexp#compare_pos(that, ket)
         if that_dir && cmp >= 0 || this_dir && cmp <= 0
             " Limiting *may* be required. In any case, we need to determine
             " exclusivity of limit: even if cmp alone guarantees we'll be
             " limiting, exclusivity will determine the limiting position.
             let exc = s:nearest_bracket(this_dir) != this
             if exc || cmp
-                let lim = exc ? s:offset_char(ket, this_dir) : ket
+                let lim = exc ? sexp#offset_char(ket, this_dir) : ket
             else
                 let lim = [0, 0, 0, 0]
             endif
@@ -1549,7 +1642,7 @@ endfunction
 
 " Returns 1 if character at position is in a comment, or is in the whitespace
 " between two line comments.
-function! s:is_comment(line, col)
+function! sexp#is_comment(line, col)
     if s:is_rgn_type('comment', a:line, a:col)
         return 1
     else
@@ -1650,7 +1743,7 @@ endfunction
 " Returns -1 if position a is before position b, 1 if position a is after
 " position b, and 0 if they are the same position. Only compares the line and
 " column, ignoring buffer and offset.
-function! s:compare_pos(a, b)
+function! sexp#compare_pos(a, b)
     if a:a[1] == a:b[1] && a:a[2] == a:b[2]
         return 0
     elseif a:a[1] != a:b[1]
@@ -1663,12 +1756,12 @@ endfunction
 " Return true iff there's *any* whitespace in the range [beg,end].
 " Note: If 'check_ignored' set, differentiate between whitespace in ignored region and
 " whitespace that separates tokens.
-fu! s:range_has_ws(beg, end, check_ignored)
+fu! sexp#range_has_ws(beg, end, check_ignored)
     let save_cursor = getcurpos()
     call setpos('.', a:beg)
     " Note: Empty 'skip' skips nothing.
     let pos = searchpos('\s', 'nczW', a:end[1], 0, a:check_ignored ? s:match_ignored_region_fn : '')
-    let ret = pos[0] && s:compare_pos([0, pos[0], pos[1], 0], a:end) <= 0
+    let ret = pos[0] && sexp#compare_pos([0, pos[0], pos[1], 0], a:end) <= 0
     call setpos('.', save_cursor)
     return ret
 endfu
@@ -1676,17 +1769,17 @@ endfu
 " Return true iff there's *any* non-whitespace in the range [beg,end].
 " Note: See previous function comment for usage of 'check_ignored'.
 " TODO: Make check_ignored optional, defaulting to true.
-fu! s:range_has_non_ws(beg, end, check_ignored)
+fu! sexp#range_has_non_ws(beg, end, check_ignored)
     let ret = 0
     let save_cursor = getcurpos()
     call setpos('.', a:beg)
     let pos = searchpos('\S', 'nczW', a:end[1])
-    let ret = pos[0] && s:compare_pos([0, pos[0], pos[1], 0], a:end) <= 0
+    let ret = pos[0] && sexp#compare_pos([0, pos[0], pos[1], 0], a:end) <= 0
     if !ret && a:check_ignored
         " No true non-ws, but check for "ignored" ws, which counts as the same thing...
         let pos = searchpos('\s', 'nczW', a:end[1], 0, s:nomatch_ignored_region_fn)
         " Return true iff we found ignored ws within region.
-        let ret = pos[0] && s:compare_pos([0, pos[0], pos[1], 0], a:end) <= 0
+        let ret = pos[0] && sexp#compare_pos([0, pos[0], pos[1], 0], a:end) <= 0
     endif
     call setpos('.', save_cursor)
     return ret
@@ -1720,7 +1813,7 @@ fu! s:trim_range(beg, end)
     call s:setcursor(a:beg)
     let s = searchpos('\S', 'nczW', a:end[1])
     let s = [0, s[0], s[1], 0]
-    if s[1] && s:compare_pos(s, a:end) <= 0
+    if s[1] && sexp#compare_pos(s, a:end) <= 0
         " We have at least one non-ws within range; find the last.
         " Note: Previous search guarantees success of this one.
         call s:setcursor(a:end)
@@ -1777,7 +1870,7 @@ endfunction
 
 " TODO: Remove...
 function! s:move_char(dir)
-    let pos = s:offset_char(getpos('.'), a:dir)
+    let pos = sexp#offset_char(getpos('.'), a:dir)
     call s:setcursor(pos)
 endfunction
 
@@ -1805,7 +1898,7 @@ function! s:move_to_top_bracket(closing)
 endfunction
 
 " Tries to move cursor to current element terminal, returning its position.
-function! s:move_to_current_element_terminal(closing)
+function! sexp#move_to_current_element_terminal(closing)
     let pos = sexp#current_element_terminal(a:closing)
     if pos[1] > 0 | call s:setcursor(pos) | endif
     return pos
@@ -1820,7 +1913,14 @@ endfunction
 " respectively. Analogous to native w, e, and b commands.
 " Optional Arg: If optional 'ignore_current' flag is set and there's no adjacent element,
 " return nullpos without moving cursor.
-function! s:move_to_adjacent_element(next, tail, top, ...)
+" Renaming Note: This function has been renamed from s:move_to_adjacent_element() to make
+" it accessible to the sexp#parse module; it would have been named
+" sexp#move_to_adjacent_element, but that name was already taken by the API method invoked
+" from the plugin script.
+" TODO: Put API autoload functions in a sexp#api module so that the sexp module can be
+" reserved for internal functionality; alternatively, put the api in sexp and the internal
+" stuff in sexp#nav or sexp#impl or somesuch...
+function! sexp#move_to_adjacent_element_terminal(next, tail, top, ...)
     let cursor = getpos('.')
     let ignore_current = a:0 && a:1
     try
@@ -1829,13 +1929,13 @@ function! s:move_to_adjacent_element(next, tail, top, ...)
 
             " Stop at current top element head if moving backward and did not
             " start on a top element head.
-            if !a:next && top[1] > 0 && s:compare_pos(top, cursor) != 0
+            if !a:next && top[1] > 0 && sexp#compare_pos(top, cursor) != 0
                 let pos = top
                 return
             endif
         endif
         " Note: We fall through here from top case iff not stopping at current top head.
-        let pos = s:nearest_element_terminal(
+        let pos = sexp#nearest_element_terminal(
             \ a:next, a:tail, ignore_current, ignore_current)
     finally
         call s:setcursor(pos[1] ? pos : cursor)
@@ -1848,7 +1948,7 @@ endfunction
 function! s:move_to_element_near_position(pos)
     call s:setcursor(a:pos)
     return getline('.')[col('.') - 1] =~# '\v\s'
-           \ ? s:move_to_adjacent_element(1, 0, 0)
+           \ ? sexp#move_to_adjacent_element_terminal(1, 0, 0)
            \ : a:pos
 endfunction
 
@@ -1862,7 +1962,7 @@ function! s:move_cursor_extending_selection(func, ...)
     endif
 
     let [start, end] = s:get_visual_marks()
-    let omode = s:compare_pos(start, getpos('.')) == 0
+    let omode = sexp#compare_pos(start, getpos('.')) == 0
 
     let pos = call(a:func, a:000)
     let valid = pos[1] > 0
@@ -1913,7 +2013,7 @@ function! sexp#move_to_nearest_bracket(mode, next)
         let cursor = getpos('.')
         let bracket = getline(cursor[1])[cursor[2] - 1]
 
-        call s:move_to_current_element_terminal(1)
+        call sexp#move_to_current_element_terminal(1)
         let pos = s:nearest_bracket(1)
 
         if pos[1] < 1 || (bracket =~# s:closing_bracket
@@ -1934,7 +2034,7 @@ function! sexp#move_to_nearest_bracket(mode, next)
     endif
 endfunction
 
-" Calls s:move_to_adjacent_element count times, with the following additional
+" Calls sexp#move_to_adjacent_element_terminal count times, with the following additional
 " behaviours:
 "
 " * If mode == 'v', the current visual selection is extended
@@ -1948,14 +2048,17 @@ endfunction
 "   bounded by the parent list.
 function! sexp#move_to_adjacent_element(mode, count, next, tail, top)
     if a:mode ==? 'n'
-        return sexp#docount(a:count, 's:move_to_adjacent_element', a:next, a:tail, a:top)
+        return sexp#docount(a:count, 'sexp#move_to_adjacent_element_terminal',
+            \ a:next, a:tail, a:top)
     elseif a:mode ==? 'v'
-        return sexp#docount(a:count, 's:move_cursor_extending_selection', 's:move_to_adjacent_element', a:next, a:tail, a:top)
+        return sexp#docount(a:count, 's:move_cursor_extending_selection',
+            \ 'sexp#move_to_adjacent_element_terminal', a:next, a:tail, a:top)
     elseif a:mode ==? 'o'
         let cursor = getpos('.')
-        call sexp#docount(a:count, 's:move_to_adjacent_element', a:next, a:tail, a:top)
+        call sexp#docount(a:count, 'sexp#move_to_adjacent_element_terminal',
+            \ a:next, a:tail, a:top)
         let pos = getpos('.')
-        let nomove = s:compare_pos(cursor, pos) == 0
+        let nomove = sexp#compare_pos(cursor, pos) == 0
 
         " Bail out if the cursor has not moved and is resting on a delimiter
         if nomove && getline(pos[1])[pos[2] - 1] =~ s:delimiter
@@ -1965,7 +2068,7 @@ function! sexp#move_to_adjacent_element(mode, count, next, tail, top)
         "   * Moving forward to head but ending on tail because we are bounded
         "   * Same as above, but element is a single character so head == tail
         elseif a:tail
-            \ || (a:next && s:compare_pos(pos, sexp#current_element_terminal(0)) != 0)
+            \ || (a:next && sexp#compare_pos(pos, sexp#current_element_terminal(0)) != 0)
             \ || (a:next && nomove)
             " We make selections inclusive by entering visual mode
             call s:set_visual_marks([cursor, pos])
@@ -2074,7 +2177,7 @@ function! sexp#leaf_flow(mode, count, next, tail)
         " preparation for subsequent search (which may or may not be needed,
         " given that if far side is sought, this initial positioning may
         " actually count as jump).
-        let pos = s:move_to_current_element_terminal(a:next)
+        let pos = sexp#move_to_current_element_terminal(a:next)
         if pos[1]
             " We're on far side of non-list element. If far side is desired
             " target, and we weren't already on it, first jump is complete.
@@ -2104,7 +2207,7 @@ function! sexp#leaf_flow(mode, count, next, tail)
         if cnt > 1 || !near
             " Either we're going to search again or we're done searching but
             " target is far side: in either case, position on far side.
-            call s:move_to_current_element_terminal(a:next)
+            call sexp#move_to_current_element_terminal(a:next)
             let nf = 1
         else
             " Done searching and target is near side.
@@ -2269,7 +2372,8 @@ function! s:set_marks_around_current_list(mode, offset, allow_expansion)
     let visual = a:mode ==? 'v'
     let counting = s:countindex > 0
     let start_is_valid = start[1] > 0
-    let have_selection = start_is_valid && s:compare_pos(start, s:get_visual_end_mark()) != 0
+    let have_selection = start_is_valid
+        \ && sexp#compare_pos(start, s:get_visual_end_mark()) != 0
     let expanding = a:allow_expansion && (counting || (visual && have_selection))
 
     " When evaluating via sexp#docount the cursor position will not be updated
@@ -2317,7 +2421,7 @@ function! s:set_marks_around_current_list(mode, offset, allow_expansion)
 
     " Inner selection on adjacent brackets results in open being one character
     " past close due to offset calculations
-    if open[1] > 0 && close[1] > 0 && s:compare_pos(open, close) < 0
+    if open[1] > 0 && close[1] > 0 && sexp#compare_pos(open, close) < 0
         call s:set_visual_marks([open, close])
         let success = 1
     " Don't erase marks when in visual mode
@@ -2407,7 +2511,7 @@ function! s:nth_from(pos, n, tail)
             let cnt = a:n
             while cnt
                 " Land on near side of elements.
-                let p = s:move_to_adjacent_element(a:tail, !a:tail, 0, 1)
+                let p = sexp#move_to_adjacent_element_terminal(a:tail, !a:tail, 0, 1)
                 if !p[1]
                     " We've gone as far as we can go.
                     break
@@ -2470,7 +2574,7 @@ function! s:child_range(count, tail, inner, ...)
                 call s:setcursor(p)
                 while cnt
                     " Land on outside of elements.
-                    let p = s:move_to_adjacent_element(!a:tail, a:tail, 0, 1)
+                    let p = sexp#move_to_adjacent_element_terminal(!a:tail, a:tail, 0, 1)
                     if !p[1]
                         " We've gone as far as we can go.
                         break
@@ -2524,7 +2628,7 @@ function! s:get_sel_dir(mode)
         " Use relative position of '.' and 'v' marks to determine whether cursor is at end
         " of visual sel.
         " Design Decision: Single-char selection considered at 'at end'.
-        return s:compare_pos(getpos('.'), getpos('v')) >= 0
+        return sexp#compare_pos(getpos('.'), getpos('v')) >= 0
     finally
         if enter_visual
             call sexp#ensure_normal_mode()
@@ -2593,11 +2697,11 @@ function! s:set_marks_around_current_element(mode, inner, count, no_sel)
     " selected, this block is still needed to move starting search position to the next
     " element. Optimization would skip if super_range has been called *and* the selection
     " *isn't* pure whitespace.
-    let start = s:move_to_current_element_terminal(0)
+    let start = sexp#move_to_current_element_terminal(0)
     if !start[1]
         " We are on whitespace; check for next element
         let p = getpos('.')
-        let next = s:move_to_adjacent_element(1, 0, 0)
+        let next = sexp#move_to_adjacent_element_terminal(1, 0, 0)
         if next == p
             " No next element!
             if a:mode !=? 'v'
@@ -2616,20 +2720,20 @@ function! s:set_marks_around_current_element(mode, inner, count, no_sel)
     " cleanup logic.
     " Rationale: Input to terminals_with_whitespace.
     let leading = a:mode ==? 'v' ? vs_orig : save_cursor
-    if s:compare_pos(leading, start) >= 0
+    if sexp#compare_pos(leading, start) >= 0
         let leading = []
     endif
 
     " Position ourselves to look for (first) end, taking care to begin the search no
     " earlier than start, which could be *after* ve in certain corner cases.
-    call s:setcursor(a:mode ==? 'v' && s:compare_pos(ve, start) > 0 ? ve : start)
+    call s:setcursor(a:mode ==? 'v' && sexp#compare_pos(ve, start) > 0 ? ve : start)
 
     " Find first end, looking backwards if necessary.
     let end = sexp#current_element_terminal(1)
     if !end[1]
         " Weren't on an element. Get to end of previous (whose existence is implied by
         " existence of start).
-        let end = s:move_to_adjacent_element(0, 1, 0)
+        let end = sexp#move_to_adjacent_element_terminal(0, 1, 0)
     endif
     " At this point, end is on 'inner' end of the current (possibly partial) selection.
     " Subsequent logic handles cleanup and possibly expansion.
@@ -2643,7 +2747,7 @@ function! s:set_marks_around_current_element(mode, inner, count, no_sel)
         call s:setcursor(p)
         while cnt > 1
             let pp = p
-            let p = s:move_to_adjacent_element(dir, dir, 0)
+            let p = sexp#move_to_adjacent_element_terminal(dir, dir, 0)
             if p == pp
                 " We've gone as far as possible.
                 break
@@ -2679,10 +2783,10 @@ function! s:set_marks_around_adjacent_element(mode, next)
     " If moving backward, first position ourselves at the head of the current
     " element.
     if !a:next
-        call s:move_to_current_element_terminal(0)
+        call sexp#move_to_current_element_terminal(0)
     endif
 
-    call s:move_to_adjacent_element(a:next, 0, 0)
+    call sexp#move_to_adjacent_element_terminal(a:next, 0, 0)
     call s:set_marks_around_current_element('n', 1, 0, 0)
     call s:setcursor(cursor)
 endfunction
@@ -2716,7 +2820,7 @@ function! s:select_current_marks(mode, ...)
             " Jump to other side to see which side we're on.
             " TODO: Remove the keepjumps if I determine o can't affect jumplist.
             keepjumps normal! o
-            let cmp = s:compare_pos(getpos('.'), pos)
+            let cmp = sexp#compare_pos(getpos('.'), pos)
             if a:1 && cmp < 0 || !a:1 && cmp > 0
                 " We were already on the desired end.
                 keepjumps normal! o
@@ -2854,59 +2958,44 @@ function! s:insert_brackets_around_current_element(bra, ket, at_tail, headspace)
     call s:insert_brackets_around_visual_marks(a:bra, a:ket, a:at_tail, a:headspace)
 endfunction
 
-" Return true iff a put in indicated direction at specified location of the contents of
-" register indicated by v:register should be multiline.
-" Note: Decision is not final: a check for paste ending in comment
-" Note: Ignore multi-line nature of the register itself, considering only whether it
-" contains *internal* newlines.
-" -- Logic - adapted from clone --
-" * either register or target is multiline
-" * register ends with a comment
-"   TODO: Decide best way to determine: direct analysis with heuristics or paste then
-"   check, adjusting afterwards if necessary? I don't like embedding expression parser.
-" * target is a comment
-" * target is on a line by itself, possibly followed by a trailing comment
-" * target is the first or last element of a list whose open and close brackets are not
-"   colinear, and none of the target's sibling elements (ignoring any trailing comment)
-"   are colinear with target
-" * target is at toplevel
-function! s:is_multiline_put(loc, dir)
-    let reg = getreg(v:register)
-    let ml_reg = reg =~ '\S.\{-}\n.\{-}\S'
-
+" Simple pass-through to autoload function that puts the codestr in a temporary buffer for
+" parsing.
+function! s:analyze_codestr_legacy(codestr, filetype)
+    return sexp#parse#analyze_codestr(a:codestr, a:filetype)
 endfunction
 
-" TODO: Where to put this... Eventually, the legacy version will put the code in a hidden
-" buffer to have it parsed by legacy syntax engine.
-function! s:analyze_codestr_legacy(codestr, filetype)
+" Note: This version does everything manually, with no parsing.
+" It has been superseded by s:analyze_codestr_legacy(), which delegates the actual parsing
+" to sexp#parse#analyze_codestr(); however, I may allow it to be selected by expert (or
+" even hidden) option.
+function! s:analyze_codestr_simple(codestr, filetype)
     " Note: Processed text added later.
     " TODO: Some of these fields won't be set properly until we're creating a hidden
     " buffer in which to perform the analysis.
     let ret = {
-        \ 'err_count': 0, 'elem_count': 1, 'is_ml': 0, 'linewise': 0,
+        \ 'elem_count': 1,
+        \ 'is_ml': 0, 'linewise': 0,
         \ 'has_com': 0, 's_is_com': 0, 'e_is_com': 0,
         \ 'node_ranges': [],
-        \ 'error_ranges': [],
-        \ 'text': ''
+        \ 'err_loc': s:nullpos, 'err_hint': '',
+        \ 'text': '',
+        \ 'linewise': g:sexp_regput_untrimmed_is_linewise
+            \ ? a:codestr =~ '^\s\|\s$'
+            \ : a:codestr =~ '\n$'
     \ }
-    " TODO: This should really be handled by a parser to ensure we don't treat *ignored*
-    " whitespace at the end of the register as whitespace.
-    let ret.linewise = g:sexp_regput_untrimmed_is_linewise
-        \ ? ret.text =~ '^\s\|\s$' ? 1 : 0
-        \ : ret.text =~ '\n$' ? 1 : 0
-    let ret.s_is_com = codestr =~ '^\s*;'
-    let ret.e_is_com = codestr =~ ';.*$'
+    let ret.s_is_com = a:codestr =~ '^\s*;'
+    let ret.e_is_com = a:codestr =~ ';.*$'
     " TODO: Come up with less simple patterns that at least attempt to differentiate
     " between string and non-string context.
     " Flag indicating whether register is *only* a (potentially multi-line) comment.
-    let ret.has_com = codestr =~ ';'
+    let ret.has_com = a:codestr =~ ';'
     " TODO: Decide whether this should be single line only, given use case.
     " TODO: If this is not needed, remove!
-    let ret.is_com = codestr =~ '\(\_^\s*;.*\_$\)\+'
+    let ret.is_com = a:codestr =~ '\(\_^\s*;.*\_$\)\+'
     " Trim *all* whitespace at both ends since we're adding deterministic amount.
     " FIXME: Needs to account for possibility of escaped whitespace; have this done by
     " function that performs language-specific validation.
-    let ret.text = substitute(codestr, '^\_s\+\|\_s\+$', '', 'g')
+    let ret.text = substitute(a:codestr, '^\_s\+\|\_s\+$', '', 'g')
     " Design Decision: Stripped leading/trailing whitespace should not influence
     " multline test.
     " Caveat: Vim =~ operator treats rhs like a single line; thus, literal NL ("\n") (not
@@ -2918,14 +3007,64 @@ endfunction
 
 " Build and return a dict characterizing the text in the put register and canonicalize the
 " register contents. Use Treesitter if applicable, falling back to legacy syntax
-" highlighting.
+" highlighting, and even to simplistic regex-based parser if neither Treesitter nor legacy
+" syntax is usable. When deciding how to handle invalid lisp in register, consider
+" relevant user options, warning user if appropriate and throwing "sexp-abort" if we
+" cannot proceed.
+" Args: None (register and filetype determined from Vim var/option)
+" Return: A dict whose format can be found in the analyze_codestr() functions in both the
+" sexp#parse autoload and sexp.ts Lua modules.
+" Exceptions:
+"   sexp-abort:  register contents cannot be parsed as valid code and user options (and
+"                possibly user response to input()) prohibit proceeding with paste.
+"                buffer's 'filetype
+"   sexp-noop:   register is empty (or whitespace-only); no reason to continue with put
 function! s:regput__get_reginfo()
+    let ret = {}
     let regstr = getreg(v:register)
     if regstr =~ '^\s*$'
         " No-op!
-        return {}
+        throw "sexp-noop"
     endif
-    let ret = s:invoke('analyze_codestr', regstr, &ft)
+    if !g:sexp_regput_inhibit_regparse
+        let ret = s:invoke('analyze_codestr', regstr, &ft)
+    endif
+    if empty(ret)
+        " Either something went wrong or register parsing is inhibited by option.
+        " Assumption: The simpler fallback method will always return non-empty dict.
+        let ret = s:analyze_codestr_simple(regstr, &ft)
+    endif
+    if ret.err_loc[1]
+        " Register contents are not valid lisp. Decide how to handle...
+        " Assumption: Can't get here if g:sexp_regput_inhibit_regparse disables parsing.
+        let errmsg = printf("Error encountered at or near %s%s.",
+            \ string(ret.err_loc),
+            \ !empty(ret.err_hint) ? " (Hint: " . ret.err_hint . ")" : "" )
+        " Enumeration defined in help doc.
+        let action = g:sexp_regput_invalid_register_action
+        if action < 0
+            " Defer continue/abort decision to user.
+            let ans = ''
+            while ans !~? '^\v\s*%(y%[es]|n%[o])\s*$'
+                let ans = input("Warning: Register text does not appear to be valid lisp:\n"
+                    \ . errmsg
+                    \ . "\nPaste anyways? y(es)/n(o)")
+            endwhile
+            let proceed = ans =~ '^\s*y'
+        else
+            let proceed = action >= 1
+        endif
+        " Warn if action requires warning and we haven't already presented prompt to user.
+        if action == 0 || action == 1
+            " Display warning!
+            call sexp#warn#msg("Warning: Paste register contains invalid form(s): "
+                \ . errmsg)
+        endif
+        if !proceed
+            " Abort!
+            throw "sexp-abort"
+        endif
+    endif
     return ret
 endfunction
 
@@ -3018,11 +3157,11 @@ function! s:regput__get_context(tgt_info)
             if !ret.is_bra[i]
                 " Attempt to find outer adjacent.
                 call s:setcursor(ret.range[i])
-                let outer = s:nearest_element_terminal(i, !i, 1, 1)
+                let outer = sexp#nearest_element_terminal(i, !i, 1, 1)
                 if !outer[1]
                     " Pre-position on outside of element to ensure that if element is
                     " list, nearest_bracket doesn't find its match.
-                    call s:move_to_current_element_terminal(i)
+                    call sexp#move_to_current_element_terminal(i)
                     let outer = s:nearest_bracket(i)
                     if outer[1]
                         let outer_is_bra = 1
@@ -3067,7 +3206,7 @@ function! s:regput__check_list_context(ctx, reg)
         " Add start of range element to list of ranges.
         call add(ps, [sexp#current_element_terminal(0), ctx.range[0]])
         while sidx <= 2
-            let prev_e = s:move_to_adjacent_element(0, 1, 0, 1)
+            let prev_e = sexp#move_to_adjacent_element_terminal(0, 1, 0, 1)
             if prev_e[1]
                 call add(ps, [sexp#current_element_terminal(0), prev_e])
                 let sidx += 1
@@ -3090,7 +3229,7 @@ function! s:regput__check_list_context(ctx, reg)
         call s:setcursor(ctx.range[1])
         call add(ps, [ctx.range[1], sexp#current_element_terminal(1)])
         while eidx < 3
-            let next_s = s:move_to_adjacent_element(1, 0, 0, 1)
+            let next_s = sexp#move_to_adjacent_element_terminal(1, 0, 0, 1)
             if next_s[1]
                 call add(ps, [next_s, sexp#current_element_terminal(1)])
                 let eidx += 1
@@ -3152,10 +3291,7 @@ function! s:regput__get_seps(ctx, reg)
     let [ctx, reg] = [a:ctx, a:reg]
     let tail = ctx.tail
     let ret = [s:NL, s:NL, s:NL, '']
-    if g:sexp_regput_linewise_forces_multiline && reg.linewise
-        " Force multi-line due to linewise register.
-        return ret
-    endif
+    let force_ml = g:sexp_regput_linewise_forces_multiline && reg.linewise
     " Determine whether put is into one of the special slots in a 'shaped' list.
     " Note: Inhibit this special case logic if more than one toplevel element in register.
     " Rationale: For the special logic to be meaningful in the multiple toplevel element
@@ -3165,8 +3301,6 @@ function! s:regput__get_seps(ctx, reg)
     let lpi = g:sexp_regput_ignore_list_shape
         \ || reg.elem_count > 1 || ctx.empty_buffer || ctx.empty_list
         \ ? 0 : s:regput__check_list_context(ctx, reg)
-    " TODO: Make global option for this?
-    let g:append_sl_comment = get(g:, 'append_sl_comment', 1)
     " Override the NL separators as needed.
     if ctx.empty_buffer
         let ret[0:1] = [s:EMPTY, s:EMPTY]
@@ -3185,15 +3319,15 @@ function! s:regput__get_seps(ctx, reg)
             if lpi == 2
                 " Slot 2 needs a leading SPC and a trailing NL (the latter of which is
                 " requested implicitly by clearing this flag).
-                let want_spc = !i
+                let want_spc = !force_ml && !i
             elseif lpi == 3 && !i
                 " Slot 3 needs a NL at the leading side. The !i guard condition ensures
-                " that normal logic will apply to trailing side.
+                " that normal (else) logic will apply to trailing side.
                 let want_spc = 0
             else
                 " TODO: Decide on elem_count criterion.
-                let want_spc =
-                    \ ctx.is_ele[i] && !ctx.alone[i] && !ctx.force_nl[i]
+                let want_spc = !force_ml
+                    \ && ctx.is_ele[i] && !ctx.alone[i] && !ctx.force_nl[i]
                     \ && !reg.is_ml && reg.elem_count <= 1
                     \ && (tail != -1 && (i != tail || ctx.colinear[i]))
             endif
@@ -3222,7 +3356,7 @@ function! s:regput__get_seps(ctx, reg)
                 " disturbance; however, if NL sep has been requested on a side whose range
                 " endpoint is currently colinear with its nearest innner_range endpoint,
                 " we need to leave the NL request intact to ensure separation.
-                if ret[i] != s:NL || ctx.range[i] != ctx.inner_range[i]
+                if ret[i] != s:NL || ctx.range[i][1] != ctx.inner_range[i][1]
                     let ret[i] = s:EMPTY
                 endif
             endif
@@ -3277,7 +3411,7 @@ function! s:last_colinear_sibling(tail)
     try
         " At loop termination, pos will be the position we're seeking.
         while 1
-            let next = s:move_to_adjacent_element(a:tail, a:tail, 0, 1)
+            let next = sexp#move_to_adjacent_element_terminal(a:tail, a:tail, 0, 1)
             if !next[1]
                 " No more elements. Check for enclosing bracket in desired direction.
                 let brkt = s:nearest_bracket(a:tail)
@@ -3288,7 +3422,7 @@ function! s:last_colinear_sibling(tail)
                     break
                 endif
                 " Move to other end and continue.
-                let next = s:move_to_current_element_terminal(a:tail)
+                let next = sexp#move_to_current_element_terminal(a:tail)
             endif
             let pos = next
         endwhile
@@ -3401,7 +3535,9 @@ function! s:regput__postop(ctx, sep, orig_range)
     let idx = !!g:sexp_regput_curpos
     if g:sexp_regput_curpos == idx
         " Desired position is 0 (head) or 1 (tail).
-        let ret.curpos = ret.orange[idx]
+        " Caveat: Copy the position to prevent double-adjustment if caller adds both these
+        " positions to an auto-adjustment list.
+        let ret.curpos = ret.orange[idx][:]
     endif
     " If necessary, adjust end of re-indent range.
     " Assumption: Indent logic always looks back to non-empty line preceding start, so
@@ -3427,46 +3563,56 @@ endfunction
 " Perform register put for all 4 command types (put, put_child, replace, replace_child)
 " and afterwards, visual mode restoration and option-dependent cursor repositioning.
 function! s:regput__impl(tgt, count)
-    let curpos = getpos('.')
-    " Calculate the put.
-    let reg = s:regput__get_reginfo()
-    if empty(reg) || empty(reg.text)
-        " Treat empty text like NOOP!
-        return
-    endif
-    let ctx = s:regput__get_context(a:tgt)
-    let sep = s:regput__get_seps(ctx, reg)
-    let spl = s:regput__get_splice_info(a:count, ctx, reg, sep, {})
-    " TODO: Consider having put__get_context() build the position list.
-    let ps = s:concat_positions(ctx.curpos, ctx.vrange, ctx.range)
-    " Re-indent logic will need the original (unadjusted) range.
-    " TODO: Consider having both ranges be part of context dict: e.g., range and arange
-    let orig_range = deepcopy(ctx.range)
-    " Note: Set 'failsafe override' for put modes that can change non-ws.
-    let repl_text = s:yankdel_range(spl.range[0], spl.range[1], spl.text, spl.inc, ps,
-        \ ctx.put_mode =~ 'replace')
-    " If not inhibited, update unnamed register.
-    " TODO: Consider integrating this into yankdel_range(), which, in its current form,
-    " *never* updates unnamed register (since it's been used exclusively for things that
-    " shouldn't update any registers).
-    if a:tgt.put_mode =~ 'replace' && !a:tgt.P
-        let @" = repl_text
-    endif
-    " Calculate reindent range and final curpos.
-    let d = s:regput__postop(ctx, sep, orig_range)
-    " Perform re-indent with newly-calculated positions added to adjustment list.
-    call s:post_op_reindent(d.irange[0], d.irange[1], [ps, d.curpos, d.orange])
-    if ctx.mode ==? 'v'
-        " Design Decision: Original selection may have been partial; set marks to
-        " encompass operated-on range, excluding any surrounding whitespace.
-        call s:set_visual_marks(d.orange)
-    else
-        " Restore original (but adjusted) visual marks and set post-op cursor position.
-        call s:set_visual_marks(ctx.vrange)
-    endif
-    " Since visual mode commands end in normal mode, we can always respect
-    " option-configurable desired curpos.
-    call s:setcursor(d.curpos)
+    try
+        " Analyze the register.
+        " Note: This function can throw sexp-abort and sexp-noop; in the case of
+        " sexp-abort, its responsible for any associated warnings to user.
+        let reg = s:regput__get_reginfo()
+        let ctx = s:regput__get_context(a:tgt)
+        let sep = s:regput__get_seps(ctx, reg)
+        let spl = s:regput__get_splice_info(a:count, ctx, reg, sep, {})
+        " TODO: Consider having put__get_context() build the position list.
+        let ps = s:concat_positions(a:tgt.curpos, ctx.curpos, ctx.vrange, ctx.range)
+        " Re-indent logic will need the original (unadjusted) range.
+        " TODO: Consider having both ranges be part of context dict: e.g., range and
+        " arange
+        let orig_range = deepcopy(ctx.range)
+        " Note: Set 'failsafe override' for put modes that can change non-ws.
+        let repl_text = s:yankdel_range(spl.range[0], spl.range[1], spl.text, spl.inc, ps,
+            \ ctx.put_mode =~ 'replace')
+        " If not inhibited, update unnamed register.
+        " TODO: Consider integrating this into yankdel_range(), which, in its current
+        " form, *never* updates unnamed register (since it's been used exclusively for
+        " things that shouldn't update any registers).
+        if a:tgt.put_mode =~ 'replace' && !a:tgt.P
+            let @" = repl_text
+        endif
+        " Calculate reindent range and final curpos.
+        let d = s:regput__postop(ctx, sep, orig_range)
+        " Perform re-indent with newly-calculated positions added to adjustment list.
+        call s:post_op_reindent(d.irange[0], d.irange[1], [ps, d.curpos, d.orange])
+        if ctx.mode ==? 'v'
+            " Design Decision: Original selection may have been partial; set marks to
+            " encompass operated-on range, excluding any surrounding whitespace.
+            call s:set_visual_marks(d.orange)
+        else
+            " Restore original (but adjusted) visual marks and set post-op cursor
+            " position.
+            call s:set_visual_marks(ctx.vrange)
+        endif
+        " Since visual mode commands end in normal mode, we can always respect
+        " option-configurable desired curpos.
+        call s:setcursor(d.curpos)
+    catch
+        " Don't warn about sexp-{abort,noop}, which are expected.
+        if v:exception !~ 'sexp-\%(abort\|noop\)'
+            call sexp#warn#msg(printf("regput__impl: Unexpected error '%s' at '%s'",
+                \ v:exception, v:throwpoint))
+        endif
+        " Restore pre-op curpos.
+        " Note: We use the adjusted curpos in tgt since there's no guarantee ctx exists.
+        call s:setcursor(a:tgt.curpos)
+    endtry
 endfunction
 
 " Calculate and return the tgt_info dict needed by s:regput__get_context() for a 'put'
@@ -3513,12 +3659,12 @@ function! s:put__get_tgt(count, tail)
         " First, attempt to get natural target: i.e., side of *current* element in
         " direction of put. If no such element, special logic will determine a 'virtual'
         " target.
-        let ret.range[!a:tail] = s:move_to_current_element_terminal(a:tail)
+        let ret.range[!a:tail] = sexp#move_to_current_element_terminal(a:tail)
         let no_current = !ret.range[!a:tail][1]
         " Attempt to set both ends of range.
         for i in range(2)
             if !ret.range[i][1]
-                let ret.range[i] = s:move_to_adjacent_element(i, !i, 0, 1)
+                let ret.range[i] = sexp#move_to_adjacent_element_terminal(i, !i, 0, 1)
                 if ret.range[i][1]
                     let ret.is_ele[i] = 1
                 else
@@ -3602,9 +3748,9 @@ endfunction
 
 function! sexp#put(count, tail)
     if !s:regput__handle_as_put_child_maybe(a:count, a:tail)
-        let count = a:count ? a:count : 1
-        let tgt = s:put__get_tgt(count, a:tail)
-        call s:regput__impl(tgt, count)
+        let cnt = a:count ? a:count : 1
+        let tgt = s:put__get_tgt(cnt, a:tail)
+        call s:regput__impl(tgt, cnt)
     endif
 endfunction
 
@@ -3615,7 +3761,7 @@ function! s:replace__get_tgt_visual(count, tgt)
         let [vs, ve] = s:get_visual_marks()
         let [s, e] = s:super_range(vs, ve)
         " Preceding call to s:super_range() obviates need for ignored region checking.
-        if !s:range_has_non_ws(s, e, 0)
+        if !sexp#range_has_non_ws(s, e, 0)
             " Nothing to replace.
             " Design Decision Needed: Should we a) throw and warn user or b) convert to
             " normal put. (And if (b), should we try to ensure the put is non-directional,
@@ -3677,7 +3823,7 @@ function! s:replace_mode__get_tgt(put_mode, mode, count, tail, P)
         " Determine the range that *contains* inner_range.
         for i in range(2)
             call s:setcursor(ret.inner_range[i])
-            let p = s:nearest_element_terminal(i, !i, 1, 1)
+            let p = sexp#nearest_element_terminal(i, !i, 1, 1)
             if p[1]
                 let ret.is_ele[i] = 1
             else
@@ -3702,11 +3848,11 @@ endfunction
 " register is updated.
 function! sexp#replace(mode, count, P)
     try
-        let count = a:count ? a:count : 1
+        let cnt = a:count ? a:count : 1
         " Target determination is mode-specific.
-        let tgt = s:replace_mode__get_tgt('replace', a:mode, count, -1, a:P)
+        let tgt = s:replace_mode__get_tgt('replace', a:mode, cnt, -1, a:P)
         " Design Decision: Let tail==1 represent put with P.
-        call s:regput__impl(tgt, count)
+        call s:regput__impl(tgt, cnt)
     catch /sexp-warning:/
         call sexp#warn#msg(v:exception)
     catch
@@ -3770,7 +3916,7 @@ function! s:put_child__get_tgt(count, tail)
                     " Position on outside of element and look for adjacent, with fallback
                     " to bracket.
                     call s:setcursor(r[!a:tail])
-                    let r[a:tail] = s:nearest_element_terminal(a:tail, !a:tail)
+                    let r[a:tail] = sexp#nearest_element_terminal(a:tail, !a:tail)
                     if !r[a:tail][1]
                         " No adjacent; use bracket.
                         let r[a:tail] = li.brackets[a:tail]
@@ -3800,16 +3946,16 @@ function! s:put_child__get_tgt(count, tail)
 endfunction
 
 function! sexp#put_child(count, tail)
-    let count = a:count ? a:count : 1
-    let tgt = s:put_child__get_tgt(count, a:tail)
+    let cnt = a:count ? a:count : 1
+    let tgt = s:put_child__get_tgt(cnt, a:tail)
     " Note: [count] is used only for child location, so hardcode to 1.
     call s:regput__impl(tgt, 1)
 endfunction
 
 function! sexp#replace_child(count, tail, P)
     try
-        let count = a:count ? a:count : 1
-        let tgt = s:replace_mode__get_tgt('replace_child', 'n', count, a:tail, a:P)
+        let cnt = a:count ? a:count : 1
+        let tgt = s:replace_mode__get_tgt('replace_child', 'n', cnt, a:tail, a:P)
         " Note: [count] is used only for child location, so hardcode to 1.
         call s:regput__impl(tgt, 1)
     catch /sexp-warning:/
@@ -3842,7 +3988,7 @@ function! s:swap_current_selection(mode, next, pairwise)
     if a:pairwise && s:can_set_visual_marks
         let mark = a:next ? "'>" : "'<"
         call s:setcursor(getpos(mark))
-        call setpos(mark, s:nearest_element_terminal(a:next, a:next))
+        call setpos(mark, sexp#nearest_element_terminal(a:next, a:next))
         call s:set_visual_marks(s:positions_with_element_terminals(s:get_visual_marks()))
     endif
     call s:select_current_marks(a:mode)
@@ -3852,7 +3998,7 @@ function! s:swap_current_selection(mode, next, pairwise)
     " Abort if we are already at the head or tail of the current list or at
     " the top or bottom of the file. In these cases the start/end mark will be
     " the same in the direction of movement.
-    if s:compare_pos(amarks[a:next], bmarks[a:next]) == 0
+    if sexp#compare_pos(amarks[a:next], bmarks[a:next]) == 0
         let [@a, @b] = reg_save
         return 0
     endif
@@ -3928,8 +4074,8 @@ function! s:yankdel_range__preadjust_range_start(start, inc)
         let ret[2] += eidx
     elseif !a:inc " normal-exclusive
         " Move to next position, including newline.
-        " Assumption: s:offset_char can handle s:BOF.
-        let ret = s:offset_char(ret, 1, 1)
+        " Assumption: sexp#offset_char can handle s:BOF.
+        let ret = sexp#offset_char(ret, 1, 1)
     endif
     return ret
 endfunction
@@ -3970,7 +4116,7 @@ function! s:yankdel_range__preadjust_range_end(end, inc)
         endif
     elseif !a:inc " normal-exclusive
         " Move to prev position, including newline.
-        let ret = s:offset_char(ret, 0, 1)
+        let ret = sexp#offset_char(ret, 0, 1)
     endif
     return ret
 endfunction
@@ -3989,7 +4135,7 @@ endfunction
 "   errmsg:    error description iff err == 1, else ""
 " Args: See descriptions in s:yankdel_range() header comment.
 function! s:yankdel_range__preadjust_range(start, end, del_or_spl, inc)
-    if s:compare_pos(a:start, a:end) > 0
+    if sexp#compare_pos(a:start, a:end) > 0
         " Shouldn't happen! How to handle? Internal error?
         " 'err' flag with msg?
         return {'err': 1, 'errmsg': 'Invalid (reversed) range'}
@@ -4015,7 +4161,7 @@ function! s:yankdel_range__preadjust_range(start, end, del_or_spl, inc)
         \ 'err': 0, 'errmsg': ''
     \ }
     " Is adjusted (inclusive) range empty?
-    if s:compare_pos(start, end) > 0
+    if sexp#compare_pos(start, end) > 0
         " Adjusted start/end are reversed, yielding empty target region.
         " Treat *non-empty* splice as a directed put, everything else as NO-OP.
         if ret.cmd != 's' || len(ret.text) == 0
@@ -4107,7 +4253,7 @@ function! s:yankdel_range__preadjust_positions(op, ps)
         " Assumption: We have a non-empty range.
         " Note: Use position *past* end to account for bytes in final char of range.
         let ret.delta -=
-            \ (s:pos2byte(s:offset_char(a:op.end, 1, 1)) - s:pos2byte(a:op.start))
+            \ (s:pos2byte(sexp#offset_char(a:op.end, 1, 1)) - s:pos2byte(a:op.start))
     endif
     " Calculate and store offsets of positions of interest wrt start of range.
     for p in a:ps
@@ -4139,7 +4285,7 @@ function! s:yankdel_range__postadjust_positions(adj)
         let e_off = a:adj.end_off
         let e_off_adj = e_off + delta
         let e_adj = s:byte2pos(anchor_byte + e_off_adj)
-        if s:compare_pos(anchor, e_adj) > 0
+        if sexp#compare_pos(anchor, e_adj) > 0
             " Ensure that if range is completely deleted (either with empty splice or
             " delete), positions don't fall backwards past the original start, but forward
             " to first char of non-deleted text.
@@ -4173,7 +4319,7 @@ function! s:yankdel_range__postadjust_positions(adj)
             " references.
             if op.cmd !=? 'p' && o <= e_off
                 " Case 1 or 2
-                if s:compare_pos(p, e_adj) >= 0
+                if sexp#compare_pos(p, e_adj) >= 0
                     " Case 2: Don't allow position to escape from adjusted range.
                     let [p[1], p[2]] = e_adj[1:2]
                 else
@@ -4256,8 +4402,10 @@ function! s:yankdel_range(start, end, del_or_spl, ...)
         endif
         " See header comment on failsafe mechanism.
         " Note: Failsafe doesn't apply to a directed put.
-        if !failsafe_override && op.cmd =~# '[ds]' && s:range_has_non_ws(op.start, op.end, 1)
-            call sexp#warn#msg("yankdel_range: Internal error detected: refusing to modify non-whitespace!")
+        if !failsafe_override && op.cmd =~# '[ds]'
+            \ && sexp#range_has_non_ws(op.start, op.end, 1)
+            call sexp#warn#msg("yankdel_range: Internal error detected:"
+                \ . " refusing to modify non-whitespace!")
             return
         endif
         " Perform splice, directed put, delete or yank.
@@ -4303,6 +4451,14 @@ function! s:yankdel_range(start, end, del_or_spl, ...)
             "   [pP]: directed put from cursor pos
             "   s: splice over visual selection (implemented with visual `p').
             silent! exe 'normal! "a' . (op.cmd ==# 'P' ? 'P' : 'p')
+            if @a =~ '^\n'
+                " Vim Idiosyncrasy Workaround: If the head of the put text is newline, Vim
+                " sets '[ to whatever precedes the newline, but we want it to be the
+                " newline itself.
+                " Assumption: Upstream has set ve=onemore.
+                call s:setcursor(sexp#offset_char(getpos("'["), 1, 1))
+                normal! m[
+            endif
             if linewise
                 " Delete the space we appended to inhibit linewise put.
                 " Save [ and ] marks for restoration after space deletion.
@@ -4505,7 +4661,7 @@ endfunction
 " current logic, it will be. For one thing, the calling logic has most likely already
 " stripped off trailing whitespace, with the result that the last character on the line
 " will be part of the comment. But even if it hasn't, this function performs the
-" s:is_comment() test on the final *non-ws* char of the line, not the final char of the
+" sexp#is_comment() test on the final *non-ws* char of the line, not the final char of the
 " line.
 function! s:aligncom__characterize(line)
     " Note: It's not an eol comment if there's nothing before it.
@@ -4525,7 +4681,7 @@ function! s:aligncom__characterize(line)
     let [eff_linelen, comlen] = [0, 0]
     " Figure out which type of comment (if any) we have.
     let [is_eol_com, prev_e, com_s] = [0, s:nullpos, s:nullpos]
-    let is_com = s:is_comment(a:line, c)
+    let is_com = sexp#is_comment(a:line, c)
     if is_com
         " Find start of comment.
         let com_s = s:current_comment_terminal(0)
@@ -5501,10 +5657,10 @@ function! s:adjust_positions(start, end, splice, delta, ps)
     let [s, e] = [a:start[:], a:end[:]]
 
     for p in a:ps
-        if s:compare_pos(p, s) <= 0
+        if sexp#compare_pos(p, s) <= 0
             " Position unaffected
             continue
-        elseif s:compare_pos(p, e) < 0
+        elseif sexp#compare_pos(p, e) < 0
             " Inside deleted/replaced region.
             if a:splice
                 " Original line/col has no meaning. Move to head.
@@ -5562,7 +5718,7 @@ function! s:list_info(tail, ...)
         " Assumption: We're on test position.
         " Move to its head, which is a safe place from which to search for containing open
         " bracket if necessary.
-        let p = s:move_to_current_element_terminal(0)
+        let p = sexp#move_to_current_element_terminal(0)
         let isl = p[1] ? s:is_list(p[1], p[2]) : 0
         if !isl || inner_only
             " Either not on list structure, or we are, but want its parent list.
@@ -5570,7 +5726,7 @@ function! s:list_info(tail, ...)
             let pb = s:move_to_nearest_bracket(0)
             if pb[1]
                 " Found parent open, but we need to know if there are macro chars.
-                let p = s:move_to_current_element_terminal(0)
+                let p = sexp#move_to_current_element_terminal(0)
                 if p != pb
                     " Must be macro chars.
                     let ret.macro = p
@@ -5696,16 +5852,16 @@ function! s:cleanup_ws(start, ps, ...)
         let next = sexp#current_element_terminal(0)
         if !next[1]
             " Not in element.
-            let next = s:nearest_element_terminal(1, 0)
+            let next = sexp#nearest_element_terminal(1, 0)
             " Note: nearest_element_terminal returns current pos on failure.
-            if !s:compare_pos(next, getpos("."))
+            if !sexp#compare_pos(next, getpos("."))
                 " No element on or after start. Null next so that close will
                 " be set in loop...
                 let next = [0, 0, 0, 0]
             endif
         endif
-        let prev = s:nearest_element_terminal(0, 1)
-        if !s:compare_pos(prev, getpos("."))
+        let prev = sexp#nearest_element_terminal(0, 1)
+        if !sexp#compare_pos(prev, getpos("."))
             " no previous element
             let prev = [0, 0, 0, 0]
         endif
@@ -5750,8 +5906,8 @@ function! s:cleanup_ws(start, ps, ...)
         " Do we want to remove *all* whitespace between eff_prev and eff_next?
         let full_join =
                 \ !next[1] && !prev[1]
-                \ || !next[1] && (!close[1] || !s:is_comment(prev[1], prev[2]))
-                \ || !prev[1] && (!open[1] || !s:is_comment(next[1], next[2]))
+                \ || !next[1] && (!close[1] || !sexp#is_comment(prev[1], prev[2]))
+                \ || !prev[1] && (!open[1] || !sexp#is_comment(next[1], next[2]))
 
         " Note: A single call to yankdel_range with 'splice' arg will be used to perform
         " any required whitespace contraction: calculate the 'splice' arg, which can be
@@ -5772,7 +5928,7 @@ function! s:cleanup_ws(start, ps, ...)
                 " * (else) trailing whitespace on prev line (remove trailing ws)
                 " Note: Treating negative 'keep_empty_lines' as infinity ensures removal
                 " of non-NL whitespace at EOL.
-                let precedes_com = next[1] && s:is_comment(next[1], next[2])
+                let precedes_com = next[1] && sexp#is_comment(next[1], next[2])
                 if gap > g:sexp_cleanup_keep_empty_lines + 1
                     \ || getline(eff_prev[1])[eff_prev[2] - 1:] =~ '.\s\+$'
                     " Replace gap with number of newlines determined by existing line gap
@@ -5795,7 +5951,7 @@ function! s:cleanup_ws(start, ps, ...)
             " of line, but perhaps it shouldn't be allowed to move to next line.
             elseif g:sexp_cleanup_collapse_whitespace
                 \ && getline(eff_prev[1])[eff_prev[2] - 1 : eff_next[2] - 1] =~ '.\s\s'
-                \ && next[1] && !s:is_comment(next[1], next[2])
+                \ && next[1] && !sexp#is_comment(next[1], next[2])
                 " Replace multiple whitespace on single line with single space.
                 " Assumption: BOF and EOF are always handled as full join
                 let spl = ' '
@@ -5805,7 +5961,7 @@ function! s:cleanup_ws(start, ps, ...)
             " Prevent pointless calls to s:yankdel_range (when there's no
             " whitespace to contract).
             if !(bof && eff_next[1:2] == [1, 1] ||
-                \ !bof && s:offset_char(eff_prev, 1) == eff_next)
+                \ !bof && sexp#offset_char(eff_prev, 1) == eff_next)
                 " Perform the indicated whitespace contraction.
                 " Argument Notes:
                 " *Normally, range to be spliced is exclusive, but cleaning
@@ -5838,14 +5994,14 @@ function! s:cleanup_ws(start, ps, ...)
             call s:setcursor(next)
         endif
         " Now that we've recursed (if possible), attempt to advance.
-        let prev = s:move_to_current_element_terminal(1)
-        let next = s:nearest_element_terminal(1, 0)
+        let prev = sexp#move_to_current_element_terminal(1)
+        let next = sexp#nearest_element_terminal(1, 0)
         if next == prev
             " No more elements at current level.
             " Note: Null next to ensure attempt to find close on next and
             " final iteration of this recursion.
             let next = [0, 0, 0, 0]
-        elseif end[1] && s:compare_pos(next, end) > 0
+        elseif end[1] && sexp#compare_pos(next, end) > 0
             " Next element is past range. Go through once more to clean up
             " after final element.
             let done = 1
@@ -6005,7 +6161,7 @@ fu! sexp#convolute(count, ...)
             " as good a point as any.
             " Rationale: Emacs is extremely literal about the dividing point,
             " using cursor pos even in middle of an element!
-            let pos = s:nearest_element_terminal(1, 0)
+            let pos = sexp#nearest_element_terminal(1, 0)
         endif
     endif
     " Record distance from dividing point to end of line to facilitate
@@ -6084,7 +6240,7 @@ function! s:get_clone_target_range(mode, after, list)
                 " Make sure we're on or in the found list.
                 " Rationale: select_current_list can find list after cursor,
                 " and we're not interested in those.
-                if s:compare_pos(cursor, vs) >= 0 && s:compare_pos(cursor, ve) <= 0
+                if sexp#compare_pos(cursor, vs) >= 0 && sexp#compare_pos(cursor, ve) <= 0
                     return [vs, ve]
                 endif
             endif
@@ -6100,7 +6256,7 @@ function! s:get_clone_target_range(mode, after, list)
                 let p = getpos('.')
                 " Not on an element. Find adjacent (if one exists in applicable
                 " direction).
-                call s:move_to_adjacent_element(1, 0, 0)
+                call sexp#move_to_adjacent_element_terminal(1, 0, 0)
                 let found = p != getpos('.')
             endif
             return found
@@ -6157,7 +6313,7 @@ function! s:get_clone_context(start, end, flags)
     let bol = s:at_bol(a:start[1], a:start[2])
     let eol = s:at_eol(a:end[1], a:end[2])
     call s:setcursor(a:end)
-    let next = s:nearest_element_terminal(1, 0)
+    let next = sexp#nearest_element_terminal(1, 0)
     " Is there a next sibling?
     let last = a:end == next
     if !last && next[1] == a:end[1]
@@ -6187,7 +6343,7 @@ function! s:get_clone_context(start, end, flags)
         else
             " Check the condition involving targets that are first/last element of list.
             call s:setcursor(a:start)
-            let prev = s:nearest_element_terminal(0, 1)
+            let prev = sexp#nearest_element_terminal(0, 1)
             " Is there a prev sibling?
             let first = a:start == prev
             " Check multi-line conditions.
@@ -6224,7 +6380,7 @@ function! sexp#clone(mode, count, list, after, force_sl_or_ml)
     endif
     " Design Decision: If cursor starts in whitespace before target, move it
     " to head of target to ensure that cursor always stays with target.
-    if s:compare_pos(cursor, start) < 0
+    if sexp#compare_pos(cursor, start) < 0
         let cursor = start[:]
     endif
     " Assumption: Prior logic guarantees start and end at same level.
@@ -6376,10 +6532,12 @@ endfunction
 " update the state dict.
 function! sexp#stackop__update(state, result, mode, last, capture)
     if has_key(a:result, 'range')
-        if !a:state.range[0][1] || s:compare_pos(a:result.range[0], a:state.range[0]) < 0
+        if !a:state.range[0][1]
+            \ || sexp#compare_pos(a:result.range[0], a:state.range[0]) < 0
             let a:state.range[0] = a:result.range[0]
         endif
-        if !a:state.range[1][1] || s:compare_pos(a:result.range[1], a:state.range[1]) > 0
+        if !a:state.range[1][1]
+            \ || sexp#compare_pos(a:result.range[1], a:state.range[1]) > 0
             let a:state.range[1] = a:result.range[1]
         endif
     endif
@@ -6392,7 +6550,7 @@ function! sexp#stackop__update(state, result, mode, last, capture)
     " Cursor modification logic
     if !a:capture && g:sexp_emitting_bracket_is_sticky
         " Don't let cursor be emitted by list.
-        if s:compare_pos(a:result.vmarks[a:last], a:state.curpos) == (a:last ? -1 : 1)
+        if sexp#compare_pos(a:result.vmarks[a:last], a:state.curpos) == (a:last ? -1 : 1)
             " Pull cursor inward to list boundary before next iteration.
             let a:state.curpos = a:result.vmarks[a:last]
         endif
@@ -6424,8 +6582,8 @@ function! sexp#stackop__final(ex, state, mode, last, capture)
                 call s:setcursor(s)
                 let p = sexp#current_element_terminal(0)
                 " Note: nearest_element_terminal() returns current el terminal if no adjacent.
-                let s = s:nearest_element_terminal(0, 0)
-                if !s:compare_pos(p, s)
+                let s = sexp#nearest_element_terminal(0, 0)
+                if !sexp#compare_pos(p, s)
                     " No preceding sibling; re-indent parent (if it exists).
                     let p = s:move_to_nearest_bracket(0)
                     if p[1]
@@ -6494,18 +6652,19 @@ function! s:stackop_capture(last, spos, bpos, ps)
     while 1
         let prevpos = nextpos
         " Move to outside edge of adjacent element.
-        let nextpos = s:move_to_adjacent_element(a:last, a:last, 0)
+        let nextpos = sexp#move_to_adjacent_element_terminal(a:last, a:last, 0)
         " Make sure the call above actually moved us to a different element.
-        " Note: s:move_to_adjacent_element() returns terminal position of *current* element
-        " if no next element exists, and we started on the outside edge of an element
-        " (i.e., the terminal position we'll end up on when there's no adjacent element).
-        " Assumption: s:move_to_adjacent_element() will not return nullpos unless a:top is
-        " set.
-        if s:compare_pos(prevpos, nextpos) == 0
+        " Note: sexp#move_to_adjacent_element_terminal() returns terminal position of
+        " *current* element if no next element exists, and we started on the outside edge
+        " of an element (i.e., the terminal position we'll end up on when there's no
+        " adjacent element).
+        " Assumption: sexp#move_to_adjacent_element_terminal() will not return nullpos
+        " unless a:top is set.
+        if sexp#compare_pos(prevpos, nextpos) == 0
             " Nothing to capture
             return {}
         endif
-        if !s:is_comment(nextpos[1], nextpos[2])
+        if !sexp#is_comment(nextpos[1], nextpos[2])
             " Found a capturable (non-comment) element.
             break
         endif
@@ -6552,7 +6711,7 @@ function! s:stackop_emit(last, spos, bpos, ps)
     if l < 1 | return {} | endif
     let nextpos = [0, l, c, 0]
     " Make sure findpos didn't find other bracket pos.
-    if !s:compare_pos(opp_bpos, nextpos)
+    if !sexp#compare_pos(opp_bpos, nextpos)
         " List is empty. Nothing to emit. Let caller decide how to handle.
         return {}
     endif
@@ -6568,11 +6727,11 @@ function! s:stackop_emit(last, spos, bpos, ps)
     while 1
         let prevpos = nextpos
         " Move to outside edge of adjacent element.
-        let nextpos = s:move_to_adjacent_element(!a:last, a:last, 0)
+        let nextpos = sexp#move_to_adjacent_element_terminal(!a:last, a:last, 0)
         " Make sure we actually moved to a new element.
-        " Rationale: s:move_to_adjacent_element() will not return nullpos unless a:top is
-        " set.
-        if s:compare_pos(sexp#current_element_terminal(a:last), prevpos) == 0
+        " Rationale: sexp#move_to_adjacent_element_terminal() will not return nullpos
+        " unless a:top is set.
+        if sexp#compare_pos(sexp#current_element_terminal(a:last), prevpos) == 0
             " Final element being emitted; let bracket serve as "terminal".
             let nextpos = opp_bpos
             " Special Case: If no whitespace adjacent to opposite bracket, we need to
@@ -6583,7 +6742,7 @@ function! s:stackop_emit(last, spos, bpos, ps)
             endif
             break
         endif
-        if !s:is_comment(nextpos[1], nextpos[2])
+        if !sexp#is_comment(nextpos[1], nextpos[2])
             " Found non-comment element that can serve as terminal.
             break
         endif
@@ -6640,7 +6799,7 @@ function! sexp#stackop(state, mode, last, capture)
     let char = getline(cursorline)[cursorcol - 1]
 
     " Move to element tail first so we can skip leading macro chars
-    let pos = s:move_to_current_element_terminal(1)
+    let pos = sexp#move_to_current_element_terminal(1)
 
     " Move to closing bracket unless we are on one
     if !(pos[1] > 0 && getline(pos[1])[pos[2] - 1] =~# s:closing_bracket)
@@ -6654,7 +6813,7 @@ function! sexp#stackop(state, mode, last, capture)
         let bpos = pos
     else
         let bpos = s:move_to_nearest_bracket(0)
-        let pos = s:move_to_current_element_terminal(0)
+        let pos = sexp#move_to_current_element_terminal(0)
     endif
 
     " Is cursor *on* bracket performing capture? Note that this test could be performed
@@ -6806,7 +6965,7 @@ function! sexp#opening_insertion(bra)
     let [_b, line, col, _o] = getpos('.')
 
     if s:is_rgn_type('str_com_chr', line, col)
-        \ && s:compare_pos(sexp#current_element_terminal(0), [0, line, col, 0]) < 0
+        \ && sexp#compare_pos(sexp#current_element_terminal(0), [0, line, col, 0]) < 0
         return a:bra
     endif
 
@@ -6857,7 +7016,7 @@ function! sexp#closing_insertion(ket)
     let pprev = curline[col - 3]
 
     if s:is_rgn_type('str_com_chr', line, col)
-        \ && s:compare_pos(sexp#current_element_terminal(0), [0, line, col, 0]) < 0
+        \ && sexp#compare_pos(sexp#current_element_terminal(0), [0, line, col, 0]) < 0
         return a:ket
     elseif prev ==# '\' && pprev !=# '\'
         return a:ket

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -215,7 +215,7 @@ endfunction
 " Return position representing the bracket that *contains* the cursor position, else
 " nullpos if top-level.
 " Note: Differs from s:nearest_bracket() only when reference pos is *on* bracket of type
-" corresponding to 'closing'.
+" opposite to 'closing'.
 function! s:containing_bracket(closing, ...)
     let save_cursor = getcurpos()
     " TODO: Consider using s:is_list() to determine whether we need to look up a level.
@@ -559,7 +559,11 @@ endfunction
 " TODO: Convert the optional args to a (possibly optional) flags dict.
 function! sexp#nearest_element_terminal(next, tail, ...)
     let cursor = getpos('.')
-    let [pos, has_adj] = [cursor, 0]
+    " By function end, a non-null pos indicates the desired terminal pos iff
+    " !ignore_current OR have_adj.
+    " Rationale: The function logic sets 'pos' optimistically, even in cases where we
+    " ultimately fail to find adjacent.
+    let [pos, has_adj] = [s:nullpos, 0]
     " Cache optional flags.
     let ignore_current = a:0 && a:1
     let nullpos_on_fail = a:0 > 1 && a:1
@@ -616,7 +620,7 @@ function! sexp#nearest_element_terminal(next, tail, ...)
         call s:setcursor(cursor)
         " Note: The bare return statements above work like simple throws; the return value
         " is constructed here.
-        return ignore_current && !has_adj
+        return ignore_current && !has_adj || !pos[1]
             \ ? nullpos_on_fail ? s:nullpos : cursor
             \ : pos
     endtry
@@ -1557,30 +1561,6 @@ function! s:constrained_range(start, end, keep_end)
     return ret
 endfunction
 
-" Return *effective* auto-indent range calculation method, taking g:sexp_auto_indent_range
-" and g:sexp_indent_aligns_comments into account.
-function! s:get_effective_ai_range()
-    " TODO: Better way to keep this in sync with plugin script (and docs)?
-    let def_ai = 'mp'
-    " Note: We normally assume existence of global options at this point (since they're
-    " created as necessary by plugin script), but as long as we're doing processing,
-    " re-creating if necessary doesn't hurt...
-    let ai = get(g:, 'sexp_auto_indent_range', def_ai)
-    if empty(ai)
-        " Accept empty string as natural way to request default explicitly.
-        let ai = def_ai
-    endif
-    if ai != def_ai && (type(ai) != type('') || ai !~ '\v^[mpt]{1,2}$')
-        call sexp#warn#msg_once(
-            \ printf("sexp_auto_indent_range:invalid_format:%s", string(ai)),
-            \ "Ignoring invalid g:sexp_auto_indent_range setting: "
-            \ . string(ai) . ". Defaulting to '" . def_ai . "'")
-        let ai = def_ai
-    endif
-    " If two-char form is used, let align comment enable status pick the char.
-    return len(ai) == 1 ? ai : ai[!!g:sexp_indent_aligns_comments]
-endfunction
-
 " Calculate and return a dict representing the re-indent required for the buffer
 " modification spanning start/end, taking g:sexp_auto_indent_range option into account.
 " Return Dict:
@@ -1590,7 +1570,7 @@ endfunction
 "   cnt:    count argument for sexp#indent() (N/A in explicit range mode)
 function! s:get_reindent_range(s, e)
     let cursor = getpos('.')
-    let ai_range = s:get_effective_ai_range()
+    let ai_range = g:sexp_auto_indent_range
     " Return range may be adjusted below.
     let [s, e] = [a:s, a:e]
     " These will be adjusted later if parent list is to be used in lieu of explicit range.
@@ -1598,26 +1578,29 @@ function! s:get_reindent_range(s, e)
     try
         " Position at start of first element of input range.
         let [s, e] = s:super_range(s, e)
-        " If at top, just use [s,e].
+        " If at top, just use [s,e] with explicit range mode.
         if !s:at_top(s[1], s[2])
-            if ai_range == 'm' && s:is_list_terminal(s, 0)
+            if ai_range == 0 && s:is_list_terminal(s, 0)
                 " Changes to list head can propagate to the end of a list, so force
-                " parent.
-                let ai_range = 'p'
+                " re-indent of parent.
+                let ai_range = 1
             endif
             " Assumption: Containing if guard obviates need to validate bracket searches.
-            " Note: We're on tail end of input end element.
-            if ai_range == 't'
-                " containing top-level form
+            if ai_range < 0
+                " containing top-level form (should be -1, but be permissive)
                 let top = 1
-            elseif ai_range == 'p'
-                " containing form only
-                let top = 0
-                " If start is open bracket, use count of 2 to reindent that list's parent.
+            elseif ai_range > 0
+                " N containing forms
+                let [top, cnt] = [0, ai_range]
+                " If start is open bracket, increment configured count by 1.
+                " Rationale: If start and end are siblings and start is a list, the first
+                " call to select_current_list() will select only the start list, not the
+                " common parent, but it's the common parent that the user would expect to
+                " be selected by an option value of 1.
                 if s:is_list(s[1], s[2]) == 2
-                    let cnt = 2
+                    let cnt += 1
                 endif
-            else " ai_range == 'm'
+            else " ai_range == 0
                 " Calculate impacted range.
                 " Logic: We know s is not list head, so as long as indentation was correct
                 " before the operation, we should be able to keep it so by indenting up to
@@ -2753,10 +2736,10 @@ function! s:get_sel_dir(mode)
     endtry
 endfunction
 
-" TODO: Update this comment to reflect major changes with the handling of counts!!!
 " Set visual marks to the start and end of the current element. If inner is 0, trailing or
 " leading whitespace is included by way of s:terminals_with_whitespace().
 " TODO: Update documentation to reflect changes in s:terminals_with_whitespace logic.
+" TODO: Update this comment to reflect major changes with the handling of counts!!!
 "
 " If cursor is on whitespace that is not in a string or between line comments, the marks
 " are set around the next element if inner is 1, and around the current position and end
@@ -2767,7 +2750,7 @@ endfunction
 " Args:
 "   count   (> 0 means expansion possible)
 "   no_sel  inhibit visual selection (return range only)
-" Return: adjusted position, else null pos
+" Return: adjusted range, else null range
 " FIXME: Consider using try/catch; re-examine the off-nominal handling.
 " Idiosyncrasy: Hitting vie in normal mode on a single-char atom will cause two atoms to
 " be selected! When I first observed this behavior, it was sufficiently disconcerting that
@@ -2816,9 +2799,8 @@ function! s:set_marks_around_current_element(mode, inner, count, no_sel)
     let start = sexp#move_to_current_element_terminal(0)
     if !start[1]
         " We are on whitespace; check for next element
-        let p = getpos('.')
-        let next = sexp#move_to_adjacent_element_terminal(1, 0, 0)
-        if next == p
+        let next = sexp#move_to_adjacent_element_terminal(1, 0, 0, 1)
+        if !next[1]
             " No next element!
             if a:mode !=? 'v'
                 " Inhibit operation.
@@ -2986,6 +2968,49 @@ function! sexp#select_current_list(mode, offset, allow_expansion, ...)
     return success
 endfunction
 
+" Use this function in lieu of sexp#docount('sexp#select_current_list', ...) when you want
+" early termination when the count is too large. The sexp#docount() call will just keep
+" going unconditionally until the count is exhausted, which is problematic since at least
+" one plugin option recommends setting a count to a large number (e.g., 1000) to select
+" "top-level".
+" Another difference is that this function doesn't fall back to current element when not
+" within a list.
+" Note: The allow_expansion arg is omitted, as this function would be pointless without
+" expansion.
+" Return: 1 if a list (not necessarily nth) has been selected, else 0
+" TODO: Refactor of set_marks_around_current_list() has obviated the need for this. Remove
+" after testing...
+function! sexp#select_nth_list(count, mode, offset)
+    try
+        " Maintain prev range so we can detect when expansion stops.
+        let [vs_, ve_] = [s:nullpos, s:nullpos]
+        for i in range(a:count > 0 ? a:count : 1)
+            " Note: Need to set the script-local counter used by sexp#docount because
+            " s:set_marks_around_current_list()'s logic uses it to prevent expansion on
+            " the first (0th) iteration.
+            " TODO: This feels wrong and should probably be changed, but any change there
+            " would entail significant re-validation, so tread carefully...
+            let s:countindex = i
+            " Set optional 'list_only' flag to prevent fallback to nearest element.
+            if !sexp#select_current_list(a:mode, a:offset, 1, 1)
+                " TODO: Decide how best to handle failure. Note that inability to expand
+                " further is not considered failure, and is handled below.
+                return 0
+            endif
+            " Did expansion occur?
+            let [vs, ve] = s:get_visual_marks()
+            if vs_ == vs
+                " No expansion occurred! Short-circuit.
+                break
+            endif
+            let [vs_, ve_] = [vs, ve]
+        endfor
+        return 1
+    finally
+        let s:countindex = -1
+    endtry
+endfunction
+
 " Set visual marks at current outermost list's brackets, then enter visual
 " mode with that selection. Selects current element if cursor is not in a
 " list.
@@ -3008,6 +3033,8 @@ endfunction
 function! sexp#select_current_element(mode, inner, ...)
     let cnt = a:0 && a:1 ? a:1 : 1
     call s:set_marks_around_current_element(a:mode, a:inner, cnt, 0)
+    " TODO: Should this really be called unconditionally, given that
+    " s:set_marks_around_current_element() may have failed and deleted < > marks?
     return s:select_current_marks(a:mode, a:mode ==? 'v' ? b:sexp_cmd_cache.sel_dir : 1)
 endfunction
 
@@ -5790,8 +5817,9 @@ endfunction
 
 " Calculate useful state (primarily target range) for a command that operates on either
 " forms (possibly more than one, as determined by count) or visual range and needs to
-" preserve view and cursor position across the operation: e.g., indent and align. Return a
-" dict containing the calculated state.
+" preserve view and cursor position across the operation: e.g., indent and align.
+" Return: a dict containing the calculated state, else {} if we can't determine a valid
+" range.
 " Note: Currently, this function also handles saving window state, but I'm thinking
 " perhaps that should be pulled out.
 " TODO: Rename this to make it more general...
@@ -5808,9 +5836,12 @@ function! s:pre_align_or_indent(mode, top, count, clean, ps)
     " Rationale: For Normal mode invocation, we use visual selection to perform indent,
     " but this is an implementation detail that should be transparent to user.
     let [vs, ve] = s:get_visual_marks()
+    let [start, end] = [s:nullpos, s:nullpos]
     if a:mode ==? 'n'
         " Move to current list tail since the expansion step of
         " s:set_marks_around_current_list() happens at the tail.
+        " TODO: It's no longer the case that expansion happens only at tail; look at
+        " refactoring this entire block!
         if getline(line)[col - 1] =~ s:closing_bracket
             \ && !s:is_rgn_type('str_com_chr', line, col)
             let pos = [0, line, col, 0]
@@ -5818,11 +5849,17 @@ function! s:pre_align_or_indent(mode, top, count, clean, ps)
             let pos = s:move_to_nearest_bracket(1)
         endif
 
-        normal! v
+        " TODO: Need rationale for this `v`, given that the functions below ensure entry
+        " into visual mode. I'm not sure it's needed, but it's been here a *long* time.
+        "normal! v
         if pos[1] < 1
             let at_top = 1
-            " At top-level. If current (or next) element is list, select it.
-            " Note: When not within list, 'inner' includes brackets.
+            " At top-level. Select current (or next) element.
+            " Note: On list close, the move_to_nearest_bracket() above will return
+            " nullpos, even though we're effectively on a list; in that case, the
+            " following call will select the list, including brackets.
+            " TODO: Consider whether it ever makes sense to select *next* element when
+            " we're not within element or list.
             call sexp#select_current_element('n', 1)
         elseif a:top
             " Inside list. Select topmost list.
@@ -5875,10 +5912,10 @@ function! sexp#align_comments(mode, top, count)
         " comment alignment.
         let state = s:pre_align_or_indent(a:mode, a:top, a:count, 0, [])
         " Don't attempt alignment on null range.
-        if state.start[1] && state.end[1]
+        if !empty(state) && state.start[1] && state.end[1]
             call s:align_comments(state.start, state.end, state.ps)
+            call s:post_align_or_indent(a:mode, state)
         endif
-        call s:post_align_or_indent(a:mode, state)
     finally
         " Re-enable autocmds.
         let &ei = ei_save

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -225,7 +225,7 @@ function! s:containing_bracket(closing, ...)
         let p = call('s:nearest_bracket', [a:closing] + a:000)
         " Check to see whether this is the matching bracket of input pos.
         call s:setcursor(p)
-        let opos = s:nearest_bracket([!a:closing] + a:000)
+        let opos = call('s:nearest_bracket', [!a:closing] + a:000)
         if !sexp#compare_pos(opos, save_cursor)
             " We found matching bracket. Need to go up a level.
             let p = call('s:nearest_bracket', [a:closing] + a:000)

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3899,7 +3899,8 @@ function! s:replace_mode__get_tgt(tgt, s, e)
     let rng = [s, e]
     if !sexp#is_uniform_range(rng)
         throw 'sexp-abort: Invalid attempt to perform replacement'
-            \ . ' on range that crosses list boundaries'
+            \ . ' on range that crosses list boundaries.'
+            \ . ' Did you mean to set g:sexp_regput_enable_teleop?'
     endif
     for i in range(2)
         call s:setcursor(rng[i])
@@ -4006,7 +4007,8 @@ function! s:replace_op__get_tgt(ctx, inclusive)
     try
         let [s, e] = [getpos("'["), getpos("']")]
         " First, attempt to process as "endpoint" motion (unless inhibited by option).
-        if !s:replace_op__try_get_endpoint_tgt(ret, s, e, inclusive)
+        if !g:sexp_regput_enable_teleop
+            \ || !s:replace_op__try_get_endpoint_tgt(ret, s, e, inclusive)
             " Fallback to non-endpoint mode.
             call s:replace_mode__get_tgt(ret, s, e)
         endif
@@ -4018,23 +4020,30 @@ endfunction
 
 " TODO: Probably add a parameter for the motion mode.
 function! sexp#replace_op(mode, count, P, ...)
+    " Replace operator doesn't use a count.
+    " TODO: Currently, warning is given by plug wrapper, but consider creating a
+    " sexp#warn#if_count_provided() or some such, which could eventually be easily invoked
+    " from other sexp operators (but only the ones for which it makes sense).
+    " TODO: Consider whether the aforementioned warning would be best coming before or
+    " after the motion/object.
+    let cnt = 1
     if !a:0
         " Initial call (invoked explicitly, not via Vim's opfunc engine)
         let ctx = {
             \ 'curpos': getpos('.'),
             \ 'regname': v:register,
             \ 'backtick': getpos("'`"),
-            \ 'mode': a:mode, 'count': a:count, 'P': a:P
+            \ 'mode': a:mode, 'count': cnt, 'P': a:P
         \ }
         " Important Note: Ideally, we'd use the black hole register for this, but we need
         " TextYankPost to fire, and it doesn't for the black hole register; thus, use z
         " register and ensure the handlers save/restore both it and the unnamed register.
         " TODO: Consider just returning boolean flag indicating the mode to use and
         " letting opfunc handle the details?
-        let op = has('nvim-0.5') && g:sexp_regput_op_tele ? '"zyv' : 'g@v'
+        let op = v:version >= 801 && g:sexp_regput_enable_teleop ? '"zyv' : 'g@v'
         " The call via 'opfunc' or TextYankPost will get the original args + the context
         " dict and the operator itself.
-        return [op, function('sexp#replace_op', [a:mode, a:count, a:P, ctx, op])]
+        return [op, function('sexp#replace_op', [a:mode, cnt, a:P, ctx, op])]
     endif
     try
         " We've been invoked by our opfunc wrapper, called either as true 'opfunc' or in

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2380,77 +2380,112 @@ function! s:set_marks_around_current_string(mode, offset)
     endif
 endfunction
 
-" TODO: Document...
-" FIXME: Get rid of the suffix after refactoring namespaces.
-function! s:select_child(mode, count, next, inner)
-    let cursor = getpos('.')
-    " Are we on a list?
-    let isl = s:is_list(cursor[1], cursor[2])
-    if !isl
-        " Find parent list head or tail
-        let p = s:move_to_nearest_bracket(!a:next)
-        if !p[1]
-            " At top level. Move to buffer head/tail
-            exe 'normal!' (a:next ? 'gg0' : 'G$')
-        endif
-    else
-        " On list. Position on desired bracket (if not already there).
-        if a:next
-            if isl == 1
-                " Move to open
-                " Get to tail of macro chars.
-                call s:setcursor(s:current_macro_character_terminal(1))
-                call s:move_char(1)
-            elseif isl == 3
-                " Move to open
-                call s:move_to_nearest_bracket(0)
-            endif
-        elseif isl != 3
-            " Move to close
-            call s:move_to_current_element_terminal(1)
-        endif
-    endif
-    " On list open/close.
-    " Get opposite bracket's position so we can detect null list.
-    let p = s:nearest_bracket(a:next)
-    " Move inside bracket.
-    call s:move_char(a:next)
-    if p == getpos('.')
-        " Null list!
-        " TODO: How to handle...
-        return
-    endif
-    " We're inside non-null (but possibly empty) list.
-    " Are we on an element? If so, get to its near side.
-    let p = s:move_to_current_element_terminal(!a:next)
-    if !p[1]
-        " In whitespace next to bracket. Find head/tail element.
-        let pp = getpos('.')
-        " TODO: Fold this into the list perhaps, but need to differentiate
-        " case in which nothing found.
-        let p = s:move_to_adjacent_element(a:next, !a:next, 0)
-        if p == pp
-            " No elements in list.
-            " TODO: How to handle...
-            return
-        endif
-    endif
-    " Assumption: We're sitting on first/last element (whose position is p).
-    " If count > 1, find count-1'th adjacent element.
-    let cnt = a:count ? a:count - 1 : 0
-    while cnt
-        let pp = p
-        let p = s:move_to_adjacent_element(a:next, !a:next, 0)
-        if p == pp
-            " We've gone as far as we can go.
-            break
-        endif
-        let cnt -= 1
-    endwhile
 
-    " Note: Although we may be called from visual mode, child selection
-    " ignores current selection by definition.
-    call s:set_marks_around_current_element('n', a:inner, 0, 0)
+" Return range of sibling n elements away from pos. If requested element does not exist,
+" 'missing' key will indicate how many siblings were lacking and range will be for the
+" final element in desired direction.
+" -- Args --
+" pos:    starting position
+" n:      desired number of steps from input pos
+" tail:   direction of traversal
+" Return Dict:
+" remaining     0 if returned range corresponds to requested element, else number of
+"               missing siblings
+" range         [start, end] of element n steps from pos
+function! s:nth_from(pos, n, tail)
+    let cursor = getpos('.')
+    let ret = {'missing': 0, 'range': [s:nullpos, s:nullpos]}
+    try
+        " Move to starting position.
+        call s:setcursor(a:pos)
+        if !a:n
+            " Note: This probably represents internal error.
+            let ret.range =
+                \ [sexp#current_element_terminal(0), sexp#current_element_terminal(1)]
+        else
+            " Start on outside of terminal element and search inward.
+            let cnt = a:n
+            while cnt
+                " Land on near side of elements.
+                let p = s:move_to_adjacent_element(a:tail, !a:tail, 0, 1)
+                if !p[1]
+                    " We've gone as far as we can go.
+                    break
+                endif
+                let cnt -= 1
+            endwhile
+            " We're positioned on near side of desired element (or if count was too high,
+            " the final element in list in desired direction).
+            let ret.range[!a:tail] = getpos('.')
+            let ret.range[a:tail] = sexp#current_element_terminal(a:tail)
+            let ret.missing = cnt
+        endif
+    finally
+        call s:setcursor(cursor)
+        return ret
+    endtry
+endfunction
+
+" Return range of positions for the requested child of the current list, else nullpos
+" pair. If optional 'top_is_list' arg is set and cursor is at toplevel, treat buffer
+" itself as a list.
+" -- Args --
+" count:   1-based index of desired child, counted from 'tail' side of list
+" tail:    side of list from which we look for [count]th element inward
+" inner:   1 iff "inner element" is desired
+" -- Optional Dict --
+" top_is_list      Treat toplevel as list if cursor at toplevel
+" list_info        If not empty or omitted, use to skip call to s:list_info()
+function! s:child_range(count, tail, inner, ...)
+    let cursor = getpos('.')
+    let ret = {'range': [s:nullpos, s:nullpos], 'missing': a:count}
+    try
+        if a:0
+            let top_is_list = get(a:1, 'top_is_list', 0)
+            let li = get(a:1, 'list_info', {})
+        endif
+        " Get relevant info about current list, including desired terminal.
+        let li = empty(li) ? s:list_info(a:tail) : li
+        let ret.range = li.terminal_range
+        if !ret.range[0][1] && !li.brackets[0][1] && top_is_list
+            " Check for buffer head/tail.
+            let ret = s:buffer_terminal(a:tail)
+        endif
+        if ret.range[0][1]
+            " Assumption: We're sitting on head/tail element.
+            " If count > 1, find count-1'th adjacent element.
+            let cnt = a:count ? a:count - 1 : 0
+            if cnt
+                " Start on outside of terminal element and search inward.
+                let p = ret.range[a:tail]
+                call s:setcursor(p)
+                while cnt
+                    " Land on outside of elements.
+                    let p = s:move_to_adjacent_element(!a:tail, a:tail, 0, 1)
+                    if !p[1]
+                        " We've gone as far as we can go.
+                        break
+                    endif
+                    let cnt -= 1
+                endwhile
+                " We're positioned on outside of desired element (or if count was too
+                " high, the final element in list in desired direction).
+                let ret.range[a:tail] = getpos('.')
+                let ret.range[!a:tail] = sexp#current_element_terminal(!a:tail)
+                let ret.missing = cnt
+            else
+                " Terminal is sought child.
+                let ret.missing = 0
+            endif
+            if !a:inner
+                " Perform whitespace cleanup.
+                let ret.range = s:terminals_with_whitespace(ret[0], ret[1])
+            endif
+        endif
+    finally
+        call s:setcursor(cursor)
+        return ret
+    endtry
 endfunction
 
 " Return 1 iff the most recent (possibly active) visual selection has cursor at end.
@@ -2744,12 +2779,17 @@ function! sexp#select_adjacent_element(mode, next)
     return s:select_current_marks(a:mode)
 endfunction
 
-" Set visual marks around count'th child of current (or parent) list; 0 to
-" count backwards from tail, 1 to count forwards from head. If no such child
-" element exists, selects closest one (i.e., last in the specified direction).
-function! sexp#select_child(mode, count, next, rev)
-    call s:select_child(a:mode, a:count, a:next, a:rev)
-    return s:select_current_marks(a:mode)
+" Set visual marks around count'th inner/outer child of current (or parent) list; 0 to
+" count backwards from tail, 1 to count forwards from head. If no such child element
+" exists, selects closest one (i.e., last in the specified direction).
+function! sexp#select_child(mode, count, next, inner)
+    let [s, e] = s:child_range(a:count, a:next, a:inner)
+    if s[1]
+        " Note: Although we may be called from visual mode, child selection ignores
+        " current selection by definition.
+        call s:set_visual_marks([s, e])
+        call s:select_current_marks(a:mode)
+    endif
 endfunction
 
 """ BUFFER MUTATION {{{1
@@ -2824,7 +2864,8 @@ function! s:is_multiline_put(loc, dir)
 
 endfunction
 
-" TODO: Where to put this... Eventually, the legacy version will be more complex.
+" TODO: Where to put this... Eventually, the legacy version will put the code in a hidden
+" buffer to have it parsed by legacy syntax engine.
 function! s:analyze_codestr_legacy(codestr, filetype)
     " Note: Processed text added later.
     let ret = {
@@ -2854,8 +2895,9 @@ function! s:analyze_codestr_legacy(codestr, filetype)
 endfunction
 
 " Build and return a dict characterizing the text in the put register and canonicalize the
-" register contents.
-function! s:put__get_reginfo()
+" register contents. Use Treesitter if applicable, falling back to legacy syntax
+" highlighting.
+function! s:regput__get_reginfo()
     let regstr = getreg(v:register)
     if regstr =~ '^\s*$'
         " No-op!
@@ -2867,29 +2909,42 @@ function! s:put__get_reginfo()
     return ret
 endfunction
 
-" Build and return dict characterizing the context in which a register put occurs.
-" Field Descriptions:
-"   tgt:             the put side of the target element, else virtual target
-"                    May be 'virtual' in special case scenarios.
-"   adj:             the target side of the element adjacent to target on put side, else
-"                    BOF/EOF sentinel, else nullpos
-"   adj_bracket:     if target is terminal element, position of bracket on put side of
-"                    target, else nullpos
-"   empty_list:      putting into empty list
-"   empty_buffer:    putting into empty buffer
+" Build and return dict characterizing the context in which a register put occurs. To
+" minimize duplication across the various put commands, this function expects a tgt dict,
+" which characterizes the put target slightly differently, as a function of put type.
+" Since this tgt dict is simply merged into the dict returned by this shared function, its
+" format is described here.
+" Args:
+"   tgt_info:        dict containing information on the target of the put, which is simply
+"                    merged into the dict returned by this function.
+" Return Dict:
+"   Note: List keys are pairs whose indices correspond to the elements of range[].
+"   --[[ Beginning of merged-in tgt_info dict
+"   put_mode:        one of 'put', 'put_child', 'replace', 'replace_child'
 "   tail:            possibly adjusted version of the input flag
 "                    Note: Adjustment performed only when cursor not on element
-"   -- Flags: The following flags are N/A if either of empty_{list,buffer} set.
-"   tgt_is_alone:    1 iff target is alone on its line, with possible exception of open or
-"                    close, but not both
-"   adj_colinear:    1 iff target and adjacent are colinear elements (not brackets)
-"   force_nl:        1 iff subsequent processing should force 'near sep' of NL.
-"                    Used only when cursor is not on element.
-" Position Note: In the current approach, mutually-exclusive fields are maintained for
-" elements and brackets in a given direction, with the unused field set to nullpos:
-" e.g., non-null adj implies null adj_bracket and vice-versa. An equally valid (and
-" possibly simpler) approach would be to maintain a single position var to hold either
-" element or bracket pos, along with a dedicated 'is_bracket' flag.
+"   range[]:         position pair specifying exclusive range for the put
+"   is_bra[]:        1 iff corresponding end of range is bracket
+"   is_ele[]:        1 iff coreesponding end of range is element
+"   tail:            Meaning varies slightly across put modes, but in some sense, this
+"                    value determines direction of put. Can be adjusted by special case
+"                    logic; hence, its inclusion here.
+"   force_nl[]:      1 iff subsequent processing should force use of NL separator.
+"                    Currently, used only for a normal (targeted) put when cursor is not
+"                    on an element.
+"   --]] End of merged-in tgt_info Dict
+"   empty_list:      putting into empty list
+"   empty_buffer:    putting into empty buffer
+"   -- Flags: The following flag pairs are N/A if either of empty_{list,buffer} set.
+"   alone[]:         1 iff element at corresponding range endpoint is alone on its line,
+"                    with possible exception of open or close, but not both
+"   colinear[]:      1 iff element at corresponding range endpoint is colinear with its
+"                    adjacent (in the direction of the other range endpoint)
+"                    Implication: For non-replacement put modes, both values in the pair
+"                    will be identical, since the same 2 elements are used for both
+"                    comparisons; for replacement put modes, the values can differ because
+"                    opposite sides of the form(s) being replaced are used for the
+"                    comparisons.
 " Cursor Preservation: Caller handles.
 " Special Logic: There are 3 distinct scenarios in which cursor is not *on* an element:
 "   1. cursor inside (not on brackets of) empty list
@@ -2897,11 +2952,12 @@ endfunction
 "   3. cursor in whitespace adjacent to one or more elements
 " In the interest of simplifying downstream logic, we attempt to make the special cases
 " look somewhat like the nominal case (e.g., by allowing tgt to be a bracket or a special
-" BOF/EOF sentinel), but we also set flags (e.g., empty_{list,buffer}, force_nl) that
+" BOF/EOF sentinel), but we also set flags (e.g., empty_{list,buffer}, force_nl[]) that
 " allow downstream logic to discriminate when necessary.
 " The handling of case 3 depends on the colinearity of cursor pos with whatever comes
 " before/after (i.e., effective prev/next, which can be either element or bracket, or even
 " BOF/EOF) and is outlined below:
+"
 " If cursor colinear with both effective prev/next
 "   p = put after effective prev
 "   P = put before effective next
@@ -2917,106 +2973,60 @@ endfunction
 " Design Decision: Although we could handle p and P the same way in the 2 ElseIf's above,
 " treating the one that puts *away from* the colinear target as a request for extra
 " separation seems intuitive and gives extra flexibility.
-function! s:put__get_context(count, tail)
-    " Bool flags all initialized to 0 and set subsequently as needed.
-    let ret = {
-        \ 'range': [[0,0,0,0],[0,0,0,0]],
-        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
-        \ 'tgt_is_alone': 0, 'adj_colinear': 0,
+function! s:regput__get_context(tgt_info)
+    " Merge target information into return dict.
+    let ret = extend({
+        \ 'alone': [0, 0], 'colinear': [0, 0],
         \ 'empty_list': 0, 'empty_buffer': 0,
-        \ 'force_nl': 0,
-        \ 'tail': a:tail
-    \ }
-    let curpos = getpos('.')
-    " First, attempt to get natural target: i.e., side of current element in direction of
-    " put. If no such element, special logic will determine a 'virtual' target.
-    let ret.range[!a:tail] = sexp#current_element_terminal(a:tail)
-    let no_current = !ret.range[!a:tail][1]
-    " If either end of range is still nullpos, attempt to set it to adjacent or bracket.
-    " Caveat: Must pre-position on correct side of element prior to nearest_bracket() call
-    " to ensure we get parent bracket, not one of list element's own brackets.
-    for i in range(0, 1)
-        if !ret.range[i][1]
-            let ret.range[i] = s:nearest_element_terminal(i, !i, 1, 1)
-            if ret.range[i][1]
-                let ret.is_ele[i] = 1
-            else
-                if ret.range[!i][1] | call s:setcursor(ret.range[!i]) | endif
-                let ret.range[i] = s:nearest_bracket(i)
-                if ret.range[i][1]
-                    let ret.is_bra[i] = 1
-                endif
-            endif
-        else
-            let ret.is_ele[i] = 1
-        endif
-    endfor
-    " At this point, range endpoints can still be nullpos, but is_ele[] and is_bra[] are
-    " set correctly.
+    \ }, a:tgt_info)
+
+    " Note: is_bra[] and is_ele[] have been merged into ret from input a:tgt.
     let ret.empty_list = ret.is_bra[0] && ret.is_bra[1]
     let ret.empty_buffer = !ret.is_ele[0] && !ret.is_ele[1] && !ret.empty_list
-    " Unless superseded by empty_{list,buffer} special logic, use special logic described
-    " in header to determine target if cursor was not *on* element.
-    " Note: This logic may set tgt to pre-BOF/post-EOF sentinel position.
-    if !ret.empty_list && !ret.empty_buffer && no_current
-        " The conditional blocks below can...
-        "   * reverse range
-        "   * set flag forcing insertion of NL at near side.
-        " Note: The fact that curpos cannot be null and prev/next can only be null if
-        " neither bracket nor element obviates need for explicit nullpos checks on
-        " prev/next.
-        " Design Decision: Never force NL around brackets.
-        let [prev, next] = [ret.range[0], ret.range[1]]
-        if curpos[1] != prev[1] && curpos[1] != next[1]
-            " Design Decision: The fact that we're not on the element (or even near it)
-            " implies direction change: intuitively, the direction of p or P in empty line
-            " selects the target element.
-            let ret.tail = !ret.tail
-        elseif curpos[1] == prev[1] && curpos[1] != next[1]
-            let [ret.force_nl, ret.tail] = [a:tail && ret.is_ele[0], 1]
-        elseif curpos[1] == next[1] && curpos[1] != prev[1]
-            let [ret.force_nl, ret.tail] = [!a:tail && ret.is_ele[1], 0]
-        endif
-    endif
-    " If either range endpoint is still null, set it to corresponding buffer extremity.
-    if !ret.range[0][1]
-        let ret.range[0] = s:BOF
-    endif
-    if !ret.range[1][1]
-        let ret.range[1] = [0, line('$'), col([line('$'), '$']), 0]
-    endif
-    " Set adj_colinear and tgt_is_alone
+
+    " Set colinear[] and alone[] flag pairs.
     " Note: Flags are N/A for empty buffer/list special cases.
     if !ret.empty_buffer && !ret.empty_list
-        " Account for possibility direction has been adjusted by special logic.
-        let tail = ret.tail
-        let ret.adj_colinear = ret.is_ele == [1, 1] && ret.range[0][1] == ret.range[1][1]
-        " Position on target to look for away element.
-        call s:setcursor(ret.range[!tail])
-        let away = s:nearest_element_terminal(!tail, tail, 1, 1)
-        if !away[1]
-            " Pre-position on away side of tgt to ensure that if tgt is list,
-            " nearest_bracket doesn't find its other end.
-            call s:move_to_current_element_terminal(!tail)
-            let away_bra = s:nearest_bracket(!tail)
-        else
-            let away_bra = s:nullpos
+        if ret.put_mode == 'replace'
+            " TODO - take inner range into account
+            " TODO: Consider cacheing either inner range ends or adj so that alone
+            " logic can be shared.
+        elseif ret.put_mode == 'replace_child'
+            " TODO!!!!
+        else " put_mode in ['put', 'put_child']
+            " Note: For non-replace modes, colinear[] is effectively a scalar.
+            let ret.colinear =
+                \ ret.is_ele == [1, 1] && ret.range[0][1] == ret.range[1][1]
+                \ ? [1, 1] : [0, 0]
+            " Set side-specific 'alone' flags in loop.
+            for i in range(2)
+                let [outer, outer_is_bra] = [s:nullpos, 0]
+                if !ret.is_bra[i]
+                    " Attempt to find outer adjacent.
+                    call s:setcursor(ret.range[i])
+                    let outer = s:nearest_element_terminal(i, !i, 1, 1)
+                    if !outer[1]
+                        " Pre-position on outside of element to ensure that if element is
+                        " list, nearest_bracket doesn't find its match.
+                        call s:move_to_current_element_terminal(i)
+                        let outer = s:nearest_bracket(i)
+                        if outer[1]
+                            let outer_is_bra = 1
+                        endif
+                    endif
+                endif
+                let ret.alone[i] = ret.is_ele[i]
+                    \ && (!ret.is_ele[!i] || ret.range[0][1] != ret.range[1][1])
+                    \ && (outer_is_bra || !outer[1] || outer[1] != ret.range[i][1])
+                    \ && (!outer_is_bra || !ret.is_bra[!i] || outer[1] != ret.range[!i][1])
+            endfor
         endif
-        " Is (element) tgt alone on its line, with possible exception of containing open
-        " or close (but not both)?
-        " Note: Any of the positions can be nullpos here.
-        let [tgt_idx, adj_idx] = [!tail, tail]
-        let [tgt, adj] = [ret.range[tgt_idx], ret.range[adj_idx]]
-        let ret.tgt_is_alone = ret.is_ele[tgt_idx]
-            \ && (!ret.is_ele[adj_idx] || tgt[1] != adj[1])
-            \ && (!away[1] || away[1] != tgt[1])
-            \ && !(away_bra[1] && ret.is_bra[adj_idx] && away_bra[1] == adj[1])
     endif
     return ret
 endfunction
 
 " TODO: Comment this!!!!!
-function! s:put__check_list_context(ctx, reg)
+function! s:regput__check_list_context(ctx, reg)
     " Initialize return value to special list containing "don't care" values for sep at
     " both ends. If list position logic applies, one or both of the values may be changed
     " to NL or SPC.
@@ -3024,10 +3034,18 @@ function! s:put__check_list_context(ctx, reg)
     let [ctx, reg] = [a:ctx, a:reg]
     let [sidx, ps] = [0, []]
     if !ctx.is_bra[0]
-        " Is start one of first two elements?
+        if !ctx.is_ele[0]
+            " Shouldn't happen, but just to be safe...
+            return
+        endif
+        " Traverse preceding siblings till either hitting an open bracket or visiting a
+        " number of siblings that precludes possibility of start of range being within
+        " first three elements of list. After exiting loop, sidx will represent 1-based
+        " child index for start of range.
         let sidx = 1
         call s:setcursor(ctx.range[0])
-        cal add(ps, [sexp#current_element_terminal(0), ctx.range[0]])
+        " Add start of range element to list of ranges.
+        call add(ps, [sexp#current_element_terminal(0), ctx.range[0]])
         while sidx <= 2
             let prev_e = s:move_to_adjacent_element(0, 1, 0, 1)
             if prev_e[1]
@@ -3061,22 +3079,26 @@ function! s:put__check_list_context(ctx, reg)
             endif
         endwhile
     else
+        " Start of range was tail element of list.
         let eidx = sidx
     endif
 
-    " Cache some useful vars.
+    " Cache some useful vars pertaining to the first 3 elements of list.
     let [s1, e1] = eidx > 0 ? ps[0] : s:nullpos_pair
     let [s2, e2] = eidx > 1 ? ps[1] : s:nullpos_pair
     let [s3, e3] = eidx > 2 ? ps[2] : s:nullpos_pair
-    " Design Decision: No special case for multi-line head
+    " Design Decision: Special case applies only to single-line head elements.
     let colinear12 = eidx > 1 && s1[1] == e1[1] && e1[1] == s2[1]
     let colinear23 = eidx > 2 && e2[1] == s3[1]
     " Note: The colinear12 condition will rule out scenarios with too few elements.
     if colinear12 && !colinear23
         if sidx == 0
-            " TODO: Decide whether to insert NL *after* range!!! Note that this would involve
-            " something more than near/far sep: a separate operation after the put.
-            echomsg "Would like forcible break after 2nd element!"
+            " Inserting to head position.
+            " Design Decision: Don't treat as special case.
+            " Rationale: Handling would entail inserting a line break after the current
+            " head element, which can't be accomplished with separators around the put
+            " text. Keep it simple. Users don't often paste the name of a function
+            " anyways...
         elseif sidx == 1
             return [s:SPC, s:NL]
         elseif sidx == 2
@@ -3096,7 +3118,7 @@ endfunction
 "   [1]:  separator needed after register contents
 "   [2]:  separator used to join the individual instances of register contents in case of
 "         a [count]
-function! s:put__get_seps(ctx, reg)
+function! s:regput__get_seps(ctx, reg)
     " Default start/end sep to NL; overrides below.
     let [ctx, reg] = [a:ctx, a:reg]
     let tail = ctx.tail
@@ -3111,53 +3133,40 @@ function! s:put__get_seps(ctx, reg)
         " Supersedence Logic: Non-N/A values in returned lpi dict supersede the normal
         " flag logic. Since the default separator is NL, a NL in lpi clears the
         " corresponding *_side_spc flag and a SPC sets it.
-        let lpi = s:put__check_list_context(ctx, reg)
+        let lpi = s:regput__check_list_context(ctx, reg)
 
         " Compute side-dependent flags used to determine SPC-insertion at both start/end.
         " Note: These flags do not incorporate comment checks, which are applied below.
-        let near_side_spc = !empty(lpi[!tail])
-            \ ? lpi[!tail] == s:SPC
-            \ : ctx.is_ele[!tail] && !ctx.tgt_is_alone && !ctx.force_nl && !reg.is_ml
         " Preserve colinearity at far side unless pasted text is ml.
-        " Note: The lack of symmetry between near/far cases is due to...
-        " 1. force_nl is inherently target-centric
-        " 2. tgt_is_alone/adj_colinear reflect unwillingness to make put text colinear
-        "    with adj unless adj was already colinear with target.
-        " Idea: Need way to parameterize this for case in which there is no fixed concept
-        " of tgt/adj: i.e., the put into command.
-        let far_side_spc = !empty(lpi[tail])
-            \ ? lpi[tail] == s:SPC
-            \ : ctx.is_ele[tail] && ctx.adj_colinear && !reg.is_ml
-        "
-        " Override NL (if necessary) at start.
-        "
-        if ctx.is_bra[0]
-            let ret[0] = reg.s_is_com ? s:SPC : s:EMPTY
-        elseif !ctx.is_ele[0]
-            " No bracket or element requiring separation at start 
-            let ret[0] = s:EMPTY
-        elseif tail && near_side_spc && (g:append_sl_comment || !reg.s_is_com)
-            " TODO: Should we remove the s_is_com check to allow single-line comment to be
-            " appended, keeping in mind that far side logic will insert NL *after* the
-            " comment if necessary?
-            " Bottom Line: Make near and far-side cases consistent on this.
-            let ret[0] = s:SPC
-        elseif !tail && far_side_spc && (g:append_sl_comment || !reg.s_is_com)
-            let ret[0] = s:SPC
-        endif
-        "
-        " Override NL (if necessary) at end.
-        "
-        if ctx.is_bra[1]
-            if !reg.e_is_com | let ret[1] = s:EMPTY | endif
-        elseif !ctx.is_ele[1]
-            " No bracket or element requiring separation at end
-            let ret[1] = s:EMPTY
-        elseif !tail && near_side_spc && !reg.e_is_com
-            let ret[1] = s:SPC
-        elseif tail && far_side_spc && !reg.e_is_com
-            let ret[1] = s:SPC
-        endif
+        " Note: There's a slight asymmetry between near/far side of range, but only for
+        " put modes that differentiate between tgt and adjacent. In these modes, the
+        " 'force_nl' flag is set only on the target side, and the colinearity check
+        " reflects our unwillingness to make put text colinear with adj unless adj was
+        " already colinear with target.
+        let has_tgt = ctx.put_mode == 'put'
+        for i in range(2)
+            " Note: The ternary's first branch either inhibits SPC (ensuring default to
+            " NL) or requests SPC explicitly (subject to comment constraints).
+            let want_spc = !empty(lpi[i])
+                \ ? lpi[i] == s:SPC
+                \ : ctx.is_ele[i] && !ctx.alone[i] && !ctx.force_nl[i] && !reg.is_ml
+                \   && (!has_tgt || i != tail || ctx.colinear[i])
+
+            " Override NL (if necessary).
+            " TODO: Change {e,s}_is_com to is_com[] to obviate need for this.
+            let is_com = i ? reg.e_is_com : reg.s_is_com
+            if ctx.is_bra[i]
+                " No override for post sep if reg ends in comment.
+                if !is_com || !i
+                    let ret[i] = is_com ? s:SPC : s:EMPTY
+                endif
+            elseif !ctx.is_ele[i]
+                " No bracket or element requiring separation on this side
+                let ret[i] = s:EMPTY
+            elseif want_spc && (i == 0 && g:append_sl_comment || !is_com)
+                let ret[i] = s:SPC
+            endif
+        endfor
     endif
 
     " -- Interior separator
@@ -3186,6 +3195,7 @@ endfunction
 "   }]
 " Note: The point of this return structure is to make it easy for caller to ignore all but
 " the sought pos if desired.
+" TODO: This probably doesn't belong in this section...
 function! s:last_colinear_sibling(tail)
     let curpos = getpos('.')
     let [pos, next, brkt] = [curpos, s:nullpos, s:nullpos]
@@ -3215,14 +3225,16 @@ endfunction
 
 " Return a dict that characterizes the splice (or directed put) to be performed as the set
 " of arguments to s:yankdel_range().
-function! s:put__get_splice_info(count, ctx, reg, sep, flags)
+function! s:regput__get_splice_info(count, ctx, reg, sep, flags)
     let ret = { 'range': a:ctx.range, 'text': '', 'inc': [0, 0]}
     let [ctx, reg, sep] = [a:ctx, a:reg, a:sep]
     let tail = ctx.tail
+    let has_tgt = ctx.put_mode == 'put'
 
     " No range/inclusivity adjustments required in empty buffer case.
     if !ctx.empty_buffer
-        if sep[tail] == s:NL
+        " TODO: Decide whether/how tail matters for replace/child put modes.
+        if has_tgt && sep[tail] == s:NL
             " Determine number of newlines needed between put text and adjacent as a
             " function of the number of blank lines *currently* between target and
             " adjacent (taking options into account).
@@ -3264,19 +3276,23 @@ function! s:put__get_splice_info(count, ctx, reg, sep, flags)
     return ret
 endfunction
 
-function! sexp#put(count, tail)
+" Perform register put for all 4 command types: put, put_child, replace, replace_child.
+function! s:regput__impl(tgt, count, tail)
+    let curpos = getpos('.')
     " Save/adjust visual marks.
+    " Question: Does this really need to be done? Don't worker functions do it? If it's
+    " still necessary, it's needed at higher level (possibly even in pre_op()).
     let [vs, ve] = s:get_visual_marks()
-    let count = a:count ? a:count : 1
+
     " Calculate the put.
-    let reg = s:put__get_reginfo()
+    let reg = s:regput__get_reginfo()
     if empty(reg.text)
         " Treat empty text like NOOP!
         return
     endif
-    let ctx = s:put__get_context(count, a:tail)
-    let sep = s:put__get_seps(ctx, reg)
-    let spl = s:put__get_splice_info(count, ctx, reg, sep, {})
+    let ctx = s:regput__get_context(a:tgt)
+    let sep = s:regput__get_seps(ctx, reg)
+    let spl = s:regput__get_splice_info(a:count, ctx, reg, sep, {})
     let ps = [vs, ve]
     " TODO: Consider having put__get_context() build the position list.
     let ps = s:concat_positions(vs, ve, ctx.range)
@@ -3322,15 +3338,161 @@ function! sexp#put(count, tail)
     endif
     " FIXME: Make sure all branches above set curpos.
     call s:post_op_reindent(s, e, [ps, curpos])
-    " !!!!! WIP !!!!!
     call s:setcursor(curpos)
     call s:set_visual_marks([vs, ve])
 endfunction
 
+" Calculate and return the tgt_info dict needed by s:regput__get_context() for the case of
+" a 'put' command.
+" Note: For details, see header of s:regput__get_context().
+function! s:put__get_tgt(count, tail)
+    let curpos = getpos('.')
+    let ret = {
+        \ 'put_mode': 'put',
+        \ 'range': [s:nullpos, s:nullpos],
+        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
+        \ 'tail': a:tail, 'force_nl': [0, 0]}
+    try
+        " First, attempt to get natural target: i.e., side of *current* element in
+        " direction of put. If no such element, special logic will determine a 'virtual'
+        " target.
+        let ret.range[!a:tail] = s:move_to_current_element_terminal(a:tail)
+        let no_current = !ret.range[!a:tail][1]
+        " Attempt to set both ends of range.
+        for i in range(2)
+            if !ret.range[i][1]
+                let ret.range[i] = s:move_to_adjacent_element(i, !i, 0, 1)
+                if ret.range[i][1]
+                    let ret.is_ele[i] = 1
+                else
+                    " If other end of range is already determined, we should be on its
+                    " near side, thereby ensuring call to nearest_bracket() from list will
+                    " not find the list's own bracket.
+                    let ret.range[i] = s:nearest_bracket(i)
+                    if ret.range[i][1]
+                        let ret.is_bra[i] = 1
+                    endif
+                endif
+            else
+                let ret.is_ele[i] = 1
+            endif
+        endfor
+        " At this point, range endpoints can still be nullpos, but is_ele[] and is_bra[] are
+        " set correctly.
+        let empty_list = ret.is_bra[0] && ret.is_bra[1]
+        let empty_buffer = !ret.is_ele[0] && !ret.is_ele[1] && !empty_list
+        " Unless superseded by empty_{list,buffer} special logic, use special logic described
+        " in header to determine target if cursor was not *on* element.
+        " Note: This logic may set tgt to pre-BOF/post-EOF sentinel position.
+        if !empty_list && !empty_buffer && no_current
+            " The conditional blocks below can...
+            "   * reverse range
+            "   * set flag forcing insertion of NL at near side.
+            " Note: The following logic allows for possibility of nullpos next/prev.
+            " Design Decision: Never force NL around brackets.
+            let [prev, next] = [ret.range[0], ret.range[1]]
+            if curpos[1] != prev[1] && curpos[1] != next[1]
+                " Design Decision: The fact that we're not on the element (or even near it)
+                " implies direction change: intuitively, the direction of p or P in empty line
+                " selects the target element.
+                let ret.tail = !ret.tail
+            elseif curpos[1] == prev[1] && curpos[1] != next[1]
+                let [ret.force_nl[0], ret.tail] = [a:tail && ret.is_ele[0], 1]
+            elseif curpos[1] == next[1] && curpos[1] != prev[1]
+                let [ret.force_nl[1], ret.tail] = [!a:tail && ret.is_ele[1], 0]
+            endif
+        endif
+        " If either range endpoint is still null, set it to corresponding buffer extremity.
+        if !ret.range[0][1]
+            let ret.range[0] = s:BOF
+        endif
+        if !ret.range[1][1]
+            let ret.range[1] = [0, line('$'), col([line('$'), '$']), 0]
+        endif
+    finally
+        call s:setcursor(curpos)
+        return ret
+    endtry
+endfunction
+
+function! sexp#put(count, tail)
+    let count = a:count ? a:count : 1
+    let tgt = s:put__get_tgt(count, a:tail)
+    call s:regput__impl(tgt, count, a:tail)
+endfunction
+
 function! sexp#replace(mode, count, pvar)
+    " TODO!!!!!!!!!!!
+endfunction
+
+" Calculate and return the tgt_info dict needed by s:regput__get_context() for the case of
+" a 'put_child' command.
+" Note: For details, see header of s:regput__get_context().
+function! s:put_child__get_tgt(count, tail)
+    let cursor = getpos('.')
+    let ret = {
+        \ 'put_mode': 'put_child',
+        \ 'range': [s:nullpos, s:nullpos],
+        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
+        \ 'tail': a:tail, 'force_nl': 0}
+    try
+        let li = s:list_info(a:tail) 
+        if li.terminal_range[0][1]
+            " Non-empty list
+            let r = ret.range
+            if a:count > 1
+                " Child other than terminal element requested.
+                " Find element before/after which to insert.
+                let c = s:child_range(a:count, a:tail, 0, {'list_info': li})
+                if c.missing
+                    " Requested child doesn't exist, so use limiting list bracket and
+                    " bracket end of terminal child.
+                    let r[a:tail] = c.range[!a:tail]
+                    call s:setcursor(r[a:tail])
+                    let r[!a:tail] = li.brackets[!a:tail]
+                    let ret.is_bra[!a:tail] = 1
+                    let ret.is_ele[a:tail] = 1
+                else
+                    " Requested child exists; use it and adjacent on near side.
+                    let r[!a:tail] = c.range[a:tail]
+                    let ret.is_ele[!a:tail] = 1
+                    " Position on outside of element and look for adjacent, with fallback
+                    " to bracket.
+                    call s:setcursor(r[!a:tail])
+                    let r[a:tail] = s:nearest_element_terminal(a:tail, !a:tail)
+                    if !r[a:tail][1]
+                        " No adjacent; use bracket.
+                        let r[a:tail] = li.brackets[a:tail]
+                        let ret.is_bra[a:tail] = 1
+                    else
+                        let ret.is_ele[a:tail] = 1
+                    endif
+                endif
+            else
+                " Terminal element requested.
+                " Use bracket and terminal element.
+                let r[!a:tail] = li.terminal_range[a:tail]
+                let r[a:tail] = li.brackets[a:tail]
+                let ret.is_bra[a:tail] = 1
+                let ret.is_ele[!a:tail] = 1
+            endif
+        elseif li.brackets[0][1]
+            " Empty list
+            let [s, e] = li.brackets
+            let ret.is_bra = [1, 1]
+            let ret.is_ele = [0, 0]
+        endif
+    finally
+        call s:setcursor(cursor)
+        return ret
+    endtry
 endfunction
 
 function! sexp#put_child(count, tail)
+    let count = a:count ? a:count : 1
+    let tgt = s:put_child__get_tgt(count, a:tail)
+    " Note: [count] is used only for child location, so hardcode to 1.
+    call s:regput__impl(tgt, 1, a:tail)
 endfunction
 
 function! sexp#replace_child(count, dir, pvar)
@@ -5038,23 +5200,109 @@ function! s:adjust_positions(start, end, splice, delta, ps)
     endfor
 endfunction
 
-" Assumption: We're on an open (but no guarantee form contains elements).
-function! s:list_head()
+" Calculate and return a dict describing the current list: i.e., the list within or on
+" which the cursor lies.
+" Design Decision: Macro chars considered part of the list, just like brackets.
+" -- Args --
+" tail:   determines whether terminal_range should reflect head (0) or tail (1)
+" Return Dict:
+"   macro:           position of start of macro chars, else nullpos
+"   brackets[]:      [open, close], else [s:nullpos, s:nullpos] if no list
+"   terminal_range:  pos pair representing extents of terminal element requested by
+"                    a:tail, else nullpos_pair
+" Exception Handling: Bare returns inside try/finally used to short-circuit remainder of
+" function, with cleanup and return value construction assured by the finally block.
+" TODO: Consider allowing caller to provide count to get non-terminal; let this be a
+" workhorse wrapped by child_range(), etc...
+" Rationale: Sometimes, you need both list info and also specific child; too much
+" duplication as it is now.
+" Partial Solution: child_range() accepts this function's return as optional arg, thereby
+" avoiding most of the duplication.
+function! s:list_info(tail)
     let cursor = getpos('.')
-    let close = sexp#current_element_terminal(1)
-    let ret = [0, 0, 0, 0]
-    " Attempt move to first non-whitespace.
-    let [l, c] = s:findpos('\S', 1)
-    if [0, l, c, 0] == close
-        " Empty form
+    let ret = {
+        \ 'macro': s:nullpos, 'brackets': [s:nullpos, s:nullpos],
+        \ 'terminal_range': s:nullpos_pair
+    \ }
+    try
+        " Make sure we get macro chars if they exist.
+        let p = s:move_to_current_element_terminal(0)
+        " Are we on a list?
+        let isl = p[1] ? s:is_list(p[1], p[2]) : 0
+        if !isl
+            " Not *on* list brackets or macro chars. Move to parent list bracket in
+            " desired direction.
+            let p = s:move_to_nearest_bracket(a:tail)
+            if p[1]
+                " Update isl to allow downstream logic to work naturally.
+                " Note: 2=open 3=close
+                let isl = a:tail + 2
+            else
+                " No current or parent list!
+                return
+            endif
+        elseif isl == 1
+            " On macro chars preceding list.
+            " Save macro char start pos and move to open bracket.
+            let ret.macro = p
+            call s:setcursor(s:current_macro_character_terminal(1))
+            call s:move_char(1)
+            " Update isl to simplify downstream logic.
+            let isl = 2
+        endif
+        " We're on open or close bracket.
+        let i = isl - 2
+        let ret.brackets[i] = getpos('.')
+        " Find the opposite bracket.
+        let ret.brackets[!i] = s:nearest_bracket(!i)
+        " Begin search for list terminal from bracket indicated by a:tail.
+        call s:setcursor(ret.brackets[a:tail])
+        " Look *inward* for first non-whitespace.
+        let [l, c] = s:findpos('\S', !a:tail)
+        if [0, l, c, 0] != ret.brackets[!a:tail]
+            " Since we didn't hit opposite bracket, not an empty list.
+            " Position on the found element and get its range, allowing for possibility
+            " that what we hit was not element terminal (due to ignored whitespace).
+            call s:setcursor([0, l, c, 0]) 
+            let ret.terminal_range =
+                \ [sexp#current_element_terminal(0), sexp#current_element_terminal(1)]
+        endif
+    finally
+        " Restore original position.
+        call s:setcursor(cursor)
         return ret
-    endif
-    call s:setcursor([0, l, c, 0]) 
-    " Just to be sure...
-    let ret = sexp#current_element_terminal(0)
-    " Restore original position.
-    call s:setcursor(cursor)
-    return ret
+    endtry
+endfunction
+
+" Like s:list_terminal() but treating entire buffer as a list
+function! s:buffer_terminal(tail)
+    let cursor = getpos('.')
+    let ret = s:nullpos_pair
+    try
+        call s:setcursor(a:tail
+            \ ? [0, line('$'), col([line('$'), '$']), 0], [0, 1, 1, 0])
+        " Look inward for first non-whitespace (possibly under cursor).
+        let [l, c] = searchpos('\S', (a:tail ? 'b' : '') . 'cW')
+        if l
+            " Found an element. Get its extents.
+            let ret = [sexp#current_element_terminal(0), sexp#current_element_terminal(1)]
+        endif
+    finally
+        call s:setcursor(cursor)
+        return ret
+    endtry
+endfunction
+
+" Return range of first/last element of current list as position pair, else nullpos pair
+" if not on or within a non-empty list.
+" -- Args --
+" tail:  0=head 1=tail
+" Note: This is really just a convenience wrapper around s:list_info(); alternatively,
+" could use s:child_range() with count of 0 or 1.
+" FIXME!!!! This is broken, which breaks cleanup_ws()!!!
+function! s:list_terminal(tail, ...)
+    let li = s:list_info(a:tail)
+    return li.terminal_range
 endfunction
 
 " Remove extra whitespace in the range determined as follows:
@@ -5088,7 +5336,7 @@ function! s:cleanup_ws(start, ps, ...)
             return
         endif
         " Descend into list.
-        let next = s:list_head()
+        let next = s:list_terminal(0)[0]
     else
         " Cleanup specified range without assuming anything about start.
         " Set things up as though loop processing is already in progress:

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3888,8 +3888,8 @@ endfunction
 
 function! s:replace_op__get_tgt(ctx)
     let ctx = a:ctx
-    " Note: For replace operator, use the register saved in the context dict at operator
-    " invocation, *not* current v:register.
+    " Note: For replace operator, use the register/count saved in the context dict at
+    " operator invocation, *not* current v:register/v:count.
     let ret = {
         \ 'mode': ctx.mode, 'put_mode': 'replace_op', 'count': ctx.count, 'P': ctx.P,
         \ 'regname': ctx.regname,

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3534,9 +3534,10 @@ function! s:regput__postop(ctx, sep, orig_range)
             let ret.orange[i] = sexp#current_element_terminal(i)
         endif
     endfor
-    " If option requests curpos target of head or tail, make adjustment.
-    let idx = !!g:sexp_regput_curpos
-    if g:sexp_regput_curpos == idx
+    " If put mode-specific option requests curpos target of head or tail, make adjustment.
+    let opt = a:ctx.put_mode =~ 'child' ? g:sexp_regput_into_curpos : g:sexp_regput_curpos
+    let idx = !!opt
+    if opt == idx
         " Desired position is 0 (head) or 1 (tail).
         " Caveat: Copy the position to prevent double-adjustment if caller adds both these
         " positions to an auto-adjustment list.

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -1428,22 +1428,6 @@ function! s:constrained_range(start, end, keep_end)
     return ret
 endfunction
 
-function! sexp#check_balance()
-    let lz_save = &lz
-    try
-        "set lz
-        new
-        a|one
-two
-.
-        redraw
-        sleep 1
-        q
-    finally
-        let &lz = lz_save
-    endtry
-endfunction
-
 " Return *effective* auto-indent range calculation method, taking g:sexp_auto_indent_range
 " and g:sexp_indent_aligns_comments into account.
 function! s:get_effective_ai_range()
@@ -2833,39 +2817,46 @@ function! s:is_multiline_put(loc, dir)
 
 endfunction
 
-" Build and return a dict characterizing the text in the put register and canonicalize the
-" register contents.
-function! s:put__get_reginfo()
+" TODO: Where to put this... Eventually, the legacy version will be more complex.
+function! s:analyze_codestr_legacy(codestr, filetype)
     " Note: Processed text added later.
     let ret = {
         \ 'reg_s_is_com': 0, 'reg_e_is_com': 0, 'reg_is_com': 0, 'reg_is_ml': 0,
     \ }
-    let regstr = getreg(v:register)
-    if regstr =~ '^\s*$'
-        " No-op!
-        let ret.text = ''
-        return ret
-    endif
     " Caveat: Vim =~ operator treats rhs like a single line; thus, literal NL ("\n") (not
     " '\n') must be used to match interior NLs. Also, ^ and $ work only at beginning/end
     " of multiline string.
-    let ret.is_ml = regstr =~ "\n"
-    let ret.s_is_com = regstr =~ '^\s*;'
-    let ret.e_is_com = regstr =~ ';.*$'
+    let ret.is_ml = codestr =~ "\n"
+    let ret.s_is_com = codestr =~ '^\s*;'
+    let ret.e_is_com = codestr =~ ';.*$'
     " TODO: Come up with less simple patterns that at least attempt to differentiate
     " between string and non-string context.
     " Flag indicating whether register is *only* a (potentially multi-line) comment.
-    let ret.has_com = regstr =~ ';'
+    let ret.has_com = codestr =~ ';'
     " TODO: Decide whether this should be single line only, given use case.
     " TODO: If this is not needed, remove!
-    let ret.is_com = regstr =~ '\(\_^\s*;.*\_$\)\+'
+    let ret.is_com = codestr =~ '\(\_^\s*;.*\_$\)\+'
     " Trim whitespace at both ends since we're adding deterministic amount.
     " Design Decision: Putting this here ensures presence of NL in raw register text will
     " influence 'is_ml'.
     " Rationale: If user performs (eg) linewise yank on comment, respect that.
     " FIXME: Needs to account for possibility of escaped whitespace; have this done by
     " function that performs language-specific validation.
-    let ret.text = substitute(regstr, '^\s\+\|\s\+$', '', 'g')
+    let ret.text = substitute(codestr, '^\s\+\|\s\+$', '', 'g')
+    return ret
+endfunction
+
+" Build and return a dict characterizing the text in the put register and canonicalize the
+" register contents.
+function! s:put__get_reginfo()
+    let regstr = getreg(v:register)
+    if regstr =~ '^\s*$'
+        " No-op!
+        let ret.text = ''
+        return ret
+    endif
+    let ret = s:invoke('analyze_codestr', regstr, &ft)
+    "echomsg string(ret)
     return ret
 endfunction
 
@@ -2914,7 +2905,8 @@ endfunction
 "   put before effective next
 "   force NL between effective next and put text iff op == 'P'
 " Else
-"   put after effective prev
+"   p = put after effective prev
+"   P = put before effective next
 " Design Decision: Although we could handle p and P the same way in the 2 ElseIf's above,
 " treating the one that puts *away from* the colinear target as a request for extra
 " separation seems intuitive and gives extra flexibility.
@@ -2969,7 +2961,10 @@ function! s:put__get_context(count, tail)
         " Design Decision: Never force NL around brackets.
         let [prev, next] = [ret.range[0], ret.range[1]]
         if curpos[1] != prev[1] && curpos[1] != next[1]
-            let ret.tail = 1
+            " Design Decision: The fact that we're not on the element (or even near it)
+            " implies direction change: intuitively, the direction of p or P in empty line
+            " selects the target element.
+            let ret.tail = !ret.tail
         elseif curpos[1] == prev[1] && curpos[1] != next[1]
             let [ret.force_nl, ret.tail] = [a:tail && ret.is_ele[0], 1]
         elseif curpos[1] == next[1] && curpos[1] != prev[1]
@@ -3013,6 +3008,77 @@ function! s:put__get_context(count, tail)
     return ret
 endfunction
 
+" TODO: Comment this!!!!!
+function! s:put__check_list_context(ctx, reg)
+    " Initialize return value to special list containing "don't care" values for sep at
+    " both ends. If list position logic applies, one or both of the values may be changed
+    " to NL or SPC.
+    let ret = ['', '']
+    let [ctx, reg] = [a:ctx, a:reg]
+    let [sidx, ps] = [0, []]
+    if !ctx.is_bra[0]
+        " Is start one of first two elements?
+        let sidx = 1
+        call s:setcursor(ctx.range[0])
+        cal add(ps, [sexp#current_element_terminal(0), ctx.range[0]])
+        while sidx <= 2
+            let prev_e = s:move_to_adjacent_element(0, 1, 0, 1)
+            if prev_e[1]
+                call add(ps, [sexp#current_element_terminal(0), prev_e])
+                let sidx += 1
+            else
+                break
+            endif
+        endwhile
+        if sidx > 2
+            " Start of range was not within 1st 2 elements of list (and possibly not even
+            " within list).
+            return ret
+        endif
+        " Since list was built moving backwards...
+        call reverse(ps)
+    endif
+    " Arrival here implies start within first two elements of list.
+    if !ctx.is_bra[1]
+        " Find last element of interest.
+        let eidx = sidx + 1
+        call s:setcursor(ctx.range[1])
+        call add(ps, [ctx.range[1], sexp#current_element_terminal(1)])
+        while eidx < 3
+            let next_s = s:move_to_adjacent_element(1, 0, 0, 1)
+            if next_s[1]
+                call add(ps, [next_s, sexp#current_element_terminal(1)])
+                let eidx += 1
+            else
+                break
+            endif
+        endwhile
+    else
+        let eidx = sidx
+    endif
+
+    " Cache some useful vars.
+    let [s1, e1] = eidx > 0 ? ps[0] : s:nullpos_pair
+    let [s2, e2] = eidx > 1 ? ps[1] : s:nullpos_pair
+    let [s3, e3] = eidx > 2 ? ps[2] : s:nullpos_pair
+    " Design Decision: No special case for multi-line head
+    let colinear12 = eidx > 1 && s1[1] == e1[1] && e1[1] == s2[1]
+    let colinear23 = eidx > 2 && e2[1] == s3[1]
+    " Note: The colinear12 condition will rule out scenarios with too few elements.
+    if colinear12 && !colinear23
+        if sidx == 0
+            " TODO: Decide whether to insert NL *after* range!!! Note that this would involve
+            " something more than near/far sep: a separate operation after the put.
+            echomsg "Would like forcible break after 2nd element!"
+        elseif sidx == 1
+            return [s:SPC, s:NL]
+        elseif sidx == 2
+            return [s:NL, '']
+        endif
+    endif
+    return ret
+endfunction
+
 " Return a list containing 3 types of separators required for the put indicated by the
 " inputs.
 " Args:
@@ -3034,12 +3100,27 @@ function! s:put__get_seps(ctx, reg)
     if ctx.empty_buffer
         let ret[0:1] = [s:EMPTY, s:EMPTY]
     else
+        " Give list position logic a chance to request separator override.
+        " Supersedence Logic: Non-N/A values in returned lpi dict supersede the normal
+        " flag logic. Since the default separator is NL, a NL in lpi clears the
+        " corresponding *_side_spc flag and a SPC sets it.
+        let lpi = s:put__check_list_context(ctx, reg)
+
         " Compute side-dependent flags used to determine SPC-insertion at both start/end.
         " Note: These flags do not incorporate comment checks, which are applied below.
-        let near_side_spc =
-            \ ctx.is_ele[!tail] && !ctx.tgt_is_alone && !ctx.force_nl && !reg.is_ml
+        let near_side_spc = !empty(lpi[!tail])
+            \ ? lpi[!tail] == s:SPC
+            \ : ctx.is_ele[!tail] && !ctx.tgt_is_alone && !ctx.force_nl && !reg.is_ml
         " Preserve colinearity at far side unless pasted text is ml.
-        let far_side_spc = ctx.adj_colinear && !reg.is_ml
+        " Note: The lack of symmetry between near/far cases is due to...
+        " 1. force_nl is inherently target-centric
+        " 2. tgt_is_alone/adj_colinear reflect unwillingness to make put text colinear
+        "    with adj unless adj was already colinear with target.
+        " Idea: Need way to parameterize this for case in which there is no fixed concept
+        " of tgt/adj: i.e., the put into command.
+        let far_side_spc = !empty(lpi[tail])
+            \ ? lpi[tail] == s:SPC
+            \ : ctx.is_ele[tail] && ctx.adj_colinear && !reg.is_ml
         "
         " Override NL (if necessary) at start.
         "

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2929,6 +2929,8 @@ endfunction
 "   tail:            Meaning varies slightly across put modes, but in some sense, this
 "                    value determines direction of put. Can be adjusted by special case
 "                    logic; hence, its inclusion here.
+"                    FIXME: I don't like setting this to 0/1 for a mode like 'replace',
+"                    for which it has no meaning: make sure it can be set to -1 safely.
 "   force_nl[]:      1 iff subsequent processing should force use of NL separator.
 "                    Currently, used only for a normal (targeted) put when cursor is not
 "                    on an element.
@@ -2987,40 +2989,46 @@ function! s:regput__get_context(tgt_info)
     " Set colinear[] and alone[] flag pairs.
     " Note: Flags are N/A for empty buffer/list special cases.
     if !ret.empty_buffer && !ret.empty_list
-        if ret.put_mode == 'replace'
-            " TODO - take inner range into account
-            " TODO: Consider cacheing either inner range ends or adj so that alone
-            " logic can be shared.
-        elseif ret.put_mode == 'replace_child'
-            " TODO!!!!
-        else " put_mode in ['put', 'put_child']
+        " Set side-specific 'alone' flags in loop.
+        for i in range(2)
+            if ret.put_mode == 'replace'
+                " TODO - take inner range into account
+                " TODO: Consider cacheing either inner range ends or adj so that alone
+                " logic can be shared.
+                let range = i
+                    \ ? [ret.inner_range[1], ret.range[1]]
+                    \ : [ret.range[0], ret.inner_range[0]]
+                let is_ele = i ? [1, ret.is_ele[1]] : [ret.is_ele[0], 1]
+                let is_bra = i ? [0, ret.is_bra[1]] : [ret.is_bra[0], 0]
+            elseif ret.put_mode == 'replace_child'
+                " TODO!!!!
+            else " put_mode in ['put', 'put_child']
+                let range = ret.range
+                let [is_ele, is_bra] = [ret.is_ele, ret.is_bra]
+            endif
             " Note: For non-replace modes, colinear[] is effectively a scalar.
-            let ret.colinear =
-                \ ret.is_ele == [1, 1] && ret.range[0][1] == ret.range[1][1]
-                \ ? [1, 1] : [0, 0]
-            " Set side-specific 'alone' flags in loop.
-            for i in range(2)
-                let [outer, outer_is_bra] = [s:nullpos, 0]
-                if !ret.is_bra[i]
-                    " Attempt to find outer adjacent.
-                    call s:setcursor(ret.range[i])
-                    let outer = s:nearest_element_terminal(i, !i, 1, 1)
-                    if !outer[1]
-                        " Pre-position on outside of element to ensure that if element is
-                        " list, nearest_bracket doesn't find its match.
-                        call s:move_to_current_element_terminal(i)
-                        let outer = s:nearest_bracket(i)
-                        if outer[1]
-                            let outer_is_bra = 1
-                        endif
+            let ret.colinear[i] = is_ele[i] && range[0][1] == range[1][1]
+
+            let [outer, outer_is_bra] = [s:nullpos, 0]
+            if !ret.is_bra[i]
+                " Attempt to find outer adjacent.
+                call s:setcursor(ret.range[i])
+                let outer = s:nearest_element_terminal(i, !i, 1, 1)
+                if !outer[1]
+                    " Pre-position on outside of element to ensure that if element is
+                    " list, nearest_bracket doesn't find its match.
+                    call s:move_to_current_element_terminal(i)
+                    let outer = s:nearest_bracket(i)
+                    if outer[1]
+                        let outer_is_bra = 1
                     endif
                 endif
-                let ret.alone[i] = ret.is_ele[i]
-                    \ && (!ret.is_ele[!i] || ret.range[0][1] != ret.range[1][1])
-                    \ && (outer_is_bra || !outer[1] || outer[1] != ret.range[i][1])
-                    \ && (!outer_is_bra || !ret.is_bra[!i] || outer[1] != ret.range[!i][1])
-            endfor
-        endif
+            endif
+            let ret.alone[i] = is_ele[i]
+                \ && (!is_ele[!i] || range[0][1] != range[1][1])
+                \ && (outer_is_bra || !outer[1] || outer[1] != range[i][1])
+                \ && (!outer_is_bra || !is_bra[!i] || outer[1] != range[!i][1])
+        endfor
     endif
     return ret
 endfunction
@@ -3298,8 +3306,9 @@ function! s:regput__impl(tgt, count, tail)
     let ps = s:concat_positions(vs, ve, ctx.range)
     " Re-indent logic needs to know whether range was colinear.
     let range_linespan = ctx.range[0][1] - ctx.range[1][1]
-    " Note: Don't set 'failsafe override': a put should change only whitespace.
-    call s:yankdel_range(spl.range[0], spl.range[1], spl.text, spl.inc, ps)
+    " Note: Set 'failsafe override' for put modes that can change non-ws.
+    call s:yankdel_range(spl.range[0], spl.range[1], spl.text, spl.inc, ps,
+        \ ctx.put_mode =~ 'replace')
     " Determine final cursor position.
     " Design Decision: Analogously to builtin p and P, always position at end;
     " however, unlike the builtins, always position on last non-ws at end.
@@ -3421,8 +3430,75 @@ function! sexp#put(count, tail)
     call s:regput__impl(tgt, count, a:tail)
 endfunction
 
-function! sexp#replace(mode, count, pvar)
-    " TODO!!!!!!!!!!!
+function! s:replace__get_tgt_visual(count)
+endfunction
+
+" Note: This mode is almost unnecessary, since the same effect could be achieved simply by
+" hitting v before the visual mapping.
+function! s:replace__get_tgt_normal(count)
+    let curpos = getpos('.')
+    " TODO: Make sure it's safe to set tail to -1; I don't like setting it to 0..1 if it's
+    " don't care...
+    let ret = {
+        \ 'error': '',
+        \ 'put_mode': 'replace',
+        \ 'range': [s:nullpos, s:nullpos],
+        \ 'inner_range': [s:nullpos, s:nullpos],
+        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
+        \ 'tail': -1, 'force_nl': [0, 0]}
+    try
+        " Look for element under cursor.
+        let p = sexp#current_element_terminal(0)
+        if !p[1]
+            " Refuse to do anything if no element under cursor!
+            " TODO: Need a way to communicate noop/error back to caller.
+            throw "sexp-warning: 'Replace with register' requires element under cursor!"
+        endif
+        " We have a current element to replace.
+        let ret.inner_range = [p, sexp#current_element_terminal(1)]
+    finally
+        call s:setcursor(curpos)
+        return ret
+    endtry
+endfunction
+
+function! s:replace__get_tgt(mode, count)
+    let tgt = a:mode == 'v'
+        \ ? s:replace__get_tgt_visual(a:count)
+        \ : s:replace__get_tgt_normal(a:count)
+    " Determine the range that contains inner_range.
+    for i in range(2)
+        call s:setcursor(tgt.inner_range[i])
+        let p = s:nearest_element_terminal(i, !i, 1, 1)
+        if p[1]
+            let tgt.is_ele[i] = 1
+        else
+            let p = s:nearest_bracket(i)
+            if p[1]
+                let tgt.is_bra[i] = 1
+            else
+                " Default to buffer extremity.
+                let p = i ? [0, line('$'), col([line('$'), '$']), 0] : s:BOF
+            endif
+        endif
+        let tgt.range[i] = p
+    endfor
+    return tgt
+endfunction
+
+" Note: tail == 1 ==> 'P'
+function! sexp#replace(mode, count, tail)
+    try
+        let count = a:count ? a:count : 1
+        " Target determination is mode-specific.
+        let tgt = s:replace__get_tgt(a:mode, count)
+
+        " Design Decision: Let tail==1 represent put with P.
+        call s:regput__impl(tgt, count, a:tail)
+    catch
+        " FIXME!!!!!
+        call sexp#warn#msg(v:exception)
+    endtry
 endfunction
 
 " Calculate and return the tgt_info dict needed by s:regput__get_context() for the case of
@@ -3495,7 +3571,7 @@ function! sexp#put_child(count, tail)
     call s:regput__impl(tgt, 1, a:tail)
 endfunction
 
-function! sexp#replace_child(count, dir, pvar)
+function! sexp#replace_child(count, dir, tail)
 endfunction
 
 " Swap current visual selection with adjacent element. If pairwise is true,

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3823,8 +3823,26 @@ function! s:regput__postop(ctx, sep, orig_range)
     return ret
 endfunction
 
-" Perform register put for all 4 command types (put, put_child, replace, replace_child)
-" and afterwards, visual mode restoration and option-dependent cursor repositioning.
+" Perform register put for *all* put modes: i.e.,
+"     put, put_op, put_op_tele, replace, replace_op, replace_op_tele, put_child
+" After the put, implement mode/option-dependent logic for the following:
+"   - visual mode restoration
+"   - cursor positioning
+"   - 'last jump' mark update
+"
+" -- Latest Jump Mark Logic --
+" We can't use the s:defplug() mechanism to update 'last jump' mark because it sets the
+" mark *prior to* the paste, *before* the adjusted position is known; thus, we use
+" Def{oper,plug}N for the regput commands and update the mark here as appropriate.
+" Conditional Logic: Set "latest jump" mark only for combinations of put_mode and 'curpos'
+" option that tend to move cursor a significant distance. Actually, even the put
+" before/after commands *can* move cursor significantly (e.g., if register contents are
+" large and cursor is being placed at far side). But normal Vim put with gp doesn't update
+" '` even for multiline puts and I've elected to treat the basic regput commands
+" analogously. Treat only the put/replace *operators* and put child specially, though even
+" with them, I'm thinking it might make sense to update '` only if movement exceeds a
+" (configurable?) number of lines. For now, however, use minimum of 1 line, just as Vim
+" does for / or ? searches.
 function! s:regput__impl(tgt, count)
     try
         " Analyze the register.
@@ -3868,6 +3886,13 @@ function! s:regput__impl(tgt, count)
         " Since visual mode commands end in normal mode, we can always respect
         " option-configurable desired curpos.
         call s:setcursor(d.curpos)
+        " See note in header for rationale behind the conditions for setting 'latest jump'
+        " mark.
+        if (a:tgt.put_mode =~ '_op' && g:sexp_regput_curpos_op != 2
+            \ || a:tgt.put_mode =~ '_child' && g:sexp_regput_curpos_child != 2)
+            \ && a:tgt.curpos[1] != d.curpos[1]
+            call setpos("'`", a:tgt.curpos)
+        endif
     catch
         " Don't warn about sexp-{abort,noop}, which are expected.
         if v:exception !~ 'sexp-\%(abort\|noop\)'

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -1807,6 +1807,7 @@ endfu
 " Return true iff there's *any* non-whitespace in the range [beg,end].
 " Note: See previous function comment for usage of 'check_ignored'.
 " TODO: Make check_ignored optional, defaulting to true.
+" TODO: Consider taking a true range (for consistency with is_uniform_range()).
 fu! sexp#range_has_non_ws(beg, end, check_ignored)
     let ret = 0
     let save_cursor = getcurpos()
@@ -3987,7 +3988,7 @@ function! s:replace__get_tgt(mode, count, tail, P, ...)
                 let rng[i] = sexp#move_to_current_element_terminal(i)
                 if !rng[i][1]
                     " Attempt to find nearest terminal in inward direction.
-                    let rng[i] = sexp#move_to_adjacent_element_terminal(!i)
+                    let rng[i] = sexp#move_to_adjacent_element_terminal(!i, i, 0)
                 endif
             endfor
             " Design Decision: Be less strict with visual selections.
@@ -4012,6 +4013,19 @@ function! s:replace__get_tgt(mode, count, tail, P, ...)
     endtry
 endfunction
 
+" !!!No longer needed!!!
+" Adjust a *normalized* range (obtained from within 'opfunc') to include the excluded char
+" if the operator's motion was exclusive.
+function! s:fix_operator_range_from_opfunc(rng, inclusive)
+    " Note: Deepcopy not really necessary, but doesn't hurt.
+    let ret = deepcopy(a:rng)
+    if !a:inclusive
+        " Offset final position in range.
+        let ret[1] = sexp#offset_char(ret[1], 1)
+    endif
+    return ret
+endfunction
+
 " Assuming the input range represents '[ and '] after a yank, and the inclusive flag was
 " extracted from the TextYankPost autocmd event, return an adjusted range representing the
 " actual yank range, which may include one additional character: e.g., after a yw, the
@@ -4027,79 +4041,117 @@ function! s:fix_operator_range(rng, inclusive)
     let ret = deepcopy(a:rng)
     if !a:inclusive
         " Offset final position in range.
-        let ret[1] = sexp#offset_char(ret[1], 1)
+        let ret[1] = sexp#offset_char(ret[1], -1)
     endif
     return ret
 endfunction
 
-" Determine whether the motion/object represented by input context dict and inclusive flag
-" (assumed to have come from a TextYankPost autocmd v:event) should be treated as a
-" "telescopic" selection motion instead of a standard motion/object, and if so, return the
-" position selected.
-function! s:regput_op__try_get_tele_pos(ctx, inclusive)
-    let ret = s:nullpos
-    let curpos = a:ctx.curpos
-    let rng = a:ctx.orange
-    if g:sexp_regput_enable_teleop
-        " Telescopic operators enabled.
-        if a:inclusive != -1
-            let rng = s:fix_operator_range(rng, a:inclusive)
-        endif
-        " Which direction was the motion search? (-1 indicates 'object' not motion).
+" Update the provided context dict to reflect the operator motion/object stored therein,
+" using both the relevant option(s) and the nature of the motion/object itself to choose
+" between "telescopic mode" and normal mode.
+" Cursor Preservation: Set cursor position appropriately if the function that performs the
+" put or replace will use it; otherwise, restore it to curpos at function entry.
+" The following fields are subject to update:
+"   put_mode
+"   orange
+" See s:regput_op__handle() for parameter descriptions.
+function! s:regput_op__process_motion(ctx, inclusive, motion)
+    " Initial curpos used to determine whether motion may have been used.
+    let [curpos, rng] = [a:ctx.curpos, a:ctx.orange]
+    " Sexp objects inhibit telescopic mode.
+    let is_sexp_motion = a:motion =~ 'sexp_\%(inner\|outer\)_'
+    " In some cases, we'll want to restore original cursor pos; set to nullpos to inhibit.
+    let save_curpos = getpos('.')
+    try
+        " Which direction was the motion search? (-1 if 'object' not motion).
         let dir = rng[0] == curpos ? 1 : rng[1] == curpos ? 0 : -1
-        if dir != -1
-            " Motion anchored at curpos; telescopic mode may be in effect.
-            if !sexp#is_uniform_range(rng)
-                " Tree levels crossed. Treat as telescopic.
-                let ret = rng[dir]
+        " Cache effective 'tail' flag (defaulting to 0)
+        let tail = a:ctx.tail != -1 ? a:ctx.tail : 0
+        if a:inclusive != -1
+            " TextYankPost (not g@) mechanism was used.
+            if g:sexp_regput_enable_teleop && !is_sexp_motion && dir != -1
+                " Telescopic mode enabled, not sexp object/motion, and motion anchored at
+                " curpos.
+                if g:sexp_regput_enable_teleop >= (a:ctx.put_mode =~ 'replace_op' ? 3 : 2)
+                    \ || !sexp#is_uniform_range(rng)
+                    " Either telescopic mode unconditionally enabled or tree levels crossed.
+                    " Treat as telescopic, provided the reached position is actually *on* a
+                    " sexp.
+                    call s:setcursor(rng[dir])
+                    " If this is a put, tail should indicate the side of the element from
+                    " which put will occur, so might as well pick that side.
+                    let p = sexp#move_to_current_element_terminal(tail)
+                    if !p[1]
+                        throw "sexp-abort: Regput telescopic mode motion must target non-ws."
+                    endif
+                    " Keep current position.
+                    let save_curpos = s:nullpos
+                    " Record conversion to telescopic mode.
+                    let a:ctx.put_mode .= "_tele"
+                    return
+                endif
             endif
+            " Not telescopic mode, but because TextYankPost mechanism was used, we need to
+            " adjust range to account for motion exclusivity.
+            let a:ctx.orange = s:fix_operator_range(a:ctx.orange, a:inclusive)
         endif
-    endif
-    return ret
+        " Not telescopic mode, and any adjustments required for operator range have been
+        " performed.
+        if a:ctx.put_mode =~ 'put_op'
+            " Note: sexp#replace() performs validation on the operator range; however,
+            " sexp#put() uses cursor pos, even if it's in whitespace, and we don't want to
+            " allow that for put operator. Also, we don't want to allow selections that
+            " cross list boundaries in non-telescopic mode.
+            if !sexp#is_uniform_range(a:ctx.orange)
+                throw "sexp-abort: put operator requires uniform range."
+                    \ . " Did you mean to enable telescopic mode?"
+                    \ . " (:help g:sexp_regput_enable_teleop)"
+            endif
+            if !sexp#range_has_non_ws(a:ctx.orange[0], a:ctx.orange[1], 1)
+                throw "sexp-abort: put operator requires non-empty range"
+            endif
+            " Position cursor on target of put, making sure we're on actual sexp.
+            call s:setcursor(rng[dir])
+            let p = sexp#move_to_current_element_terminal(tail)
+            if !p[1]
+                " Edge of range lies in whitespace; look inwards.
+                " Assumption: Prior test guarantees success.
+                let p = sexp#move_to_adjacent_element_terminal(!tail, tail, 0)
+            endif
+            " Keep current position.
+            let save_curpos = s:nullpos
+        endif
+    finally
+        " If pos is non-null, desired cursor position has already been set.
+        if save_curpos[1]
+            call s:setcursor(save_curpos)
+        endif
+    endtry
 endfunction
 
 " Augment the provided context dict, taking the type of regput operator, and if
 " applicable, the 'inclusive' flag extracted from the TextYankPost autocmd event, into
 " account.
-function! s:regput_op__handle(ctx, inclusive)
+" -- Args --
+" ctx:        context dict (see get_context() header for format)
+" inclusive:  indicates inclusivity of motion/object (-1 if unknown)
+"             Note: If opfunc mechanism (rather than TextYankPost autocmd) was used,
+"             inclusive flag is set to -1 to reflect fact that Vim has normalized the
+"             operator range without telling us whether the motion was inclusive.
+" motion:     name of sexp plug command if motion/object provided by sexp, else ""
+function! s:regput_op__handle(ctx, inclusive, motion)
+    " Cached 'orange' reflects '[ '] at the time operator was invoked; update to reflect
+    " operand.
+    let a:ctx.orange = [getpos("'["), getpos("']")]
     " Implementation Note: To avoid redundancy and eliminate risk of inconsistent
     " behavior, we delegate to non-operator-specific functions that handle both operator
     " and non-operator commands the same way. First, however, we must ensure the function
-    " will see the correct cursor position or range.
-    " Update 'orange' to reflect motion/object. Note, however, that it won't be used in
-    " "telescopic" mode.
-    " TODO: Decide whether we want to preserve new visual range or visual range at
-    " time operator was invoked.
-    let a:ctx.orange = [getpos("'["), getpos("']")]
-    " Check to see whether "telescopic" mode selected a non-local position.
-    let tele_pos = s:regput_op__try_get_tele_pos(a:ctx, a:inclusive)
+    " will see the correct cursor position and/or range.
+    call s:regput_op__process_motion(a:ctx, a:inclusive, a:motion)
     if a:ctx.put_mode =~ 'replace'
         " Replace operator
-        if tele_pos[1]
-            " TODO: Consider not changing put_mode, but having distinct is_tele flag.
-            let a:ctx.put_mode .= "_tele"
-            call s:setcursor(tele_pos)
-        endif
         call sexp#replace('n', 1, a:ctx.P, a:ctx)
     else
-        " Put before/after operator
-        " Note: Because the non-operator sexp#put function contains the logic we need,
-        " we're going to defer to it, but first we need to pre-position cursor.
-        " Rationale: Its logic is *precisely* what we want, but we want to use the
-        " searched position, not original (saved) cursor pos.
-        if tele_pos[1]
-            let a:ctx.put_mode .= "_tele"
-            " TODO: Consider not changing put_mode, but having distinct is_tele flag.
-            call s:setcursor(tele_pos)
-        else
-            " Sanity-check the selection to see whether it makes sense to support put
-            " before/after on it.
-            if !sexp#is_uniform_range(a:ctx.orange)
-                throw "Ooops! Non-uniform range can't be used here!"
-            endif
-            " Let sexp#put handle the rest.
-            call s:setcursor(a:ctx.orange[a:ctx.tail])
-        endif
         call sexp#put(1, a:ctx.tail, a:ctx)
     endif
 endfunction
@@ -4128,7 +4180,7 @@ function! sexp#regput_op(is_replace, P, ...)
         " register and ensure the handlers save/restore both it and the unnamed register.
         " TODO: Consider just returning boolean flag indicating the mode to use and
         " letting opfunc handle the details?
-        let op = v:version >= 801 && g:sexp_regput_enable_teleop ? '"zyv' : 'g@v'
+        let op = v:version >= 801 && g:sexp_regput_enable_teleop ? '"zy' : 'g@'
         " The call via 'opfunc' or TextYankPost will get the original args + the context
         " dict and the operator itself.
         return [op, function('sexp#regput_op', [a:is_replace, a:P, ctx, op])]
@@ -4137,14 +4189,14 @@ function! sexp#regput_op(is_replace, P, ...)
         " We've been invoked by our opfunc wrapper, called either as true 'opfunc' or in
         " response to a TextYankPost: in either case, we're not invoked directly by
         " sexp#plug_runtime()).
-        let [ctx, op, type, inclusive] = a:000
+        let [ctx, op, type, inclusive, motion] = a:000
         if type != 'char'
             call sexp#warn#msg("sexp#replace_op:"
                 \ " Invalid use of mode '" . type . "' with replace operator."
                 \ " Only charwise mode supported")
             return
         endif
-        call s:regput_op__handle(ctx, inclusive)
+        call s:regput_op__handle(ctx, inclusive, motion)
     catch /sexp-\%(warning\|abort\):/
         call sexp#warn#msg(v:exception)
     catch

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -4127,8 +4127,7 @@ function! s:replace__get_tgt(mode, count, tail, P, ...)
             " command execution.
             if !g:sexp_regput_replace_expanded && ret.put_mode =~ 'replace_op'
                 " Make sure original selection contained only complete S-Expressions.
-                if sexp#compare_pos(s, rng[0]) > 0
-                    \ || sexp#compare_pos(e, rng[1]) < 0
+                if sexp#compare_pos(s, rng[0]) > 0 || sexp#compare_pos(e, rng[1]) < 0
                     throw 'sexp-abort: Current setting of g:sexp_regput_replace_expanded prohibits'
                         \ . ' selecting only part of an S-Expression for replacement.'
                         \ . ' :help g:sexp_regput_replace_expanded'
@@ -4221,26 +4220,29 @@ function! s:regput_op__process_motion(ctx, inclusive, motion)
                     let save_curpos = s:nullpos
                     " Record conversion to telescopic mode.
                     let a:ctx.put_mode .= "_tele"
+                    " Note: Always return here if operator handled as telescopic.
                     return
                 endif
             endif
             " Not telescopic mode, but because TextYankPost mechanism was used, we need to
-            " adjust range to account for motion exclusivity.
+            " adjust range to account for motion exclusivity: i.e., adjust range to make
+            " it appear that g@ was used.
             let a:ctx.orange = s:fix_operator_range(a:ctx.orange, a:inclusive)
         endif
         " Not telescopic mode, and any adjustments required for operator range have been
         " performed.
+        let rng = a:ctx.orange
         if a:ctx.put_mode =~ 'put_op'
             " Note: sexp#replace() performs validation on the operator range; however,
             " sexp#put() uses cursor pos, even if it's in whitespace, and we don't want to
-            " allow that for put operator. Also, we don't want to allow selections that
-            " cross list boundaries in non-telescopic mode.
-            if !sexp#is_uniform_range(a:ctx.orange)
+            " allow that for non-telescopic put operator. Also, we don't want to allow
+            " selections that cross list boundaries in non-telescopic mode.
+            if !sexp#is_uniform_range(rng)
                 throw "sexp-abort: put operator requires uniform range."
                     \ . " Did you mean to enable telescopic mode?"
                     \ . " (:help g:sexp_regput_tele_motion)"
             endif
-            if !sexp#range_has_non_ws(a:ctx.orange[0], a:ctx.orange[1], 1)
+            if !sexp#range_has_non_ws(rng[0], rng[1], 1)
                 throw "sexp-abort: put operator requires non-empty range"
             endif
             " Position cursor on target of put, making sure we're on actual sexp.
@@ -4248,8 +4250,14 @@ function! s:regput_op__process_motion(ctx, inclusive, motion)
             let p = sexp#move_to_current_element_terminal(tail)
             if !p[1]
                 " Edge of range lies in whitespace; look inwards.
-                " Assumption: Prior test guarantees success.
+                " Assumption: Prior call to range_has_non_ws() guarantees success.
                 let p = sexp#move_to_adjacent_element_terminal(!tail, tail, 0)
+            elseif sexp#compare_pos(rng[dir], p) < 0
+                " Selection doesn't include terminal of target element in put direction!
+                throw "sexp-abort: put operator object/motion must include"
+                    \ . " target element terminal."
+                    \ . " Did you mean to enable telescopic mode?"
+                    \ . " (:help g:sexp_regput_tele_motion)"
             endif
             " Keep current position.
             let save_curpos = s:nullpos

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3814,6 +3814,26 @@ function! sexp#put(count, tail)
     endif
 endfunction
 
+function! s:replace_mode__process_inner_range(tgt)
+    " Determine the range that *contains* inner_range.
+    for i in range(2)
+        call s:setcursor(tgt.inner_range[i])
+        let p = sexp#nearest_element_terminal(i, !i, 1, 1)
+        if p[1]
+            let tgt.is_ele[i] = 1
+        else
+            let p = s:nearest_bracket(i)
+            if p[1]
+                let tgt.is_bra[i] = 1
+            else
+                " Default to buffer extremity.
+                let p = i ? [0, line('$'), col([line('$'), '$']), 0] : s:BOF
+            endif
+        endif
+        let tgt.range[i] = p
+    endfor
+endfunction
+
 " Augment provided 'tgt' dict with several range related fields, which are calculated
 " from the raw input range, which might represent a visual selection, a motion or sexp
 " object.
@@ -3839,23 +3859,6 @@ function! s:replace_mode__get_tgt(tgt, s, e)
         endif
     endfor
     let tgt.inner_range = rng
-    " Determine the range that *contains* inner_range.
-    for i in range(2)
-        call s:setcursor(tgt.inner_range[i])
-        let p = sexp#nearest_element_terminal(i, !i, 1, 1)
-        if p[1]
-            let tgt.is_ele[i] = 1
-        else
-            let p = s:nearest_bracket(i)
-            if p[1]
-                let tgt.is_bra[i] = 1
-            else
-                " Default to buffer extremity.
-                let p = i ? [0, line('$'), col([line('$'), '$']), 0] : s:BOF
-            endif
-        endif
-        let tgt.range[i] = p
-    endfor
     if !g:sexp_regput_replace_expanded
         " Make sure original selection contained only complete S-Expressions.
         if sexp#compare_pos(s, tgt.inner_range[0]) > 0
@@ -3864,6 +3867,8 @@ function! s:replace_mode__get_tgt(tgt, s, e)
                 \ . ' selecting only part of an S-Expression for replacement.'
         endif
     endif
+    " Post-process inner_range.
+    call s:replace_mode__process_inner_range(tgt)
 endfunction
 
 function! s:replace__get_tgt(put_mode, mode, count, tail, P)
@@ -3886,6 +3891,40 @@ function! s:replace__get_tgt(put_mode, mode, count, tail, P)
     endtry
 endfunction
 
+" Assuming operator motion was exclusive, convert range to fiducial inclusive.
+function! s:fix_operator_range(rng)
+endfunction
+
+function! s:replace_op__try_get_endpoint_tgt(ctx, s, e, allow_same_level)
+    echomsg "c:" getpos('.') "[:" getpos("'[") "]:" getpos("']")
+    let [ctx] = [a:ctx]
+    let rng = [a:s, a:e]
+    " Which direction was the motion search? (-1 indicates 'object' not motion).
+    let dir = a:s == ctx.curpos ? 1 : s:e == ctx.curpos ? 0 : -1
+    if dir == -1
+        " Motion not anchored at curpos; thus, endpoint mode not in effect.
+        return 0
+    endif
+    if !a:allow_same_level && sexp#is_uniform_range(rng)
+        " Motion did not cross levels; endpoint mode not in effect.
+        return 0
+    endif
+    " Determine the target sexp.
+    call s:setcursor(rng[dir])
+    let p = sexp#current_element_terminal(0)
+    if !p[1]
+        " Endpoint mode requires an endpoint strictly *on* an element; since we don't have
+        " that, just fallback to non-endpoint processing.
+        return 0
+    endif
+    " We're on an element; use its range.
+    let ctx.inner_range = [p, sexp#current_element_terminal(1)]
+    " Post-process inner range.
+    call s:replace_mode__process_inner_range(ctx)
+    " Return true to prevent fallback to non-endpoint mode.
+    return 1
+endfunction
+
 function! s:replace_op__get_tgt(ctx)
     let ctx = a:ctx
     " Note: For replace operator, use the register/count saved in the context dict at
@@ -3901,13 +3940,20 @@ function! s:replace_op__get_tgt(ctx)
     try
         let [s, e] = [getpos("'["), getpos("']")]
         "let [s_orig, e_orig] = [s[:], e[:]]
-        call s:replace_mode__get_tgt(ret, s, e)
+        " First, attempt to process as "endpoint" motion (unless inhibited by option).
+        " TODO: 0 is placeholder; eventually, explicit endpoint mode operator will cause
+        " it to be set.
+        if !s:replace_op__try_get_endpoint_tgt(ret, s, e, 0)
+            " Fallback to non-endpoint mode.
+            call s:replace_mode__get_tgt(ret, s, e)
+        endif
         return ret
     finally
         call s:setcursor(ctx.curpos)
     endtry
 endfunction
 
+" TODO: Probably add a parameter for the motion mode.
 function! sexp#replace_op(mode, count, P, ...)
     if !a:0
         " Initial call (invoked explicitly, not via Vim's opfunc engine)

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -460,7 +460,7 @@ function! s:current_macro_character_terminal(end)
     return [0, termline, termcol, 0]
 endfunction
 
-" Return range [start,end] for element under the cursor, else [nullpos, nullpos].
+" Return range as [start,end] for element under the cursor, else [nullpos, nullpos].
 function! sexp#current_element_terminals()
     let s = sexp#current_element_terminal(0)
     if s[1]
@@ -3026,6 +3026,36 @@ function! s:analyze_codestr_legacy(codestr, filetype)
     return sexp#parse#analyze_codestr(a:codestr, a:filetype)
 endfunction
 
+" Create and return a context dict with a superset of the keys required by the various
+" regput modes, providing reasonable defaults where they exist, and giving precedence to
+" any defaults provided by caller in optional override dict.
+" Objective: Mitigate risk of error by ensuring all regput functions can rely on a
+" consistent format.
+" Note: Keys for which no reasonable default exists, and for which no initial value is
+" provided, will be set to invalid values (e.g., nullpos).
+function! s:regput__ctx_init(mode, put_mode, count, ...)
+    let ctx = {
+        \ 'mode': a:mode,
+        \ 'put_mode': a:put_mode,
+        \ 'count': a:count,
+        \ 'curpos': getpos('.'),
+        \ 'regname': v:register,
+        \ 'backtick': getpos("'`"),
+        \ 'P': -1,
+        \ 'tail': -1,
+        \ 'vrange': s:get_visual_marks(),
+        \ 'orange': [getpos("'["), getpos("']")],
+        \ 'range': [s:nullpos, s:nullpos],
+        \ 'inner_range': [s:nullpos, s:nullpos],
+        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
+        \ 'force_nl': [0, 0],
+    \ }
+    if a:0
+        let ctx = extend(ctx, a:1)
+    endif
+    return ctx
+endfunction
+
 " Note: This version does everything manually, with no parsing.
 " It has been superseded by s:analyze_codestr_legacy(), which delegates the actual parsing
 " to sexp#parse#analyze_codestr(); however, I may allow it to be selected by expert (or
@@ -3067,6 +3097,9 @@ function! s:analyze_codestr_simple(codestr, filetype)
     return ret
 endfunction
 
+" Return option value that applies to the specified put_mode.
+" TODO: This function is complicated by an option inheritance scheme, which may be going
+" away, in favor of a simpler one.
 function! s:regput__get_curpos_opt(put_mode)
     let default = g:sexp_regput_curpos
     " Just in case user has set to something invalid...
@@ -3196,7 +3229,9 @@ endfunction
 "   Note: List keys are pairs whose indices correspond to the elements of range[].
 "   --[[ Beginning of merged-in tgt_info dict
 "   count:           [count] associated with the operation
-"   put_mode:        one of 'put', 'put_child', 'replace', 'replace_op', 'replace_op_tele'
+"   put_mode:        one of the following:
+"                    'put', 'put_child', 'put_op', 'put_op_tele',
+"                    'replace', 'replace_op', 'replace_op_tele'
 "   tail:            At the time of command invocation, 'tail' indicates either the put
 "                    *direction* (non-child put) or the *side* of the list from which the
 "                    insert location is calculated (child put). At this point, however,
@@ -3652,7 +3687,6 @@ function! s:regput__postop(ctx, sep, orig_range)
         endif
     endfor
     " If put mode-specific option requests curpos target of head or tail, make adjustment.
-    " FIXME: Several more modes to consider: op and op_tele
     let opt = s:regput__get_curpos_opt(a:ctx.put_mode)
     let idx = !!opt
     if opt == idx
@@ -3741,7 +3775,11 @@ endfunction
 
 " Calculate and return the tgt_info dict needed by s:regput__get_context() for a 'put'
 " command.
-" Note: For details, see header of s:regput__get_context().
+" Note: In addition to the basic put before/after, this function also handles
+" put_op[_tele], in that case, caller supplies a pre-initialized context dict for us to
+" augment.
+" Note: For details, on the format of the context dict, see header of
+" s:regput__get_context().
 " -- Args --
 " count:        the sexp command count
 " tail:         put direction flag (0=before 1=after)
@@ -3846,9 +3884,8 @@ function! s:put__get_tgt(count, tail, ...)
     endtry
 endfunction
 
-" If all conditions are met for converting a put before/after to the corresponding put
-" child, return 1.
-" FIXME: This is going away, obsoleted by the put operators.
+" Return 1 iff all conditions are met for converting a put before/after to the
+" corresponding put into list.
 function! s:regput__handle_as_put_into_empty_list(count, tail)
     if !g:sexp_regput_bracket_is_target
         " Feature disabled by user config
@@ -3869,7 +3906,8 @@ function! s:regput__handle_as_put_into_empty_list(count, tail)
 endfunction
 
 " Put before/after (both normal and operator variants)
-" Note: Optional ctx dict provided by caller if invoked internally by operator mechanism.
+" Note: Optional context dict provided by caller if invoked internally by operator
+" mechanism.
 function! sexp#put(count, tail, ...)
     if s:regput__handle_as_put_into_empty_list(a:count, a:tail)
         " All conditions met for converting put to put_child!
@@ -3884,9 +3922,10 @@ function! sexp#put(count, tail, ...)
     endif
 endfunction
 
-" Augment provided 'tgt' dict with several range related fields, which are calculated from
-" the raw input range, which might represent a visual selection, a motion or sexp object.
-function! s:replace_mode__process_inner_range(tgt)
+" Augment provided tgt/ctx dict with several range related fields, calculated from the raw
+" input range, which might represent a visual selection, an operator motion or a sexp
+" object.
+function! s:replace__process_inner_range(tgt)
     let tgt = a:tgt
     " Determine the range that *contains* inner_range.
     for i in range(2)
@@ -3907,38 +3946,25 @@ function! s:replace_mode__process_inner_range(tgt)
     endfor
 endfunction
 
-" TODO: Move this...
-function! s:regput__ctx_init(mode, put_mode, count, ...)
-    " Create dict with superset of keys required for various regput modes.
-    " Provide reasonable defaults where they exist, giving precedence to any defaults
-    " provided by caller in optional override dict.
-    let ctx = {
-        \ 'mode': a:mode,
-        \ 'put_mode': a:put_mode,
-        \ 'count': a:count,
-        \ 'curpos': getpos('.'),
-        \ 'regname': v:register,
-        \ 'backtick': getpos("'`"),
-        \ 'P': -1,
-        \ 'tail': -1,
-        \ 'vrange': s:get_visual_marks(),
-        \ 'orange': [getpos("'["), getpos("']")],
-        \ 'range': [s:nullpos, s:nullpos],
-        \ 'inner_range': [s:nullpos, s:nullpos],
-        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
-        \ 'force_nl': [0, 0],
-    \ }
-    if a:0
-        let ctx = extend(ctx, a:1)
-    endif
-    return ctx
-endfunction
-
+" Either create and initialize a context dict, or populate the one provided by caller. If
+" no context dict is provided by caller, command is assumed to be normal or visual replace
+" command; otherwise, it's the replace operator variant indicated by input context dict's
+" 'put_mode' field.
+" Cursor Assumptions: For certain command/operator variants, the cursor position on entry
+" to this function determines the replace target; in those cases, we assume caller has
+" pre-positioned cursor appropriately.
+" Cursor Preservation: Saved/restored
 function! s:replace__get_tgt(mode, count, tail, P, ...)
-    let ret = a:0 && !empty(a:1) ? a:1 : s:regput__ctx_init(a:mode, 'replace', a:count)
+    let ret = a:0 && !empty(a:1)
+        \ ? a:1
+        \ : s:regput__ctx_init(a:mode, 'replace', a:count, {'P': a:P})
     let curpos = getpos('.')
     try
-        if a:mode ==? 'n' && ret.put_mode != 'replace_op'
+        " Note: Normal mode replace command and telescopic replace operator use cursor
+        " position; all other commands use either visual or operator range and are handled
+        " in the else.
+        if a:mode ==? 'n' && ret.put_mode == 'replace'
+            \ || ret.put_mode == 'replace_op_tele'
             " Assumption: Caller has positioned cursor correctly.
             let rng = sexp#current_element_terminals()
             if !rng[0][1]
@@ -3979,14 +4005,23 @@ function! s:replace__get_tgt(mode, count, tail, P, ...)
         endif
         let ret.inner_range = rng
         " Post-process inner_range.
-        call s:replace_mode__process_inner_range(ret)
+        call s:replace__process_inner_range(ret)
         return ret
     finally
         call s:setcursor(curpos)
     endtry
 endfunction
 
-" Assuming operator motion was exclusive, convert range to fiducial inclusive.
+" Assuming the input range represents '[ and '] after a yank, and the inclusive flag was
+" extracted from the TextYankPost autocmd event, return an adjusted range representing the
+" actual yank range, which may include one additional character: e.g., after a yw, the
+" input range would not include the first char of the subsequent word but the returned
+" range would.
+" Motivation: Regput "telescopic" operators need to know what was actually searched for
+" when the search is exclusive. Unfortunately, an 'opfunc' is not provided any information
+" on the inclusivity of the motion that triggered the opfunc. Thus, we use a yank in lieu
+" of g@, explicitly invoking what would have been the 'opfunc' in the TextYankPost
+" handler where we have access to v:event.inclusive, which is passed to this function.
 function! s:fix_operator_range(rng, inclusive)
     let ret = deepcopy(a:rng)
     if !a:inclusive
@@ -3996,14 +4031,16 @@ function! s:fix_operator_range(rng, inclusive)
     return ret
 endfunction
 
-" FIXME: This is intended to replace the subsequent function.
+" Determine whether the motion/object represented by input context dict and inclusive flag
+" (assumed to have come from a TextYankPost autocmd v:event) should be treated as a
+" "telescopic" selection motion instead of a standard motion/object, and if so, return the
+" position selected.
 function! s:regput_op__try_get_tele_pos(ctx, inclusive)
     let ret = s:nullpos
     let curpos = a:ctx.curpos
-    let [s, e] = [getpos("'["), getpos("']")]
+    let rng = a:ctx.orange
     if g:sexp_regput_enable_teleop
         " Telescopic operators enabled.
-        let rng = [s[:], e[:]]
         if a:inclusive != -1
             let rng = s:fix_operator_range(rng, a:inclusive)
         endif
@@ -4023,38 +4060,47 @@ endfunction
 " Augment the provided context dict, taking the type of regput operator, and if
 " applicable, the 'inclusive' flag extracted from the TextYankPost autocmd event, into
 " account.
-function! s:replace_op__handle(ctx, inclusive)
-    let ctx = a:ctx
-    " Check to see whether telescopic mode selected a non-local position.
-    let tele_pos = s:regput_op__try_get_tele_pos(ctx, a:inclusive)
-    if tele_pos[1]
-        " TODO: Consider not changing put_mode, but having distinct is_tele flag.
-        let ctx.put_mode .= "_tele"
-        call s:setcursor(tele_pos)
-    endif
-    call sexp#replace('n', 1, ctx.P, ctx)
-endfunction
-
-function! s:put_op__handle(ctx, inclusive)
-    " Check to see whether telescopic mode selected a non-local position.
+function! s:regput_op__handle(ctx, inclusive)
+    " Implementation Note: To avoid redundancy and eliminate risk of inconsistent
+    " behavior, we delegate to non-operator-specific functions that handle both operator
+    " and non-operator commands the same way. First, however, we must ensure the function
+    " will see the correct cursor position or range.
+    " Update 'orange' to reflect motion/object. Note, however, that it won't be used in
+    " "telescopic" mode.
+    " TODO: Decide whether we want to preserve new visual range or visual range at
+    " time operator was invoked.
+    let a:ctx.orange = [getpos("'["), getpos("']")]
+    " Check to see whether "telescopic" mode selected a non-local position.
     let tele_pos = s:regput_op__try_get_tele_pos(a:ctx, a:inclusive)
-    " Let the non-operator put_{before,after} function augment context dict.
-    " Rationale: Its logic is *precisely* what we want, but we want to use the
-    " searched position, not original (saved) cursor pos.
-    if tele_pos[1]
-        let a:ctx.put_mode .= "_tele"
-        " TODO: Consider not changing put_mode, but having distinct is_tele flag.
-        call s:setcursor(tele_pos)
-    else
-        " Sanity-check the selection to see whether it makes sense to support put
-        " before/after on it.
-        if !sexp#is_uniform_range(a:ctx.orange)
-            throw "Ooops! Non-uniform range can't be used here!"
+    if a:ctx.put_mode =~ 'replace'
+        " Replace operator
+        if tele_pos[1]
+            " TODO: Consider not changing put_mode, but having distinct is_tele flag.
+            let a:ctx.put_mode .= "_tele"
+            call s:setcursor(tele_pos)
         endif
-        " Let sexp#put handle the rest.
-        call s:setcursor(a:ctx.orange[a:ctx.tail])
+        call sexp#replace('n', 1, a:ctx.P, a:ctx)
+    else
+        " Put before/after operator
+        " Note: Because the non-operator sexp#put function contains the logic we need,
+        " we're going to defer to it, but first we need to pre-position cursor.
+        " Rationale: Its logic is *precisely* what we want, but we want to use the
+        " searched position, not original (saved) cursor pos.
+        if tele_pos[1]
+            let a:ctx.put_mode .= "_tele"
+            " TODO: Consider not changing put_mode, but having distinct is_tele flag.
+            call s:setcursor(tele_pos)
+        else
+            " Sanity-check the selection to see whether it makes sense to support put
+            " before/after on it.
+            if !sexp#is_uniform_range(a:ctx.orange)
+                throw "Ooops! Non-uniform range can't be used here!"
+            endif
+            " Let sexp#put handle the rest.
+            call s:setcursor(a:ctx.orange[a:ctx.tail])
+        endif
+        call sexp#put(1, a:ctx.tail, a:ctx)
     endif
-    call sexp#put(1, a:ctx.tail, a:ctx)
 endfunction
 
 " Note: This function used for both replace_op and put_op and "P" has meaning (albeit
@@ -4097,15 +4143,7 @@ function! sexp#regput_op(is_replace, P, ...)
                 \ " Only charwise mode supported")
             return
         endif
-        " Update 'orange' to reflect motion/object.
-        " TODO: Decide whether we want to preserve new visual range or visual range at
-        " time operator was invoked.
-        let ctx.orange = [getpos("'["), getpos("']")]
-        if a:is_replace
-            call s:replace_op__handle(ctx, inclusive)
-        else
-            call s:put_op__handle(ctx, inclusive)
-        endif
+        call s:regput_op__handle(ctx, inclusive)
     catch /sexp-\%(warning\|abort\):/
         call sexp#warn#msg(v:exception)
     catch
@@ -4216,6 +4254,7 @@ function! s:put_child__get_tgt(count, tail, ...)
     endtry
 endfunction
 
+" Put at head/tail of list.
 function! sexp#put_child(count, tail, ...)
     let cnt = a:count ? a:count : 1
     let tgt = s:put_child__get_tgt(cnt, a:tail, a:0 ? a:1 : {})

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -510,10 +510,9 @@ endfunction
 
 " Returns position of previous/next element's head/tail.
 " Returns current element's terminal if no adjacent element exists, unless optional
-" 'ignore_current' argument is set, in which case, return unmodified current position.
-" TODO: Currently, returns initial position unmodified if no adjacent and no current. Is
-" this best approach? It's always worked like this, so changing it to (eg) null pos should
-" not be done without significant analysis/testing.
+" 'ignore_current' argument is set, in which case, return unmodified current position,
+" unless 'nullpos_on_fail' (2nd optional arg) is also set, in which case, return nullpos.
+" TODO: Convert the optional args to a (possibly optional) flags dict.
 function! s:nearest_element_terminal(next, tail, ...)
     let cursor = getpos('.')
     let pos = cursor
@@ -1251,7 +1250,7 @@ function! s:offset_char(pos, dir, ...)
                     " Empty line
                     if a:pos[1] == 1
                         " Special Case: BOF
-                        let pos = [0, 1, 0, 0]
+                        let pos = [0, 1, -1, 0]
                     else
                         " Need to consider inc_nl
                         let prev_eol = col([a:pos[1] - 1, '$'])
@@ -2805,11 +2804,16 @@ endfunction
 " Build and return a dict characterizing the text in the put register and canonicalize the
 " register contents.
 function! s:put__get_reginfo()
-    let regstr = getreg(v:register)
     " Note: Processed text added later.
     let ret = {
         \ 'reg_s_is_com': 0, 'reg_e_is_com': 0, 'reg_is_com': 0, 'reg_is_ml': 0,
     \ }
+    let regstr = getreg(v:register)
+    if regstr =~ '^\s*$'
+        " No-op!
+        let ret.text = ''
+        return ret
+    endif
     let ret.is_ml = regstr =~ '\n'
     let ret.s_is_com = regstr =~ '^\s*;'
     let ret.e_is_com = regstr =~ ';\s*$'
@@ -2842,6 +2846,7 @@ endfunction
 "   tgt_is_alone:    target is alone on its line, with possible exception of open or
 "                    close, but not both
 "   tgt_is_terminal: target is head or tail of list in put direction
+"   tgt_is_open:     determines whether tgt represents position of element or open bracket
 "   adj_colinear:    element adjacent to target on put side is colinear with target
 "   empty_list:      putting into empty list
 "   empty_buffer:    putting into empty buffer
@@ -2862,20 +2867,21 @@ function! s:put__get_context(count, tail)
     let t = sexp#current_element_terminal(a:tail)
     if !t[1]
         " Nothing under cursor; see if there's a next element.
-        let t = s:nearest_element_terminal(1, a:tail)
+        let t = s:nearest_element_terminal(1, a:tail, 1, 1)
         if !t[1]
             " Fall back to prev element.
-            let t = s:nearest_element_terminal(0, a:tail)
+            let t = s:nearest_element_terminal(0, a:tail, 1, 1)
             if !t[1]
-                " Must be empty list; treat like 'put after' with cursor on virtual
-                " element located at open bracket.
-                " Note: This type of put would be more likely to use the "put into list"
-                " put variant.
-                let t = s:nearest_bracket(0)
+                " Must be empty list or empty buffer.
+                " Design Decision: Let tgt/adj brackets be determined by put direction.
+                " Rationale: Minimizes need for special handling downstream.
+                let t = s:nearest_bracket(!a:tail)
                 if t[1]
-                    " Note: Could also name this flag put_into_empty.
-                    let ret.tgt_is_open = 1
-                    " TODO: Decide on name: keep only one.
+                    " Treat like 'put after' with cursor on virtual element located at
+                    " open bracket.
+                    " Note: This type of put would be more likely to use the "put into
+                    " list" put variant.
+                    let [ret.tgt_is_terminal, ret.tgt_is_open] = [1, 1]
                     let ret.empty_list = 1
                 else
                     " Empty buffer?
@@ -2887,14 +2893,24 @@ function! s:put__get_context(count, tail)
             endif
         endif
     endif
-    " Assumption: t is on desired (put) side of tgt.
+    " Assumption: t is on desired (put) side of tgt (or on open/close bracket in case of
+    " empty list).
     let ret.tgt = t
     call s:setcursor(ret.tgt)
-    if !ret.empty_list && !ret.empty_buffer
-        " Find near side of adjacent
-        " Note: Optional flag forces return of same position if no adjacent.
-        " FIXME!!!! How is ret.adj being left at nullpos??????
-        let adj = s:nearest_element_terminal(a:tail, !a:tail, 1)
+    if ret.empty_list
+        " Treat empty list as special case to avoid complicating the logic for case
+        " involving actual (non-bracket) target. See earlier comment regarding rationale
+        " behind use of a:tail.
+        let ret.adj_bracket = s:nearest_bracket(a:tail)
+        " Design Decision: Treat empty list as having colinear open/close.
+        " Rationale: With no contained elements, there's no reason to force multi-line
+        " context.
+        let ret.adj_colinear = ret.tgt[1] == ret.adj_bracket[1]
+        let [ret.tgt_is_terminal, ret.tgt_is_alone, ret.at_top] = [1, 0, 0]
+    elseif !ret.empty_buffer
+        " Find near side of adjacent (else closing bracket).
+        " Note: Optional flags force return of nullpos if no adjacent.
+        let adj = s:nearest_element_terminal(a:tail, !a:tail, 1, 1)
         if adj[1]
             " Found an adjacent element.
             let ret.adj = adj
@@ -2907,9 +2923,9 @@ function! s:put__get_context(count, tail)
             let adj_bracket = s:nearest_bracket(a:tail)
         endif
         let ret.adj_bracket = adj_bracket
-        " Check other (away) side of target, passing 'ignore_current' to ensure nullpos
-        " returned if no adjacent.
-        let away = s:nearest_element_terminal(!a:tail, a:tail, 1)
+        " Check other (away) side of target, passing 'ignore_current' and
+        " 'nullpos_on_fail' to ensure nullpos returned if no adjacent.
+        let away = s:nearest_element_terminal(!a:tail, a:tail, 1, 1)
         " Find away bracket unconditionally (even if away is not nullpos) to obviate need
         " for at_top() call; however, put nullpos in return dict if away is non-null.
         " Note: Must position on far side of away element before looking for bracket.
@@ -2929,7 +2945,7 @@ function! s:put__get_context(count, tail)
         " bracket is irrelevant if the intervening element exists.
         let ret.tgt_is_terminal = !adj[1] && adj_bracket[1]
     else
-        " Special Case: empty list or empty buffer
+        " Special Case: empty buffer
         let ret.at_top = ret.empty_buffer
     endif
     return ret
@@ -2982,13 +2998,14 @@ function! s:put__get_seps(tail, ctx, reg)
     " -- Far separator
     " Logic: Default (else) to NL, with special cases requiring SPC/EMPTY in the
     " if/elseifs.
-    if ctx.adj_colinear && !reg.is_ml
+    if ctx.empty_buffer
+        \ || ((ctx.empty_list || ctx.tgt_is_terminal)
+        \     && !(tail && reg.e_is_com || !tail && reg.s_is_com))
+        " Safe to butt register up against bracket (or edge of buffer).
+        let ret.far_sep = EMPTY
+    elseif ctx.adj_colinear && !reg.is_ml
         " Preserve colinearity unless pasted text is ml.
         let ret.far_sep = SPC
-    elseif ctx.tgt_is_terminal 
-        \ && !(tail && reg.e_is_com || !tail && reg.s_is_com)
-        " Safe to butt register up against bracket
-        let ret.far_sep = EMPTY
     elseif ctx.tgt_is_terminal && !tail && reg.s_is_com
         " Start of comment can be separated from terminal by single space.
         let ret.far_sep = SPC
@@ -3011,49 +3028,6 @@ function! s:put__get_seps(tail, ctx, reg)
     "   Rationale: The logic that determined a NL should separate tgt from put text would
     "   quite naturally extend to subsequent copies of the put text.
     let ret.interior_sep = reg.is_ml || reg.has_com || ret.near_sep == NL ? NL : SPC
-    return ret
-endfunction
-
-" Calculate and return (unadjusted) range that will need to be re-indented after the put
-" described by the inputs is performed.
-" Note: The returned range will need to be adjusted to account for the put.
-" Return:
-"   [pos]        position of bracket for list to indent
-"   [start, end] start/end of range to adjust
-" TODO: OBSOLETE!!! Remove if not needed.
-function! s:put__get_reindent_range(tail, ctx, reg, sep)
-    let ret = [s:nullpos, s:nullpos]
-    let [ctx, reg, sep] = [a:ctx, a:reg, a:sep]
-    if ctx.empty_list
-    elseif ctx.empty_buffer
-    else
-        " Start of range
-        " Assumption: Arrival here guarantees presence of either adj or adj_bracket.
-        " NO!!! Could be a single element in buffer: i.e., tgt but !adj
-        " Also Note: In theory, pasting at head of list can necessitate re-indent of
-        " parent.
-        let ret[0] = a:tail ? ctx.tgt : ctx.adj[1] ? ctx.adj : ctx.adj_bracket
-        " End of range
-        " Assumption: SPC separator implies existence of adj/away element.
-        let extra_el = a:tail && sep.far_sep == ' '
-            \ ? ctx.adj
-            \ : !a:tail && sep.near_sep == ' '
-            \ ? ctx.away
-            \ : s:nullpos
-        if extra_el[1]
-            " Assumption: SPC sep implies actual adj element.
-            call s:setcursor(extra_el)
-            " Need far side of adj
-            let ret[1] = sexp#current_element_terminal(1)
-        else
-            " Don't need to indent extra element. If this is a tail put, leave at nullpos
-            " to have end of range taken from ']; otherwise, start of tgt marks end of
-            " range.
-            if !a:tail
-                let ret[1] = ctx.tgt
-            endif
-        endif
-    endif
     return ret
 endfunction
 
@@ -3093,10 +3067,13 @@ function! s:last_colinear_sibling(tail)
     endtry
 endfunction
 
+" Return a dict that characterizes the splice (or directed put) to be performed as the set
+" of arguments to s:yankdel_range().
 function! s:put__get_splice_info(count, tail, ctx, reg, sep, flags)
     let ret = { 'range': [s:nullpos, s:nullpos], 'text': '', 'inc': 0}
     let [ctx, reg, sep] = [a:ctx, a:reg, a:sep]
     let [NL, SPC, EMPTY] = ["\n", " ", ""]
+    let [near_sep, interior_sep, far_sep] = [sep.near_sep, sep.interior_sep, sep.far_sep]
 
     " Set the target-side splice position.
     " Assumption: Currently, ctx.tgt is always set to something non-null.
@@ -3104,52 +3081,54 @@ function! s:put__get_splice_info(count, tail, ctx, reg, sep, flags)
     let ret.range[!a:tail] = ctx.tgt
     call s:setcursor(ctx.tgt)
     " Determine the range.
-    if ctx.empty_list
-        " TODO
-    elseif ctx.empty_buffer
-        " Just put in indicated direction.
-        " TODO: Should we eat whitespace?
+    " Nominal case: we have a target to put before/after.
+    " Note: Target could be element or open bracket.
+    " Note: This handles both nominal and empty_list cases.
+    let adj_pos = ctx.adj[1] ? ctx.adj : ctx.adj_bracket[1] ? ctx.adj_bracket : s:nullpos
+    if ctx.empty_buffer
+        " Replace entire buffer (possibly ws or maybe just NUL char at head).
+        let ret.range = [[0, 1, 1, 0], [0, line('$'), col([line('$'), '$']), 0]]
+        let ret.inc = [1, 1]
+    elseif !adj_pos[1]
+        " No element or bracket in direction of put, so put to BOF or EOF.
+        " Note: Empty buffer case currently handled separately in if, but could be handled
+        " here if we wanted to replace only whitespace in direction of put.
+        let ret.range[a:tail] = a:tail
+            \ ? [0, line('$'), col([line('$'), '$']), 0]
+            \ : [0, 1, 1, 0]
+        " Note: The following resolves to a directed put towards BOF/EOF if no whitespace
+        " separates tgt position from BOF/EOF.
+        let ret.inc = a:tail ? [0, 1] : [1, 0]
     else
-        " Nominal case: we have a target to put before/after.
-        let adj_pos = ctx.adj[1] ? ctx.adj : ctx.adj_bracket[1] ? ctx.adj_bracket : s:nullpos
-        if !adj_pos[1]
-            " No element or bracket in direction of put, so put to BOF or EOF.
-            let ret.range[a:tail] = a:tail
-                \ ? [0, line('$'), col([line('$'), '$']), 0]
-                \ : [0, 1, 1, 0]
-            " Use directed put (direction determined by inclusive end).
-            let ret.inc = a:tail ? [0, 1] : [1, 0]
-        else
-            " There's something adjacent to target to anchor splice at other end.
-            let ret.range[a:tail] = adj_pos
-            let [near_sep, far_sep] = [sep.near_sep, sep.far_sep]
-            " May be set to 2 (EOL-exclusive) later.
-            let exc_typ = 0
-            if far_sep == NL
-                " Determine number of newlines to prepend/append on far side of put text,
-                " as function of number of blank lines between target and adjacent (taking
-                " options into account).
-                let gap = ret.range[1][1] - ret.range[0][1]
-                let num_nl = min([gap, g:sexp_cleanup_keep_empty_lines + 1])
-                if a:tail
-                    " Keep the final NL to avoid clobbering leading indent.
-                    " Rationale: Permits earlier "clean point" for re-indent.
-                    let exc_typ = 2
-                    let num_nl -= 1
-                endif
-                let far_sep = repeat("\n", num_nl)
+        " There's something adjacent to target to anchor splice at other end.
+        let ret.range[a:tail] = adj_pos
+        " May be set to 2 (EOL-exclusive) later.
+        let exc_typ = 0
+        if far_sep == NL
+            " Determine number of newlines to prepend/append on far side of put text,
+            " as function of number of blank lines between target and adjacent (taking
+            " options into account).
+            let gap = ret.range[1][1] - ret.range[0][1]
+            " Note: Because far_sep has been determined to be NL, we must ensure a
+            " min gap of 1, even if tgt and adj are currently colinear.
+            let num_nl = min([max([gap, 1]), g:sexp_cleanup_keep_empty_lines + 1])
+            if a:tail
+                " Use adjacent whitespace-exclusive mode at end to preserve any
+                " leading indent on line following the put.
+                " Rationale: Permits earlier "clean point" for re-indent; otherwise,
+                " we'd have to include at least one extra element at tail.
+                let exc_typ = 2
             endif
-            " Build splice string.
-            " TODO: Refactor this into a function somehow, since something similar is used
-            " elsewhere (for cloning, I think).
-            " TODO: Do we need to consider 'collapse whitespace' option?
-            let t = repeat([reg.text], a:count)
-            let t = join(t, sep.interior_sep)
-            let t = a:tail ? near_sep . t . far_sep : far_sep . t . near_sep
-            let ret.text = t
-            let ret.inc = [0, exc_typ]
+            let far_sep = repeat("\n", num_nl)
         endif
+        let ret.inc = [0, exc_typ]
     endif
+    " Build splice string.
+    " TODO: Refactor this into a function somehow, since something similar is used
+    " elsewhere (for cloning, I think).
+    " TODO: Do we need to consider 'collapse whitespace' option?
+    let t = join(repeat([reg.text], a:count), interior_sep)
+    let ret.text = a:tail ? near_sep . t . far_sep : far_sep . t . near_sep
     return ret
 endfunction
 
@@ -3157,39 +3136,60 @@ function! sexp#put(count, tail)
     " Save/adjust visual marks.
     let [vs, ve] = s:get_visual_marks()
     let count = a:count ? a:count : 1
+    let [NL, SPC, EMPTY] = ["\n", " ", ""]
     " Calculate the put.
     let reg = s:put__get_reginfo()
+    if empty(reg.text)
+        " Treat empty text like NOOP!
+        return
+    endif
     let ctx = s:put__get_context(count, a:tail)
     let sep = s:put__get_seps(a:tail, ctx, reg)
     let spl = s:put__get_splice_info(count, a:tail, ctx, reg, sep, {})
     let ps = [vs, ve]
-    if !spl.range[1][1]
-        " TODO: Consider handling this with simple p/P: i.e., without yankdel_range().
-        " Question: Do we need yankdel_range for position adjustments?
-        echoerr "FIXME: WIP!!!"
-    else
-        " TODO: Consider having put__get_context() build the position list.
-        let ps = s:concat_positions(vs, ve,
-            \ ctx.tgt, ctx.adj, ctx.away, ctx.adj_bracket, ctx.away_bracket)
-        call s:yankdel_range(spl.range[0], spl.range[1], spl.text, spl.inc, ps, 1)
-        " Determine final cursor position.
-        " Design Decision: Analogously to builtin p and P, always position at end;
-        " however, unlike the builtins, always position on last non-ws at end.
-        let curpos = getpos("']")
-        if sep[a:tail ? 'far_sep' : 'near_sep'] != ''
-            " Need to back '] up to closest non-ws (i.e., final put element).
-            call s:setcursor(curpos)
-            " TODO: Consider adding stopline, but shouldn't be necessary.
-            let p = searchpos('\S', 'bW')
-            if !p[1]
-                " This shouldn't happen!
-                throw 'sexp-error'
-            endif
-            let curpos = [0, p[0], p[1], 0]
-            call setpos("']", curpos)
-        endif
+    " TODO: Consider having put__get_context() build the position list.
+    let ps = s:concat_positions(vs, ve,
+        \ ctx.tgt, ctx.adj, ctx.away, ctx.adj_bracket, ctx.away_bracket)
+    " Note: Don't set 'failsafe override': a put should change only whitespace.
+    call s:yankdel_range(spl.range[0], spl.range[1], spl.text, spl.inc, ps)
+    " Determine final cursor position.
+    " Design Decision: Analogously to builtin p and P, always position at end;
+    " however, unlike the builtins, always position on last non-ws at end.
+    let curpos = getpos("']")
+    if sep[a:tail ? 'far_sep' : 'near_sep'] != ''
+        " Need to back '] up to closest non-ws (i.e., final put element).
+        " TODO: Consider trimming register context to obviate need for this.
+        call s:setcursor(curpos)
+        " TODO: Consider adding stopline, but shouldn't be necessary.
+        " Assumption: Earlier short-circuit precludes possibility of empty or
+        " whitespace-only put, thereby ensuring this search will succeed.
+        let p = searchpos('\S', 'bW')
+        let curpos = [0, p[0], p[1], 0]
+        call setpos("']", curpos)
     endif
-    let [s, e] = [getpos("'["), getpos("']")]
+    " Determine range to pass to s:post_op_reindent.
+    " Assumption: Indent logic always looks back to non-empty line preceding start, so
+    " there's no need for start adjustment.
+    let s = getpos("'[")
+    " Special Case: If sep following put text is NL but element following it was
+    " originally colinear with element on other side, include the element past the NL.
+    " Note: If adjacent was not colinear, adjustment is not needed because the splice will
+    " have used adjacent whitespace-exlusive mode to preserve leading indent.
+    " Note: What makes this tricky is that s:post_op_reindent() assumes a NL creates a
+    " 'clean point', but this is true only for *pre-existing* NLs, not ones inserted by
+    " the put!
+    " TODO: Consider putting in a separate function; also, consider whether to just make
+    " s:post_op_reindent always look to subsequent element, rather than trying to shave it
+    " this close.
+    " FIXME: I believe nearest_bracket_{legacy,ts}() are inconsistent! The ts version
+    " finds close bracket when on leading macro chars. Need to resolve this as it has
+    " implications for parent reindent: specifically, whether count should be 1 or 2 when
+    " on leading macro chars.
+    if ctx.adj_colinear && sep[a:tail ? 'far_sep' : 'near_sep'] == NL
+        let e = a:tail ? ctx.adj : ctx.tgt
+    else
+        let e = getpos("']")
+    endif
     " FIXME: Make sure all branches above set curpos.
     call s:post_op_reindent(s, e, [ps, curpos])
     " !!!!! WIP !!!!!
@@ -3300,6 +3300,7 @@ endfunction
 "   1 = inclusive (nop)
 "   2 = exclusive of whitespace up to and including newline at EOL
 "       Note: Equivalent to inc==0 if not in whitespace at EOL
+"   3 = exclusive of non-NL whitespace adjacent to pos
 " Example:
 " foo)|<SPC>   ==>   foo)<SPC>
 " bar                |bar
@@ -3316,9 +3317,20 @@ function! s:yankdel_range__preadjust_range_start(start, inc)
             " position before BOF returned by *_range_end())?
             let ret = getpos([line('$'), '$'])
         endif
-    elseif a:inc != 1 " 0 or 2
-        " Move to next position, including newline.
-        let ret = s:offset_char(ret, 1, 1)
+    elseif a:inc != 1 " 0, 2 (treated as 0) or 3
+        if a:inc == 3
+            let idx = match(getline(ret[1]), '\v^.\s*\zs\S', ret[2] - 1)
+            if idx >= 0
+                " Use nearest colinear non-ws.
+                let ret[2] = ret[2] + idx
+            else
+                " Use NL
+                let ret[2] = col([ret[1], '$'])
+            endif
+        else
+            " Move to next position, including newline.
+            let ret = s:offset_char(ret, 1, 1)
+        endif
     endif
     return ret
 endfunction
@@ -3329,6 +3341,7 @@ endfunction
 "   1 = inclusive (nop)
 "   2 = exclusive of whitespace back to and including newline at BOL
 "       Note: Equivalent to inc==0 if not in whitespace at BOL
+"   3 = exclusive of non-NL whitespace adjacent to pos
 " Example:
 " foo)        ==>   foo)|
 " <SPC>|bar         <SPC>bar
@@ -3359,12 +3372,25 @@ function! s:yankdel_range__preadjust_range_end(end, inc)
             " before beginning of first line.
             let ret[1:2] = [1, -1]
         endif
-    elseif a:inc != 1 " 0 or 2
+    elseif a:inc != 1 " 0, 2 or 3
         " Move to prev position, including newline.
         if ret[1:2] == [1, 1]
             " Already at BOF, so return the special sentinel position just
             " prior to first char.
             let ret[2] = -1
+        elseif a:inc == 3
+            " adjacent whitespace-exclusive
+            let idx = match(getline(ret[1]), '\v\S\s*%' . ret[2] . 'c.')
+            if idx >= 0
+                " Use nearest colinear non-ws.
+                let ret[2] = idx + 1
+            elseif ret[1] > 1
+                " Consumed all whitespace back to BOL. Use previous line's NL.
+                let ret = [0, ret[1] - 1, col([ret[1] - 1, '$']), 0]
+            else
+                " Use virtual position just before BOF.
+                let ret[1:2] = [1, -1]
+            endif
         else
             let ret = s:offset_char(ret, 0, 1)
         endif
@@ -3439,26 +3465,72 @@ function! s:yankdel_range__preadjust_range(start, end, del_or_spl, inc)
             endif
             if i0 == 2 || i1 == 2
                 " At least one end is (still) EOL-exclusive, so we know a:start and a:end
-                " are separated by at least a NL, guaranteeing our ability to determine
-                " non-empty splice range (even if only a NL). Handle as a splice using
-                " corresponding normal-exclusive range, with NL's prepended/appended to
-                " the splice text as required.
-                let [pre_nl, post_nl] = ['', '']
-                if i0 == 2
-                    let start = s:yankdel_range__preadjust_range_start(a:start, 0)
-                    let pre_nl = "\n"
-                endif
-                if i1 == 2
-                    let end = s:yankdel_range__preadjust_range_end(a:end, 0)
-                    let post_nl = "\n"
-                endif
-                " Treat like splice, with adjusted splice text.
-                let [ret.start, ret.end] = [start, end]
-                let ret.text = pre_nl . ret.text . post_nl
+                " are separated by at least a NL (but possibly 2, due to a corner case
+                " involving blank line), guaranteeing our ability to determine non-empty
+                " splice range (even if only a NL).
+                " Logic: Make inclusive region from NL at end of a:start to NL just before
+                " a:end (possibly the same NL), which will be replaced with spliced text
+                " prefixed/suffixed with NL according to the following logic:
+                " * prefix NL if adjusted start on later line than original start
+                " * suffix NL if adjusted end on earlier line than original end
+                " Rationale: Respect desire to include or exclude the NL from splice.
+                let ret.text = (a:start[1] < start[1] ? NL : '')
+                    \ . ret.text
+                    \ . (a:end[1] > end[1] ? NL : '')
+                let ret.start = [0, a:start[1], col([a:start[1], '$']), 0]
+                let ret.end = [0, a:end[1] - 1, col([a:end[1] - 1, '$']), 0]
             else
-                " Both ends normal-exclusive implies original a:start/a:end were adjacent.
-                " Directed put from unadjusted start
-                let [ret.pos, ret.cmd] = [a:start, 'p']
+                " Both sides exclusive, but neither side EOL-exclusive
+                let [pre, post] = ['', '']
+                if i0 == 3 || i1 == 3
+                    " At least one side is adjacent whitespace-exclusive.
+                    if a:start < a:end
+                        " Only one way reversed range could have occurred: a:start was NL
+                        " and a:end was in leading whitespace of subsequent line. Highly
+                        " improbable, but most sensible thing is to replace the NL with...
+                        "   NL . spl_text.
+                        let [pre, start, end] = [NL, a:start, a:start]
+                    else
+                        " Both start/end in same run of colinear whitespace. Replace the
+                        " normal-exclusive range from a:start..a:end with...
+                        "   [pre] . spl_text . [post]
+                        " ...where pre/post is the whitespace in the open range a:start..a:end.
+                        " Rationale: Makes intuitive sense, as it preserves the whitespace
+                        " both sides requested preserved (albeit preserves it twice). Keep
+                        " in mind that the duplicthis is a scenario that should probably never
+                        " arise, mainly because the adjacent whitespace exclusion mode
+                        " has valid use cases only at the end.
+                        let s = s:offset_char(a:start, 1, 1)
+                        " Note: Handle adjacent a:{start,end} like normal exclusive.
+                        if s:compare_pos(s, a:end) < 0
+                            " a:start/a:end *not* adjacent.
+                            " Grab all the whitespace between them.
+                            let ws = getline(s[1])[s[2] - 1 : a:end[2] - 2]
+                            if i0 == 3 && i1 == 3
+                                let [pre, post] = [ws, ws]
+                            elseif i0 == 3
+                                let pre = ws
+                            else " i1 == 3
+                                let post = ws
+                            endif
+                            " Make the splice range normal exclusive since pre/post are
+                            " accounted for.
+                            let [start, end] = [s, i0 == 3
+                                \ ? s:yankdel_range__preadjust_range_end(a:end, 0)
+                                \ : end]
+                        endif
+                    endif
+                endif
+                if empty(pre) && empty(post)
+                    " a:start/a:end were adjacent. Directed put from unadjusted start
+                    let [ret.pos, ret.cmd] = [a:start, 'p']
+                else
+                    " Wrap splice text and use normal exlusive positions.
+                    " Assumption: Getting here implies pre and/or post non-empty, which
+                    " means it's safe to use normal exclusive range at both ends.
+                    let ret.text = pre . ret.text . post
+                    let [ret.start, ret.end] = [start, end]
+                endif
             endif
         endif
     else
@@ -3616,6 +3688,8 @@ endfunction
 "        both_inclusive
 "      | [start_inclusive, end_inclusive]
 "      Defaults to inclusive start, exclusive end (i.e., [1, 0].
+"      FIXME: This design choice feels a bit risky, as it violates the POLS. Consider
+"      defaulting both ends to the same thing.
 " a:2  list of positions to adjust
 "      Note: As a convenience to caller, will be passed through s:concat_positions().
 " a:3  failsafe_override - unless this flag is set, function will not delete

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -88,7 +88,8 @@ let s:aligncom_weights = {
 
 let s:nullpos = [0,0,0,0]
 let s:nullpos_pair = [s:nullpos, s:nullpos]
-let s:bof = [0, 1, -1, 0]
+let s:BOF = [0, 1, -1, 0]
+let [s:NL, s:SPC, s:EMPTY] = ["\n", " ", ""]
 
 " Since v:maxcol wasn't added till Vim9
 let s:MAXCOL = 2147483647
@@ -539,11 +540,21 @@ function! s:nearest_element_terminal(next, tail, ...)
 
         let [l, c] = s:findpos('\v\S', a:next)
         let adjacent = [0, l, c, 0]
+        if !a:next
+            " Note: The s:findpos() above will find only literal non-ws, but we need to
+            " treat ignored ws as non-ws.
+            " Assumption: Ignored ws can be found at end of element, but not beginning.
+            " TODO Should we skip this if not on ignored char or would that be slower?
+            call s:setcursor(adjacent)
+            let adjacent = s:move_to_current_element_terminal(1)
+        endif
 
         " We are at the beginning or end of file
         if adjacent[1] < 1 || s:compare_pos(pos, adjacent) == 0
             throw 'sexp-error'
         " Or we are at the head or tail of a list
+        " FIXME! This does not consider whether bracket is ignored!!! Thus, an open
+        " bracket at end of comment would be incorrectly treated as open.
         elseif getline(l)[c - 1] =~ (a:next ? s:closing_bracket : s:opening_bracket)
             " TODO: Profile to measure the performance penalty for this. It's thrown a
             " lot...
@@ -1227,7 +1238,7 @@ function! s:offset_char(pos, dir, ...)
     let inc_nl = a:0 && !!a:1
     let eol = col([a:pos[1], '$'])
     try
-        if a:pos == s:bof
+        if a:pos == s:BOF
             " Input position is before BOF.
             let pos = [0, 1, 1, 0]
         elseif a:pos[2] >= eol
@@ -1254,7 +1265,7 @@ function! s:offset_char(pos, dir, ...)
                     " Empty line
                     if a:pos[1] == 1
                         " Special Case: before BOF
-                        let pos = s:bof
+                        let pos = s:BOF
                     else
                         " Need to consider inc_nl
                         let prev_eol = col([a:pos[1] - 1, '$'])
@@ -2835,9 +2846,12 @@ function! s:put__get_reginfo()
         let ret.text = ''
         return ret
     endif
-    let ret.is_ml = regstr =~ '\n'
+    " Caveat: Vim =~ operator treats rhs like a single line; thus, literal NL ("\n") (not
+    " '\n') must be used to match interior NLs. Also, ^ and $ work only at beginning/end
+    " of multiline string.
+    let ret.is_ml = regstr =~ "\n"
     let ret.s_is_com = regstr =~ '^\s*;'
-    let ret.e_is_com = regstr =~ ';\s*$'
+    let ret.e_is_com = regstr =~ ';.*$'
     " TODO: Come up with less simple patterns that at least attempt to differentiate
     " between string and non-string context.
     " Flag indicating whether register is *only* a (potentially multi-line) comment.
@@ -2849,6 +2863,8 @@ function! s:put__get_reginfo()
     " Design Decision: Putting this here ensures presence of NL in raw register text will
     " influence 'is_ml'.
     " Rationale: If user performs (eg) linewise yank on comment, respect that.
+    " FIXME: Needs to account for possibility of escaped whitespace; have this done by
+    " function that performs language-specific validation.
     let ret.text = substitute(regstr, '^\s\+\|\s\+$', '', 'g')
     return ret
 endfunction
@@ -2863,11 +2879,12 @@ endfunction
 "                    target, else nullpos
 "   empty_list:      putting into empty list
 "   empty_buffer:    putting into empty buffer
+"   tail:            possibly adjusted version of the input flag
+"                    Note: Adjustment performed only when cursor not on element
 "   -- Flags: The following flags are N/A if either of empty_{list,buffer} set.
 "   tgt_is_alone:    1 iff target is alone on its line, with possible exception of open or
 "                    close, but not both
-"   tgt_is_terminal: 1 iff target is head or tail of list in put direction
-"   adj_colinear:    1 iff element adjacent to target on put side is colinear with target
+"   adj_colinear:    1 iff target and adjacent are colinear elements (not brackets)
 "   force_nl:        1 iff subsequent processing should force 'near sep' of NL.
 "                    Used only when cursor is not on element.
 " Position Note: In the current approach, mutually-exclusive fields are maintained for
@@ -2904,170 +2921,155 @@ endfunction
 function! s:put__get_context(count, tail)
     " Bool flags all initialized to 0 and set subsequently as needed.
     let ret = {
-        \ 'tgt': s:nullpos, 'adj': s:nullpos, 'adj_bracket': s:nullpos,
-        \ 'away': s:nullpos, 'away_bracket': s:nullpos,
-        \ 'tgt_is_alone': 0, 'tgt_is_ml': 0, 'tgt_is_terminal': 0,
-        \ 'adj_colinear': 0, 'adj_is_ml': 0,
+        \ 'range': [[0,0,0,0],[0,0,0,0]],
+        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
+        \ 'tgt_is_alone': 0, 'adj_colinear': 0,
         \ 'empty_list': 0, 'empty_buffer': 0,
-        \ 'at_top': 0, 'force_nl': 0,
+        \ 'force_nl': 0,
         \ 'tail': a:tail
     \ }
     let curpos = getpos('.')
     " First, attempt to get natural target: i.e., side of current element in direction of
     " put. If no such element, special logic will determine a 'virtual' target.
-    let [ts, te] = [sexp#current_element_terminal(0), s:nullpos]
-    if ts[1]
-        " Get end of natural (real) target element.
-        let te = sexp#current_element_terminal(1)
-        " Set tgt to put side.
-        let ret.tgt = a:tail ? te : ts
-    endif
-    " Get some other useful positions relative to cursor.
-    let next = s:nearest_element_terminal(1, 0, 1, 1)
-    let prev = s:nearest_element_terminal(0, 1, 1, 1)
+    let ret.range[!a:tail] = sexp#current_element_terminal(a:tail)
+    let no_current = !ret.range[!a:tail][1]
+    " If either end of range is still nullpos, attempt to set it to adjacent or bracket.
     " Caveat: Must pre-position on correct side of element prior to nearest_bracket() call
-    " to properly handle case of list target.
-    " TODO: Consider skipping unnecessary s:setcursor() calls.
-    if !next[1] && ret.tgt[1] | call s:setcursor(te) | endif
-    let next_bracket = !next[1] ? s:nearest_bracket(1) : s:nullpos
-    if !prev[1] && ret.tgt[1] | call s:setcursor(ts) | endif
-    let prev_bracket = !prev[1] ? s:nearest_bracket(0) : s:nullpos
-    let ret.empty_list = !ret.tgt[1] && next_bracket[1] && prev_bracket[1]
-    let ret.empty_buffer = !ret.tgt[1] && !next[1] && !prev[1] && !ret.empty_list
-    " Use special logic to determine target in the 'no current element' scenario unless
-    " superseded by empty_{list,buffer} special logic.
-    " Note: This logic may set tgt to BOF/EOF sentinel position.
-    if !ret.empty_list && !ret.empty_buffer && !ret.tgt[1]
-        " No current element. Set tgt using special logic described in header and, if
-        " applicable, set flag to cause put__get_splice_info() to insert a NL at near
-        " side.
-        " TODO: Consider using effective positions at BOF/EOF in lieu of nullpos.
-        let eff_prev = prev[1] ? prev : prev_bracket[1]
-            \ ? prev_bracket : [0, 1, -1, 0]
-        let eff_next = next[1] ? next : next_bracket[1]
-            \ ? next_bracket : [0, line('$'), col([line('$'), '$']), 0]
-        if curpos[1] == eff_prev[1] && curpos[1] == eff_next[1]
-            let ret.tgt = a:tail ? eff_prev : eff_next
-        elseif curpos[1] == eff_prev[1] && curpos[1] != eff_next[1]
-            let ret.tgt = eff_prev
-            let [ret.force_nl, ret.tail] = [a:tail, 1]
-        elseif curpos[1] == eff_next[1] && curpos[1] != eff_prev[1]
-            let ret.tgt = eff_next
-            let [ret.force_nl, ret.tail] = [!a:tail, 0]
+    " to ensure we get parent bracket, not one of list element's own brackets.
+    for i in range(0, 1)
+        if !ret.range[i][1]
+            let ret.range[i] = s:nearest_element_terminal(i, !i, 1, 1)
+            if ret.range[i][1]
+                let ret.is_ele[i] = 1
+            else
+                if ret.range[!i][1] | call s:setcursor(ret.range[!i]) | endif
+                let ret.range[i] = s:nearest_bracket(i)
+                if ret.range[i][1]
+                    let ret.is_bra[i] = 1
+                endif
+            endif
         else
-            let ret.tgt = eff_prev
+            let ret.is_ele[i] = 1
+        endif
+    endfor
+    " At this point, range endpoints can still be nullpos, but is_ele[] and is_bra[] are
+    " set correctly.
+    let ret.empty_list = ret.is_bra[0] && ret.is_bra[1]
+    let ret.empty_buffer = !ret.is_ele[0] && !ret.is_ele[1] && !ret.empty_list
+    " Unless superseded by empty_{list,buffer} special logic, use special logic described
+    " in header to determine target if cursor was not *on* element.
+    " Note: This logic may set tgt to pre-BOF/post-EOF sentinel position.
+    if !ret.empty_list && !ret.empty_buffer && no_current
+        " The conditional blocks below can...
+        "   * reverse range
+        "   * set flag forcing insertion of NL at near side.
+        " Note: The fact that curpos cannot be null and prev/next can only be null if
+        " neither bracket nor element obviates need for explicit nullpos checks on
+        " prev/next.
+        " Design Decision: Never force NL around brackets.
+        let [prev, next] = [ret.range[0], ret.range[1]]
+        if curpos[1] != prev[1] && curpos[1] != next[1]
             let ret.tail = 1
+        elseif curpos[1] == prev[1] && curpos[1] != next[1]
+            let [ret.force_nl, ret.tail] = [a:tail && ret.is_ele[0], 1]
+        elseif curpos[1] == next[1] && curpos[1] != prev[1]
+            let [ret.force_nl, ret.tail] = [!a:tail && ret.is_ele[1], 0]
         endif
     endif
-    " Assign the generic next/prev vars to direction-dependent (e.g., tgt/adj/away) vars.
-    if ret.empty_list
-        " Assumption: Cursor position unchanged.
-        " Treat empty list as special case to avoid complicating the logic for nominal
-        " case.
-        let ret.tgt = a:tail ? prev_bracket : next_bracket
-        let ret.adj_bracket = a:tail ? next_bracket : prev_bracket
-    elseif ret.empty_buffer
-        " Don't bother setting tgt/adj/etc, as this will be handled as special case.
-        let ret.at_top = 1
-    else
+    " If either range endpoint is still null, set it to corresponding buffer extremity.
+    if !ret.range[0][1]
+        let ret.range[0] = s:BOF
+    endif
+    if !ret.range[1][1]
+        let ret.range[1] = [0, line('$'), col([line('$'), '$']), 0]
+    endif
+    " Set adj_colinear and tgt_is_alone
+    " Note: Flags are N/A for empty buffer/list special cases.
+    if !ret.empty_buffer && !ret.empty_list
         " Account for possibility direction has been adjusted by special logic.
         let tail = ret.tail
-        let [ret.adj, ret.adj_bracket] = tail
-            \ ? [next, next_bracket]
-            \ : [prev, prev_bracket]
-        " TODO: Consider not adding easily expressible flags like this.
-        let ret.adj_colinear = ret.tgt[1] == ret.adj[1]
-
-        " Move to target since we could be in whitespace.
-        call s:setcursor(ret.tgt)
-        " Check other (away) side of target, passing 'ignore_current' and
-        " 'nullpos_on_fail' to ensure nullpos returned if no adjacent.
+        let ret.adj_colinear = ret.is_ele == [1, 1] && ret.range[0][1] == ret.range[1][1]
+        " Position on target to look for away element.
+        call s:setcursor(ret.range[!tail])
         let away = s:nearest_element_terminal(!tail, tail, 1, 1)
-        " Find away bracket unconditionally (even if away is not nullpos) to obviate need
-        " for at_top() call; however, put nullpos in return dict if away is non-null.
-        " Note: Must position on far side of away element before looking for bracket.
-        " Rationale: If away element is a list, we want parent bracket, not the list's
-        " other terminal.
-        call s:move_to_current_element_terminal(!tail)
-        let away_bracket = s:nearest_bracket(!tail)
-        let ret.at_top = !away_bracket[1]
-        let [away, away_bracket] = [away, away[1] ? s:nullpos : away_bracket]
-        " Is tgt alone on its line, with possible exception of open or close (but not
-        " both)?
-        " Note: Both adj and away can be nullpos here.
-        let ret.tgt_is_alone =
-            \ !(ret.adj_bracket[1] && away_bracket[1] == ret.adj_bracket[1])
-            \ && ret.adj[1] != ret.tgt[1] && away[1] != ret.tgt[1]
-        " Is tgt head/tail of list (in direction of put)?
-        " Assumption: adj_bracket will be nullpos if adj is not. This is fine because the
-        " bracket is irrelevant if the intervening element exists.
-        let ret.tgt_is_terminal = !!ret.adj_bracket[1]
+        if !away[1]
+            " Pre-position on away side of tgt to ensure that if tgt is list,
+            " nearest_bracket doesn't find its other end.
+            call s:move_to_current_element_terminal(!tail)
+            let away_bra = s:nearest_bracket(!tail)
+        else
+            let away_bra = s:nullpos
+        endif
+        " Is (element) tgt alone on its line, with possible exception of containing open
+        " or close (but not both)?
+        " Note: Any of the positions can be nullpos here.
+        let [tgt_idx, adj_idx] = [!tail, tail]
+        let [tgt, adj] = [ret.range[tgt_idx], ret.range[adj_idx]]
+        let ret.tgt_is_alone = ret.is_ele[tgt_idx]
+            \ && (!ret.is_ele[adj_idx] || tgt[1] != adj[1])
+            \ && (!away[1] || away[1] != tgt[1])
+            \ && !(away_bra[1] && ret.is_bra[adj_idx] && away_bra[1] == adj[1])
     endif
     return ret
 endfunction
 
-" Return a dict containing 3 types of separators required for the put indicated by the
+" Return a list containing 3 types of separators required for the put indicated by the
 " inputs.
 " Args:
 "   ctx:  put context dict
 "   reg:  register characterization dict
-" Return Dict:
-"   near_sep:      text to put between target and register contents
-"   far_sep:       text to put between register contents and element that *was* adjacent
-"                  to target
-"   interior_sep:  text to join the individual instances of register contents in case of a
-"                  [count]
+" Return List:
+"   [0]:  separator needed before register contents
+"   [1]:  separator needed after register contents
+"   [2]:  separator used to join the individual instances of register contents in case of
+"         a [count]
 function! s:put__get_seps(ctx, reg)
-    let ret = {'near_sep': '', 'far_sep': '', 'interior_sep': ''}
+    " Default start/end sep to NL; overrides below.
     let [ctx, reg] = [a:ctx, a:reg]
     let tail = ctx.tail
-    let [NL, SPC, EMPTY] = ["\n", " ", ""]
-
-    " -- Near separator
-    " Logic: Default (else) to NL, with special cases requiring SPC/EMPTY in the
-    " if/elseifs.
-    " Rationale: Safer (and possibly simpler).
-    if ctx.empty_list
-        if reg.s_is_com
-            " TODO: Decide whether it should be NL or SPC.
-            let ret.near_sep = SPC
-        else
-            let ret.near_sep = EMPTY
-        endif
-    elseif ctx.empty_buffer
-        " Note: Separators are actually N/A for this case.
-        let ret.near_sep = EMPTY
-    " For the remaining cases, we have an actual target element.
-    elseif !ctx.tgt_is_alone && !ctx.force_nl && !reg.is_ml && (tail || !reg.e_is_com)
-        " Target isn't on line by itself and register is sl; additionally, we're not
-        " prepending a comment to the target. Note that it's ok to *append* a single line
-        " comment to target, since far separator logic will will insert NL *after* the
-        " comment if necessary.
-        let ret.near_sep = SPC
-    else
-        " Everything else defaults to NL.
-        " Rationale: Err on side of safety.
-        let ret.near_sep = NL
-    endif
-
-    " -- Far separator
-    " Logic: Default (else) to NL, with special cases requiring SPC/EMPTY in the
-    " if/elseifs.
+    let ret = [s:NL, s:NL, s:NL]
+    " TODO: Make global option for this?
+    let g:append_sl_comment = get(g:, 'append_sl_comment', 1)
+    " Override the NL separators as needed.
     if ctx.empty_buffer
-        \ || ((ctx.empty_list || ctx.tgt_is_terminal)
-        \     && !(tail && reg.e_is_com || !tail && reg.s_is_com))
-        " Safe to butt register up against bracket (or edge of buffer).
-        let ret.far_sep = EMPTY
-    elseif ctx.adj_colinear && !reg.is_ml
-        " Preserve colinearity unless pasted text is ml.
-        let ret.far_sep = SPC
-    elseif (ctx.empty_list || ctx.tgt_is_terminal) && !tail && reg.s_is_com
-        " Start of comment can be separated from terminal by single space.
-        let ret.far_sep = SPC
+        let ret[0:1] = [s:EMPTY, s:EMPTY]
     else
-        " Everything else defaults to NL.
-        " Rationale: Err on side of safety.
-        let ret.far_sep = NL
+        " Compute side-dependent flags used to determine SPC-insertion at both start/end.
+        " Note: These flags do not incorporate comment checks, which are applied below.
+        let near_side_spc =
+            \ ctx.is_ele[!tail] && !ctx.tgt_is_alone && !ctx.force_nl && !reg.is_ml
+        " Preserve colinearity at far side unless pasted text is ml.
+        let far_side_spc = ctx.adj_colinear && !reg.is_ml
+        "
+        " Override NL (if necessary) at start.
+        "
+        if ctx.is_bra[0]
+            let ret[0] = reg.s_is_com ? s:SPC : s:EMPTY
+        elseif !ctx.is_ele[0]
+            " No bracket or element requiring separation at start 
+            let ret[0] = s:EMPTY
+        elseif tail && near_side_spc && (g:append_sl_comment || !reg.s_is_com)
+            " TODO: Should we remove the s_is_com check to allow single-line comment to be
+            " appended, keeping in mind that far side logic will insert NL *after* the
+            " comment if necessary?
+            " Bottom Line: Make near and far-side cases consistent on this.
+            let ret[0] = s:SPC
+        elseif !tail && far_side_spc && (g:append_sl_comment || !reg.s_is_com)
+            let ret[0] = s:SPC
+        endif
+        "
+        " Override NL (if necessary) at end.
+        "
+        if ctx.is_bra[1]
+            if !reg.e_is_com | let ret[1] = s:EMPTY | endif
+        elseif !ctx.is_ele[1]
+            " No bracket or element requiring separation at end
+            let ret[1] = s:EMPTY
+        elseif !tail && near_side_spc && !reg.e_is_com
+            let ret[1] = s:SPC
+        elseif tail && far_side_spc && !reg.e_is_com
+            let ret[1] = s:SPC
+        endif
     endif
 
     " -- Interior separator
@@ -3077,12 +3079,13 @@ function! s:put__get_seps(ctx, reg)
     " * register contents multiline
     "   Rationale: Stacking many multiline forms horizontally could be problematic.
     " * register *contains* comment
-    "   Rationale: For multiline register, comments are irrelevant, but we definitely
-    "   don't want multiple single line placed on the same line.
+    "   Rationale: For multiline register, previous condition makes this one irrelevant,
+    "   but we definitely don't want multiple single line comments placed on the same
+    "   line.
     " * near sep is NL
     "   Rationale: The logic that determined a NL should separate tgt from put text would
     "   quite naturally extend to subsequent copies of the put text.
-    let ret.interior_sep = reg.is_ml || reg.has_com || ret.near_sep == NL ? NL : SPC
+    let ret[2] = reg.is_ml || reg.has_com || ret[!tail] == s:NL ? s:NL : s:SPC
     return ret
 endfunction
 
@@ -3125,46 +3128,18 @@ endfunction
 " Return a dict that characterizes the splice (or directed put) to be performed as the set
 " of arguments to s:yankdel_range().
 function! s:put__get_splice_info(count, ctx, reg, sep, flags)
-    let ret = { 'range': [s:nullpos, s:nullpos], 'text': '', 'inc': [0, 0]}
+    let ret = { 'range': a:ctx.range, 'text': '', 'inc': [0, 0]}
     let [ctx, reg, sep] = [a:ctx, a:reg, a:sep]
     let tail = ctx.tail
-    let [NL, SPC, EMPTY] = ["\n", " ", ""]
-    let [near_sep, interior_sep, far_sep] = [sep.near_sep, sep.interior_sep, sep.far_sep]
 
-    " Set the target-side splice position.
-    " Assumption: Currently, ctx.tgt is always set to something non-null.
-    " TODO: Decide whether put__get_context should allow nullpos tgt.
-    let ret.range[!tail] = ctx.tgt
-    " Determine the range.
-    " Nominal case: we have a target to put before/after.
-    " Note: Target could be element or open bracket.
-    " Note: This handles both nominal and empty_list cases.
-    let adj_pos = ctx.adj[1] ? ctx.adj : ctx.adj_bracket[1] ? ctx.adj_bracket : s:nullpos
-    if ctx.empty_buffer
-        " Replace entire buffer (possibly ws or maybe just NUL char at head).
-        let ret.range = [[0, 1, 1, 0], [0, line('$'), col([line('$'), '$']), 0]]
-        let ret.inc = [1, 1]
-    elseif !adj_pos[1]
-        " TODO: Consider eliminating this and handling in the else now that BOF/EOF
-        " positions can be handled like regular positions.
-        " No element or bracket in direction of put, so put to BOF or EOF.
-        " Note: Empty buffer case currently handled separately in if, but could be handled
-        " here if we wanted to replace only whitespace in direction of put.
-        let ret.range[tail] = tail
-            \ ? [0, line('$'), col([line('$'), '$']), 0]
-            \ : [0, 1, 1, 0]
-        " Note: The following resolves to a directed put towards BOF/EOF if no whitespace
-        " separates tgt position from BOF/EOF.
-        let ret.inc = tail ? [0, 1] : [1, 0]
-    else
-        " There's something adjacent to target to anchor splice at other end.
-        let ret.range[tail] = adj_pos
-        if far_sep == NL
+    " No range/inclusivity adjustments required in empty buffer case.
+    if !ctx.empty_buffer
+        if sep[tail] == s:NL
             " Determine number of newlines needed between put text and adjacent as a
             " function of the number of blank lines *currently* between target and
             " adjacent (taking options into account).
             " Design Decision: Configuration-controlled preservation of existing line gap
-            " applies only on the far side of the put text.
+            " applies only on the *far* side of the put text.
             " Question: Should we preserve trailing whitespace in colinear case too? (I'm
             " thinking of trailing comments with lots of aligning space... OTOH, we have
             " no way of knowing how much is right, so probably just rely on subsequent
@@ -3174,16 +3149,21 @@ function! s:put__get_splice_info(count, ctx, reg, sep, flags)
             " min gap of 1, even if tgt and adj are currently colinear.
             " Question: Does num_nl need to take exc_typ into account?
             let num_nl = min([max([gap, 1]), g:sexp_cleanup_keep_empty_lines + 1])
-            let far_sep = repeat("\n", num_nl)
+            let sep[tail] = repeat("\n", num_nl)
         endif
         " If necessary, adjust exclusion type for range end.
-        let exc_typ = 0
-        " Logic: Always use adjacent whitespace-exclusive mode at end when adj and tgt are
-        " not *currently* colinear and we're inserting at least 1 NL.
+        " Logic: Always use adjacent whitespace-exclusive mode at end of range when the
+        " range terminal is a bracket or element, which is not *currently* colinear with
+        " start (i.e., there's leading indent at end), and we're inserting at least 1 NL
+        " at end.
         " Rationale: Permits earlier "clean point" for re-indent; discarding the leading
         " indent would require inclusion of one extra element at end (tgt if !tail, adj if
         " tail).
-        if !ctx.adj_colinear && sep[tail ? 'far_sep' : 'near_sep'] == NL
+        " Note: Can't use adj_colinear flag because we care about colinearity of brackets
+        " too, and adj_colinear implies both tgt/adj are elements.
+        let exc_typ = 0
+        if (ctx.is_bra[1] || ctx.is_ele[1]) && ctx.range[0] != ctx.range[1]
+            \ && sep[1][0] == s:NL
             let exc_typ = 2
         endif
         let ret.inc = [0, exc_typ]
@@ -3191,8 +3171,8 @@ function! s:put__get_splice_info(count, ctx, reg, sep, flags)
     " Build splice string.
     " TODO: Refactor this into a function somehow, since something similar is used
     " elsewhere (for cloning, I think).
-    let t = join(repeat([reg.text], a:count), interior_sep)
-    let ret.text = tail ? near_sep . t . far_sep : far_sep . t . near_sep
+    let t = join(repeat([reg.text], a:count), sep[2])
+    let ret.text = sep[0] . t . sep[1]
     return ret
 endfunction
 
@@ -3200,7 +3180,6 @@ function! sexp#put(count, tail)
     " Save/adjust visual marks.
     let [vs, ve] = s:get_visual_marks()
     let count = a:count ? a:count : 1
-    let [NL, SPC, EMPTY] = ["\n", " ", ""]
     " Calculate the put.
     let reg = s:put__get_reginfo()
     if empty(reg.text)
@@ -3212,15 +3191,18 @@ function! sexp#put(count, tail)
     let spl = s:put__get_splice_info(count, ctx, reg, sep, {})
     let ps = [vs, ve]
     " TODO: Consider having put__get_context() build the position list.
-    let ps = s:concat_positions(vs, ve,
-        \ ctx.tgt, ctx.adj, ctx.away, ctx.adj_bracket, ctx.away_bracket)
+    let ps = s:concat_positions(vs, ve, ctx.range)
+    " Re-indent logic needs to know whether range was colinear.
+    let range_linespan = ctx.range[0][1] - ctx.range[1][1]
     " Note: Don't set 'failsafe override': a put should change only whitespace.
     call s:yankdel_range(spl.range[0], spl.range[1], spl.text, spl.inc, ps)
     " Determine final cursor position.
     " Design Decision: Analogously to builtin p and P, always position at end;
     " however, unlike the builtins, always position on last non-ws at end.
     let curpos = getpos("']")
-    if sep[a:tail ? 'far_sep' : 'near_sep'] != ''
+    " FIXME: Might not want to position cursor on end of put text.
+    " TODO: User feedback...
+    if sep[1] != s:EMPTY
         " Need to back '] up to closest non-ws (i.e., final put element).
         " TODO: Consider trimming register context to obviate need for this.
         call s:setcursor(curpos)
@@ -3235,17 +3217,18 @@ function! sexp#put(count, tail)
     " Assumption: Indent logic always looks back to non-empty line preceding start, so
     " there's no need for start adjustment.
     let s = getpos("'[")
-    " Special Case: If element following put text was originally colinear with element on
-    " other side, adjust reindent range to include the element past put text.
+    " Special Case: If ele/bra following put text was originally colinear with ele/bra on
+    " other side, adjust reindent range to include ele/bra past put text.
     " Rationale: s:post_op_reindent() assumes a NL creates a 'clean point', but this is
     " true only for *pre-existing* NLs, not ones inserted by the put! For non-colinear
     " tgt/adj, logic in put__get_splice_info() ensures use of adjacent
     " whitespace-exclusive mode to preserve leading indent for element past the put,
     " thereby obviating the need to include that element in the reindent. In the colinear
-    " tgt/adj case, however, there can be no 'clean point' before the element past the
+    " tgt/adj case, however, there can be no 'clean point' before whatever follows the
     " put, so we must include it.
-    if ctx.adj_colinear
-        let e = a:tail ? ctx.adj : ctx.tgt
+    if range_linespan == 0
+        " Use adjusted range end.
+        let e = ctx.range[1]
     else
         let e = getpos("']")
     endif
@@ -3373,7 +3356,7 @@ function! s:yankdel_range__preadjust_range_start(start, inc)
         let ret[2] += eidx
     elseif !a:inc " normal-exclusive
         " Move to next position, including newline.
-        " Assumption: s:offset_char can handle s:bof.
+        " Assumption: s:offset_char can handle s:BOF.
         let ret = s:offset_char(ret, 1, 1)
     endif
     return ret
@@ -3407,7 +3390,7 @@ function! s:yankdel_range__preadjust_range_end(end, inc)
                 let ret = [0, ret[1] - 1, col([ret[1] - 1, '$']), 0]
             else
                 " pre-BOF virtual pos
-                let ret = s:bof
+                let ret = s:BOF
             endif
         else
             " Use position of found non-ws.
@@ -3446,7 +3429,6 @@ function! s:yankdel_range__preadjust_range(start, end, del_or_spl, inc)
         " convention, uses normal-exclusive mode.
         return {'err': 1, 'errmsg': 'Ambiguous intent'}
     endif
-    let [NL, SPC, EMPTY] = ["\n", " ", ""]
     " If here, input range seems sane; make it inclusive.
     let start = s:yankdel_range__preadjust_range_start(a:start, a:inc[0])
     let end = s:yankdel_range__preadjust_range_end(a:end, a:inc[1])

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -4023,10 +4023,11 @@ endfunction
 " of g@, explicitly invoking what would have been the 'opfunc' in the TextYankPost
 " handler where we have access to v:event.inclusive, which is passed to this function.
 function! s:fix_operator_range(rng, inclusive)
+    " Note: Deepcopy not really necessary, but doesn't hurt.
     let ret = deepcopy(a:rng)
     if !a:inclusive
         " Offset final position in range.
-        let ret = sexp#offset_char(ret, 1)
+        let ret[1] = sexp#offset_char(ret[1], 1)
     endif
     return ret
 endfunction

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2941,9 +2941,18 @@ endfunction
 "   --[[ Beginning of merged-in tgt_info dict
 "   count:           [count] associated with the operation
 "   put_mode:        one of 'put', 'put_child', 'replace', 'replace_child'
-"   tail:            possibly adjusted version of the input flag
-"                    Note: Adjustment performed only when cursor not on element
-"   range[]:         position pair specifying exclusive range for the put
+"   tail:            At the time of command invocation, 'tail' indicates either the put
+"                    *direction* (non-child put) or the *side* of the list from which the
+"                    insert location is calculated (child put). At this point, however,
+"                    this flag has roughly the same meaning for both put classes, since in
+"                    the child put modes, we've already used the "side" to determine range.
+"   P:               (replace modes only) 1 iff command variant inhibits update of unnamed
+"                    register
+"   vrange[]:        position pair specifying pre-op visual range (used for restore)
+"   range[]:         for non-replace modes, a position pair specifying exclusive range for
+"                    the put; for replace modes, this range is used by positioning logic,
+"                    but the replacement splice itself uses the inclusive inner_range[].
+"   inner_range[]:   (replace modes only) inclusive range for the replacement splice
 "   is_bra[]:        1 iff corresponding end of range is bracket
 "   is_ele[]:        1 iff coreesponding end of range is element
 "   tail:            Meaning varies slightly across put modes, but in some sense, this
@@ -3362,52 +3371,40 @@ function! s:regput__get_splice_info(count, ctx, reg, sep, flags)
     return ret
 endfunction
 
-" Perform register put for all 4 command types: put, put_child, replace, replace_child.
-function! s:regput__impl(tgt, count, tail)
-    let curpos = getpos('.')
-    " Save/adjust visual marks.
-    " Question: Does this really need to be done? Don't worker functions do it? If it's
-    " still necessary, it's needed at higher level (possibly even in pre_op()).
-    let [vs, ve] = s:get_visual_marks()
-
-    " Calculate the put.
-    let reg = s:regput__get_reginfo()
-    if empty(reg) || empty(reg.text)
-        " Treat empty text like NOOP!
-        return
+" Calculate and return a dict indicating the following (assuming regput operation has just
+" completed):
+"   curpos:   desired cursor position (applies only to non-visual commands)
+"   orange:   the operated on range: '[ to '] minus any surrounding whitespace
+"   irange:   the re-indent range (i.e., range provided to s:post_op_reindent())
+" Pre Condition: '[ and '] delineate the put text (including any whitespace separators).
+function! s:regput__postop(ctx, sep, orig_range)
+    " Initialize return dict to values that may subsequently be overridden.
+    let ret = {
+        \ 'curpos': a:ctx.curpos,
+        \ 'orange': [getpos("'["), getpos("']")],
+        \ 'irange': [getpos("'["), getpos("']")]}
+    " Adjust both ends of operated-on range to exclude non-ignored whitespace.
+    " Assumption: Upstream short-circuit precludes possibility of empty or whitespace-only
+    " put, thereby guaranteeing success of subsequent searches for non-ws.
+    for i in range(2)
+        " Move past any surrounding whitespace separators to non-ws.
+        if a:sep[i] != s:EMPTY
+            call s:setcursor(ret.orange[i])
+            " Note: Upstream logic guarantees this will succeed.
+            call searchpos('\S', (i ? 'b' : '') . 'cW')
+            " Make sure we're not on ignored whitespace.
+            let ret.orange[i] = sexp#current_element_terminal(i)
+        endif
+    endfor
+    " If option requests curpos target of head or tail, make adjustment.
+    let idx = !!g:sexp_regput_curpos
+    if g:sexp_regput_curpos == idx
+        " Desired position is 0 (head) or 1 (tail).
+        let ret.curpos = ret.orange[idx]
     endif
-    let ctx = s:regput__get_context(a:tgt)
-    let sep = s:regput__get_seps(ctx, reg)
-    let spl = s:regput__get_splice_info(a:count, ctx, reg, sep, {})
-    let ps = [vs, ve]
-    " TODO: Consider having put__get_context() build the position list.
-    let ps = s:concat_positions(vs, ve, ctx.range)
-    " Re-indent logic needs to know whether range was colinear.
-    let range_linespan = ctx.range[0][1] - ctx.range[1][1]
-    " Note: Set 'failsafe override' for put modes that can change non-ws.
-    call s:yankdel_range(spl.range[0], spl.range[1], spl.text, spl.inc, ps,
-        \ ctx.put_mode =~ 'replace')
-    " Determine final cursor position.
-    " Design Decision: Analogously to builtin p and P, always position at end;
-    " however, unlike the builtins, always position on last non-ws at end.
-    let curpos = getpos("']")
-    " FIXME: Might not want to position cursor on end of put text.
-    " TODO: User feedback...
-    if sep[1] != s:EMPTY
-        " Need to back '] up to closest non-ws (i.e., final put element).
-        " TODO: Consider trimming register context to obviate need for this.
-        call s:setcursor(curpos)
-        " TODO: Consider adding stopline, but shouldn't be necessary.
-        " Assumption: Earlier short-circuit precludes possibility of empty or
-        " whitespace-only put, thereby ensuring this search will succeed.
-        let p = searchpos('\S', 'bW')
-        let curpos = [0, p[0], p[1], 0]
-        call setpos("']", curpos)
-    endif
-    " Determine range to pass to s:post_op_reindent.
+    " If necessary, adjust end of re-indent range.
     " Assumption: Indent logic always looks back to non-empty line preceding start, so
     " there's no need for start adjustment.
-    let s = getpos("'[")
     " Special Case: If ele/bra following put text was originally colinear with ele/bra on
     " other side, adjust reindent range to include ele/bra past put text.
     " Rationale: s:post_op_reindent() assumes a NL creates a 'clean point', but this is
@@ -3417,16 +3414,58 @@ function! s:regput__impl(tgt, count, tail)
     " thereby obviating the need to include that element in the reindent. In the colinear
     " tgt/adj case, however, there can be no 'clean point' before whatever follows the
     " put, so we must include it.
-    if range_linespan == 0
+    if a:orig_range[0][1] == a:orig_range[1][1]
         " Use adjusted range end.
-        let e = ctx.range[1]
-    else
-        let e = getpos("']")
+        " Assumption: Re-indent logic will pull in the entire element automatically; no
+        " need to find its end here.
+        let ret.irange[1] = a:ctx.range[1]
     endif
-    " FIXME: Make sure all branches above set curpos.
-    call s:post_op_reindent(s, e, [ps, curpos])
-    call s:setcursor(curpos)
-    call s:set_visual_marks([vs, ve])
+    return ret
+endfunction
+
+" Perform register put for all 4 command types (put, put_child, replace, replace_child)
+" and afterwards, visual mode restoration and option-dependent cursor repositioning.
+function! s:regput__impl(tgt, count)
+    let curpos = getpos('.')
+    " Calculate the put.
+    let reg = s:regput__get_reginfo()
+    if empty(reg) || empty(reg.text)
+        " Treat empty text like NOOP!
+        return
+    endif
+    let ctx = s:regput__get_context(a:tgt)
+    let sep = s:regput__get_seps(ctx, reg)
+    let spl = s:regput__get_splice_info(a:count, ctx, reg, sep, {})
+    " TODO: Consider having put__get_context() build the position list.
+    let ps = s:concat_positions(ctx.curpos, ctx.vrange, ctx.range)
+    " Re-indent logic will need the original (unadjusted) range.
+    " TODO: Consider having both ranges be part of context dict: e.g., range and arange
+    let orig_range = deepcopy(ctx.range)
+    " Note: Set 'failsafe override' for put modes that can change non-ws.
+    let repl_text = s:yankdel_range(spl.range[0], spl.range[1], spl.text, spl.inc, ps,
+        \ ctx.put_mode =~ 'replace')
+    " If not inhibited, update unnamed register.
+    " TODO: Consider integrating this into yankdel_range(), which, in its current form,
+    " *never* updates unnamed register (since it's been used exclusively for things that
+    " shouldn't update any registers).
+    if a:tgt.put_mode =~ 'replace' && !a:tgt.P
+        let @" = repl_text
+    endif
+    " Calculate reindent range and final curpos.
+    let d = s:regput__postop(ctx, sep, orig_range)
+    " Perform re-indent with newly-calculated positions added to adjustment list.
+    call s:post_op_reindent(d.irange[0], d.irange[1], [ps, d.curpos, d.orange])
+    if ctx.mode ==? 'v'
+        " Design Decision: Original selection may have been partial; set marks to
+        " encompass operated-on range, excluding any surrounding whitespace.
+        call s:set_visual_marks(d.orange)
+    else
+        " Restore original (but adjusted) visual marks and set post-op cursor position.
+        call s:set_visual_marks(ctx.vrange)
+    endif
+    " Since visual mode commands end in normal mode, we can always respect
+    " option-configurable desired curpos.
+    call s:setcursor(d.curpos)
 endfunction
 
 " Calculate and return the tgt_info dict needed by s:regput__get_context() for a 'put'
@@ -3464,7 +3503,8 @@ endfunction
 function! s:put__get_tgt(count, tail)
     let curpos = getpos('.')
     let ret = {
-        \ 'put_mode': 'put', 'count': a:count,
+        \ 'curpos': curpos, 'mode': 'n', 'put_mode': 'put', 'count': a:count,
+        \ 'vrange': s:get_visual_marks(),
         \ 'range': [s:nullpos, s:nullpos],
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
         \ 'tail': a:tail, 'force_nl': [0, 0]}
@@ -3563,7 +3603,7 @@ function! sexp#put(count, tail)
     if !s:regput__handle_as_put_child_maybe(a:count, a:tail)
         let count = a:count ? a:count : 1
         let tgt = s:put__get_tgt(count, a:tail)
-        call s:regput__impl(tgt, count, a:tail)
+        call s:regput__impl(tgt, count)
     endif
 endfunction
 
@@ -3606,16 +3646,15 @@ function! s:replace__get_tgt_normal(count, tgt)
 endfunction
 
 " Note: To avoid duplication, both replace and replace_child are handled by this function.
-" TODO: Decide about arg P, which is needed only for replace_child, and probably needs to
-" make it into the dict, since it will be needed downstream.
 function! s:replace_mode__get_tgt(put_mode, mode, count, tail, P)
+    let curpos = getpos('.')
     let ret = {
-        \ 'put_mode': a:put_mode, 'count': a:count,
+        \ 'mode': a:mode, 'put_mode': a:put_mode, 'count': a:count, 'P': a:P,
+        \ 'curpos': curpos, 'vrange': s:get_visual_marks(),
         \ 'range': [s:nullpos, s:nullpos],
         \ 'inner_range': [s:nullpos, s:nullpos],
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
         \ 'tail': -1, 'force_nl': [0, 0]}
-    let curpos = getpos('.')
     try
         if a:put_mode == 'replace'
             " Allow mode-specific function to augment dict with the inner_range.
@@ -3656,16 +3695,16 @@ function! s:replace_mode__get_tgt(put_mode, mode, count, tail, P)
     endtry
 endfunction
 
-" Note: For replace modes, tail indicates which p command was used: 0 == 'p', 1 == 'P'.
+" Note: For replace modes, P indicates which p command was used: 0 == 'p', 1 == 'P'.
 " Although it doesn't affect the result of the put, it does determine whether the unnamed
 " register is updated.
-function! sexp#replace(mode, count, tail)
+function! sexp#replace(mode, count, P)
     try
         let count = a:count ? a:count : 1
         " Target determination is mode-specific.
-        let tgt = s:replace_mode__get_tgt('replace', a:mode, count, -1, -1)
+        let tgt = s:replace_mode__get_tgt('replace', a:mode, count, -1, a:P)
         " Design Decision: Let tail==1 represent put with P.
-        call s:regput__impl(tgt, count, a:tail)
+        call s:regput__impl(tgt, count)
     catch /sexp-warning:/
         call sexp#warn#msg(v:exception)
     catch
@@ -3677,21 +3716,19 @@ endfunction
 " Calculate and return the tgt_info dict needed by s:regput__get_context() for the case of
 " a 'put_child' command.
 " Note: For details on this dict, see header of s:regput__get_context().
-" Tail Logic: For a non-child put, 'tail' indicates the *direction* of the put; for child
-" put mode, however, 'tail' indicates the side of the list at which the insert occurs (or
-" from which the insert position is offset by [count]). Although we could treat a child
-" put as a non-directional put, doing so would lead to the following ambiguity: in the
-" absence of a target, how do we decide which existing element to append/prepend to when
-" our contextual logic indicates appending/prepending makes sense. OTOH, if we make the
-" put directional, which direction makese sense? I.e., which element should server as the
-" target? Any answer to this question is bound to be somewhat arbitrary, but here's what
-" I'm thinking makes sense: when the put is *between* elements, the target is the element
-" furthest from the reference bracket (i.e., the bracket on the side from which put
-" occurs). As long as we take this approach, it's not necessary to toggle 'flag' in the
-" nominal case (put between child elements):
-" return dict: consider...
-"   put at head (a:tail == 0) <==> P (tail == 0)
-"   put at tail (a:tail == 1) <==> p (tail == 1)
+" Tail Logic: Although we could treat a child put as a non-directional put, doing so would
+" lead to the following ambiguity: in the absence of a target, how do we decide which
+" existing element to append/prepend to when our contextual logic indicates
+" appending/prepending makes sense. OTOH, if we make the put directional, which direction
+" makese sense? I.e., which element should serve as the target? Any answer to this
+" question is bound to be somewhat arbitrary, but here's what I'm thinking makes sense:
+" when the put is *between* elements, the target is the element furthest from the
+" reference bracket (i.e., the bracket on the side from which put occurs). As long as we
+" take this approach, it's not necessary to toggle 'tail' in the nominal case (put between
+" child elements): i.e.,
+"   -- Command --                  -- Implemented As --
+"   put at head (a:tail == 0)      put before target (P) (tail == 0)
+"   put at tail (a:tail == 1)      put after target (p) (tail == 1)
 " However, when the [count] is so large that the desired element doesn't exist, we put
 " between terminal child and list bracket, treating the terminal child as the target.
 " Since the put in this case is in the opposite direction relative to the target, we
@@ -3699,7 +3736,8 @@ endfunction
 function! s:put_child__get_tgt(count, tail)
     let cursor = getpos('.')
     let ret = {
-        \ 'put_mode': 'put_child', 'count': a:count,
+        \ 'mode': 'n', 'put_mode': 'put_child', 'count': a:count,
+        \ 'curpos': cursor, 'vrange': s:get_visual_marks(),
         \ 'range': [s:nullpos, s:nullpos],
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
         \ 'tail': a:tail, 'force_nl': [0, 0]}
@@ -3711,7 +3749,7 @@ function! s:put_child__get_tgt(count, tail)
             if a:count > 1
                 " Child other than terminal element requested.
                 " Find element before/after which to insert.
-                let c = s:child_range(a:count, a:tail, 0,
+                let c = s:child_range(a:count, a:tail, 1,
                     \ {'list_info': li, 'exact_count': 0})
                 if c.missing
                     " Requested child doesn't exist, so use limiting list bracket and
@@ -3763,31 +3801,7 @@ function! sexp#put_child(count, tail)
     let count = a:count ? a:count : 1
     let tgt = s:put_child__get_tgt(count, a:tail)
     " Note: [count] is used only for child location, so hardcode to 1.
-    call s:regput__impl(tgt, 1, a:tail)
-endfunction
-
-" Calculate and return the tgt_info dict needed by s:regput__get_context() for the case of
-" a 'replace_child' command.
-" Note: For details on this dict, see header of s:regput__get_context().
-" Note: For details on the meaning of 'tail', see header of put_child__get_tgt().
-function! s:replace_child__get_tgt(count, tail, P)
-    let cursor = getpos('.')
-    let ret = {
-        \ 'put_mode': 'put_child', 'count': a:count,
-        \ 'range': [s:nullpos, s:nullpos],
-        \ 'inner_range': [s:nullpos, s:nullpos],
-        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
-        \ 'tail': a:tail, 'force_nl': [0, 0]}
-    try
-        let ret.inner_range = s:child_range(a:count, a:tail, 0, {'exact_count': 1})
-        if !ret.inner_range[0][1]
-            " Requested child doesn't exist!
-            throw "sexp-warning: 'replace_child': the requested child does not exist!"
-        endif
-    finally
-        call s:setcursor(cursor)
-        return ret
-    endtry
+    call s:regput__impl(tgt, 1)
 endfunction
 
 function! sexp#replace_child(count, tail, P)
@@ -3795,7 +3809,7 @@ function! sexp#replace_child(count, tail, P)
         let count = a:count ? a:count : 1
         let tgt = s:replace_mode__get_tgt('replace_child', 'n', count, a:tail, a:P)
         " Note: [count] is used only for child location, so hardcode to 1.
-        call s:regput__impl(tgt, 1, a:tail)
+        call s:regput__impl(tgt, 1)
     catch /sexp-warning:/
         call sexp#warn#msg(v:exception)
     catch

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -1413,38 +1413,37 @@ function! s:constrained_range(start, end, keep_end)
     return ret
 endfunction
 
-" Calculate *effective* auto-indent range calculation level, taking
-" g:sexp_auto_indent_range and any other relevant options into account.
-" Note: Levels 1 and 3 specify conditional fall forward or fall back as a function of
-" other options. Thus, this function returns a value from the following set: [0, 2, 4].
+" Return *effective* auto-indent range calculation method, taking g:sexp_auto_indent_range
+" and g:sexp_indent_aligns_comments into account.
 function! s:get_effective_ai_range()
-    let val = get(g:, 'sexp_auto_indent_range', 1)
-    let [typ, ityp] = [type(val), type(0)]
-    if typ != ityp || val < 0 || val > 4
-        " If user set to something larger than 4, cap it at 4; otherwise, default to 1.
-        let bad = val
-        let val = typ == ityp && val > 4 ? 4 : 1
+    " TODO: Better way to keep this in sync with plugin script (and docs)?
+    let def_ai = 'mp'
+    " Note: We normally assume existence of global options at this point (since they're
+    " created as necessary by plugin script), but as long as we're doing processing,
+    " re-creating if necessary doesn't hurt...
+    let ai = get(g:, 'sexp_auto_indent_range', def_ai)
+    if empty(ai)
+        " Accept empty string as natural way to request default explicitly.
+        let ai = def_ai
+    endif
+    if ai != def_ai && (type(ai) != type('') || ai !~ '\v^[mpt]{1,2}$')
         call sexp#warn#msg_once(
+            \ printf("sexp_auto_indent_range:invalid_format:%s", string(ai)),
             \ "Ignoring invalid g:sexp_auto_indent_range setting: "
-            \ . bad . ". Defaulting to " . string(val))
-        " Design Decision: Wouldn't need to set global here, since msg_once() ensures we
-        " won't keep warning; still, there's no harm in doing so, as user can override at
-        " any time.
-        let g:sexp_auto_indent_range = val
+            \ . string(ai) . ". Defaulting to '" . def_ai . "'")
+        let ai = def_ai
     endif
-    if val == 1 || val == 3
-        " Increment 1 up or down
-        let val += g:sexp_indent_does_clean || g:sexp_indent_aligns_comments ? 1 : -1
-    endif
-    return val
+    " If two-char form is used, let align comment enable status pick the char.
+    return len(ai) == 1 ? ai : ai[!!g:sexp_indent_aligns_comments]
 endfunction
 
-" TODO: Comment!!!
-" Return dict with the following keys:
-"   start
-"   end
-"   top
-"   cnt
+" Calculate and return a dict representing the re-indent required for the buffer
+" modification spanning start/end, taking g:sexp_auto_indent_range option into account.
+" Return Dict:
+"   start:  start of indent range in explicit range mode, else N/A
+"   end:    end of indent range in explicit range mode, else N/A
+"   top:    -1 to request explicit range mode, else argument for sexp#indent()
+"   cnt:    count argument for sexp#indent() (N/A in explicit range mode)
 function! s:get_reindent_range(s, e)
     let cursor = getpos('.')
     let ai_range = s:get_effective_ai_range()
@@ -1457,24 +1456,24 @@ function! s:get_reindent_range(s, e)
         let [s, e] = s:super_range(s, e)
         " If at top, just use [s,e].
         if !s:at_top(s[1], s[2])
-            if !ai_range && s:is_list_terminal(s, 0)
-                " Changes to list head can propagate to the end of a list, so constrain to
-                " level >= 1.
-                let ai_range = max([1, ai_range])
+            if ai_range == 'm' && s:is_list_terminal(s, 0)
+                " Changes to list head can propagate to the end of a list, so force
+                " parent.
+                let ai_range = 'p'
             endif
             " Assumption: Containing if guard obviates need to validate bracket searches.
             " Note: We're on tail end of input end element.
-            if ai_range == 4
+            if ai_range == 't'
                 " containing top-level form
                 let top = 1
-            elseif ai_range == 2
+            elseif ai_range == 'p'
                 " containing form only
                 let top = 0
                 " If start is open bracket, use count of 2 to reindent that list's parent.
                 if s:is_list(s[1], s[2]) == 2
                     let cnt = 2
                 endif
-            else
+            else " ai_range == 'm'
                 " Calculate impacted range.
                 " Logic: We know s is not list head, so as long as indentation was correct
                 " before the operation, we should be able to keep it so by indenting up to
@@ -1487,30 +1486,32 @@ function! s:get_reindent_range(s, e)
     finally
         call s:setcursor(cursor)
     endtry
+    " Note: top == -1 requests explicit range indent (rather than list mode).
     return {'top': top, 'cnt': cnt, 'start': s, 'end': e}
 endfunction
 
-" TODO: Comment!!!
+" Perform re-indent required for operation affecting lines from s to e, passing the
+" provided position list to sexp#indent() for adjustment.
+" TODO: Eventually, this should be used for commands other than register puts!
 function! s:post_op_reindent(s, e, ps)
     let rng = s:get_reindent_range(a:s, a:e)
-    " Skip single-line, explicit range indents.
-    if rng.top >= 0 || rng.start[1] != rng.end[1]
-        if rng.top >= 0
-            " Indenting a parent (or ancestor) list rather than explicit range.
-            " Position cursor on start and let sexp#indent() find applicable parent.
-            let mode = 'n'
-            call s:setcursor(rng.start)
-        else
-            let mode = 'v'
-            " Re-indent explicit range.
-            call s:set_visual_marks([rng.start, rng.end])
-            " Note: Though we use visual marks, it's important that we be in normal mode.
-            call sexp#ensure_normal_mode()
-        endif
-        " sexp#indent() will use mode and top to determine operating mode.
-        " Caveat: Convert rng.top == -1 (explicit range) to 0.
-        call sexp#indent(mode, rng.top == 1, rng.cnt, -1, 1, a:ps)
+    " Note: Initially, I skipped single-line indents; however, even a single line indent
+    " makes sense, as the preceding line is considered.
+    if rng.top >= 0
+        " Indenting a parent (or ancestor) list rather than explicit range.
+        " Position cursor on start and let sexp#indent() find applicable parent.
+        let mode = 'n'
+        call s:setcursor(rng.start)
+    else
+        let mode = 'v'
+        " Re-indent explicit range.
+        call s:set_visual_marks([rng.start, rng.end])
+        " Note: Though we use visual marks, it's important that we be in normal mode.
+        call sexp#ensure_normal_mode()
     endif
+    " sexp#indent() will use mode and top to determine operating mode.
+    " Caveat: Convert rng.top == -1 (explicit range) to 0.
+    call sexp#indent(mode, rng.top == 1, rng.cnt, -1, 1, a:ps)
 endfunction
 
 """ PREDICATES AND COMPARATORS {{{1
@@ -3102,24 +3103,32 @@ function! s:put__get_splice_info(count, tail, ctx, reg, sep, flags)
     else
         " There's something adjacent to target to anchor splice at other end.
         let ret.range[a:tail] = adj_pos
-        " May be set to 2 (EOL-exclusive) later.
-        let exc_typ = 0
         if far_sep == NL
-            " Determine number of newlines to prepend/append on far side of put text,
-            " as function of number of blank lines between target and adjacent (taking
-            " options into account).
+            " Determine number of newlines needed between put text and adjacent as a
+            " function of the number of blank lines *currently* between target and
+            " adjacent (taking options into account).
+            " Design Decision: Configuration-controlled preservation of existing line gap
+            " applies only on the far side of the put text.
+            " Question: Should we preserve trailing whitespace in colinear case too? (I'm
+            " thinking of trailing comments with lots of aligning space... OTOH, we have
+            " no way of knowing how much is right, so probably just rely on subsequent
+            " re-align (auto or explicitly-commanded)...
             let gap = ret.range[1][1] - ret.range[0][1]
-            " Note: Because far_sep has been determined to be NL, we must ensure a
+            " Note: Because relevant sep has been determined to be NL, we must ensure a
             " min gap of 1, even if tgt and adj are currently colinear.
+            " Question: Does num_nl need to take exc_typ into account?
             let num_nl = min([max([gap, 1]), g:sexp_cleanup_keep_empty_lines + 1])
-            if a:tail
-                " Use adjacent whitespace-exclusive mode at end to preserve any
-                " leading indent on line following the put.
-                " Rationale: Permits earlier "clean point" for re-indent; otherwise,
-                " we'd have to include at least one extra element at tail.
-                let exc_typ = 2
-            endif
             let far_sep = repeat("\n", num_nl)
+        endif
+        " If necessary, adjust exclusion type for range end.
+        let exc_typ = 0
+        " Logic: Always use adjacent whitespace-exclusive mode at end when adj and tgt are
+        " not *currently* colinear and we're inserting at least 1 NL.
+        " Rationale: Permits earlier "clean point" for re-indent; discarding the leading
+        " indent would require inclusion of one extra element at end (tgt if !a:tail, adj
+        " if a:tail).
+        if !ctx.adj_colinear && sep[a:tail ? 'far_sep' : 'near_sep'] == NL
+            let exc_typ = 2
         endif
         let ret.inc = [0, exc_typ]
     endif
@@ -3171,21 +3180,16 @@ function! sexp#put(count, tail)
     " Assumption: Indent logic always looks back to non-empty line preceding start, so
     " there's no need for start adjustment.
     let s = getpos("'[")
-    " Special Case: If sep following put text is NL but element following it was
-    " originally colinear with element on other side, include the element past the NL.
-    " Note: If adjacent was not colinear, adjustment is not needed because the splice will
-    " have used adjacent whitespace-exlusive mode to preserve leading indent.
-    " Note: What makes this tricky is that s:post_op_reindent() assumes a NL creates a
-    " 'clean point', but this is true only for *pre-existing* NLs, not ones inserted by
-    " the put!
-    " TODO: Consider putting in a separate function; also, consider whether to just make
-    " s:post_op_reindent always look to subsequent element, rather than trying to shave it
-    " this close.
-    " FIXME: I believe nearest_bracket_{legacy,ts}() are inconsistent! The ts version
-    " finds close bracket when on leading macro chars. Need to resolve this as it has
-    " implications for parent reindent: specifically, whether count should be 1 or 2 when
-    " on leading macro chars.
-    if ctx.adj_colinear && sep[a:tail ? 'far_sep' : 'near_sep'] == NL
+    " Special Case: If element following put text was originally colinear with element on
+    " other side, adjust reindent range to include the element past put text.
+    " Rationale: s:post_op_reindent() assumes a NL creates a 'clean point', but this is
+    " true only for *pre-existing* NLs, not ones inserted by the put! For non-colinear
+    " tgt/adj, logic in put__get_splice_info() ensures use of adjacent
+    " whitespace-exclusive mode to preserve leading indent for element past the put,
+    " thereby obviating the need to include that element in the reindent. In the colinear
+    " tgt/adj case, however, there can be no 'clean point' before the element past the
+    " put, so we must include it.
+    if ctx.adj_colinear
         let e = a:tail ? ctx.adj : ctx.tgt
     else
         let e = getpos("']")

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -514,69 +514,74 @@ endfunction
 " Returns current element's terminal if no adjacent element exists, unless optional
 " 'ignore_current' argument is set, in which case, return unmodified current position,
 " unless 'nullpos_on_fail' (2nd optional arg) is also set, in which case, return nullpos.
+" TODO: Consider impact of combining 'ignore_current' and 'nullpos_on_fail' into a single
+" flag requesting nullpos on fail.
+" Rationale: I can't think of a scenario in which we'd want ignore_current but not
+" nullpos_on_fail, and there's at least one call site (s:move_to_adjacent_element) where
+" we simply repeat the provided ignore_current arg in the call to this function.
+" Implementation Note: Original version made liberal use of 'sexp-error' throws to handle
+" short-circuiting in non-error scenarios; although I never used profiling to determine
+" the performance implications of that approach, it tended to be distracting in a
+" debugger. Accordingly, I've converted the throws to bare return statements, with the
+" actual return value constructed in a finally block.
 " TODO: Convert the optional args to a (possibly optional) flags dict.
 function! s:nearest_element_terminal(next, tail, ...)
     let cursor = getpos('.')
-    let pos = cursor
-    " If optional flag is set, current element's terminal is not a valid target: return
-    " nullpos if no adjacent in desired direction.
+    let [pos, has_adj] = [cursor, 0]
+    " Cache optional flags.
     let ignore_current = a:0 && a:1
     let nullpos_on_fail = a:0 > 1 && a:1
     try
-        let terminal = sexp#current_element_terminal(a:next)
-
-        if terminal[1] > 0 && s:compare_pos(pos, terminal) != 0
-            if !ignore_current
-                let pos = terminal
-            endif
-            call s:setcursor(terminal)
+        " Attempt to find edge of current element (if applicable).
+        let pos = sexp#current_element_terminal(a:next)
+        if pos[1] > 0 && s:compare_pos(pos, cursor) != 0
+            " Cursor was on element and not already at edge in search direction.
+            " We may be done: i.e.,
             " b moves to the head of the current word if not already on the
             " head and e moves to the tail if not on the tail. However, ge
-            " does not!
-            if (!a:next || a:tail) && !(!a:next && a:tail)
-                throw 'sexp-error'
+            " will never result in updated position on starting element!
+            if !ignore_current && a:next == a:tail
+                return
             endif
-        endif
-
-        let [l, c] = s:findpos('\v\S', a:next)
-        let adjacent = [0, l, c, 0]
-        if !a:next
-            " Note: The s:findpos() above will find only literal non-ws, but we need to
-            " treat ignored ws as non-ws.
-            " Assumption: Ignored ws can be found at end of element, but not beginning.
-            " TODO Should we skip this if not on ignored char or would that be slower?
-            call s:setcursor(adjacent)
-            let adjacent = s:move_to_current_element_terminal(1)
-        endif
-
-        " We are at the beginning or end of file
-        if adjacent[1] < 1 || s:compare_pos(pos, adjacent) == 0
-            throw 'sexp-error'
-        " Or we are at the head or tail of a list
-        " FIXME! This does not consider whether bracket is ignored!!! Thus, an open
-        " bracket at end of comment would be incorrectly treated as open.
-        elseif getline(l)[c - 1] =~ (a:next ? s:closing_bracket : s:opening_bracket)
-            " TODO: Profile to measure the performance penalty for this. It's thrown a
-            " lot...
-            throw 'sexp-error'
-        endif
-
-        let pos = adjacent
-
-        " We are at a head if moving forward or at a tail if moving backward
-        if (a:next && !a:tail) || (!a:next && a:tail)
-            throw 'sexp-error'
-        else
+            " Still need adjacent; move to found pos before searching for it.
             call s:setcursor(pos)
-            let final = sexp#current_element_terminal(a:tail)
-            if final[1] > 0
-                let pos = final
+        endif
+        " Look for adjacent.
+        let [l, c] = s:findpos('\v\S', a:next)
+        if !l
+            " We hit beginning or end of file without finding adjacent.
+            return
+        elseif getline(l)[c - 1] =~ (a:next ? s:closing_bracket : s:opening_bracket)
+            \ && !s:is_rgn_type('str_com_chr', l, c)
+            " Already on head or tail of list
+            return
+        else
+            " Found near side of adjacent element.
+            let pos = [0, l, c, 0]
+            call s:setcursor(pos)
+            if !a:next
+                " Note: The s:findpos() above will find only literal non-ws, but we need
+                " to treat ignored ws (e.g., escaped space) as non-ws.
+                " Assumption: Ignored ws can be found at end of element, but not
+                " beginning. TODO Should we skip this if not on ignored char or would it
+                " be slower to check?
+                let pos = s:move_to_current_element_terminal(1)
             endif
         endif
-    catch /sexp-error/
+        " We're on near side of adjacent whose existence guarantees successful return,
+        " regardless of optional input flags.
+        " If movement is b or e (next == tail), move to far side of adjacent.
+        let has_adj = 1
+        if a:next == a:tail
+            let pos = sexp#current_element_terminal(a:tail)
+        endif
     finally
         call s:setcursor(cursor)
-        return ignore_current && pos == cursor ? s:nullpos : pos
+        " Note: The bare return statements above work like simple throws; the return value
+        " is constructed here.
+        return ignore_current && !has_adj
+            \ ? nullpos_on_fail ? s:nullpos : cursor
+            \ : pos
     endtry
 endfunction
 
@@ -1818,22 +1823,24 @@ endfunction
 function! s:move_to_adjacent_element(next, tail, top, ...)
     let cursor = getpos('.')
     let ignore_current = a:0 && a:1
-    if a:top
-        let top = s:move_to_top_bracket(a:next)
+    try
+        if a:top
+            let top = s:move_to_top_bracket(a:next)
 
-        " Stop at current top element head if moving backward and did not
-        " start on a top element head.
-        if !a:next && top[1] > 0 && s:compare_pos(top, cursor) != 0
-            let pos = top
-        else
-            let pos = s:nearest_element_terminal(a:next, a:tail, ignore_current)
+            " Stop at current top element head if moving backward and did not
+            " start on a top element head.
+            if !a:next && top[1] > 0 && s:compare_pos(top, cursor) != 0
+                let pos = top
+                return
+            endif
         endif
-    else
-        let pos = s:nearest_element_terminal(a:next, a:tail, ignore_current)
-    endif
-
-    if pos[1] > 0 | call s:setcursor(pos) | endif
-    return pos
+        " Note: We fall through here from top case iff not stopping at current top head.
+        let pos = s:nearest_element_terminal(
+            \ a:next, a:tail, ignore_current, ignore_current)
+    finally
+        call s:setcursor(pos[1] ? pos : cursor)
+        return pos
+    endtry
 endfunction
 
 " Move cursor to pos, and then to the next element if in whitespace.
@@ -3393,12 +3400,12 @@ function! s:swap_current_selection(mode, next, pairwise)
         call s:setcursor(amarks[0])
 
         let [sl, sc] = s:findpos(nr2char(0x02), 1)
-        call cursor(sl, sc)
+        keepjumps call cursor(sl, sc)
         normal! x
         let s = [0, sl, sc, 0]
 
         let [el, ec] = s:findpos(nr2char(0x03), 1)
-        call cursor(el, ec)
+        keepjumps call cursor(el, ec)
         normal! x
         let e = [0, el, ec - 1, 0]
 
@@ -5057,6 +5064,8 @@ endfunction
 "   a:start     start of range (a:0==1) or position of open bracket (a:0==0)
 "   a:ps        list of positions to be updated
 "   a:1 (end)   (optional) end of range
+" TODO: Update this function to take advantage of recently added 'ignore_current' and
+" 'nullpos_on_fail' arguments to nearest_element_terminal().
 function! s:cleanup_ws(start, ps, ...)
     let end = a:0 ? a:1 : [0, 0, 0, 0]
     let [open, close, prev] = [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
@@ -5122,8 +5131,22 @@ function! s:cleanup_ws(start, ps, ...)
         endif
         let eff_next = next[1] ? next : close
         if !eff_next[1]
-            " Assumption: ve=onemore obviates need for eof flag.
-            let eff_next = getpos([line('$'), '$'])
+            " Caveat: We can get here before reaching EOF if an unbalanced close bracket
+            " prevents finding either next or close. In that case, safest thing to do is
+            " short-circuit with a warning that will help user locate the issue.
+            let [l, c] = s:findpos('\S', 1)
+            if l
+                " Design Decision: Don't try to prevent the re-indent that most likely
+                " follows the cleanup, even though it may invalidate the line numbers
+                " reported here.
+                call sexp#warn#msg(
+                    \ printf("cleanup_ws: Unexpected token (possibly unbalanced"
+                    \ . " close bracket) at or near (%d,%d).", l, c))
+                return
+            else
+                " Assumption: ve=onemore obviates need for eof flag.
+                let eff_next = getpos([line('$'), '$'])
+            endif
         endif
 
         " Do we want to remove *all* whitespace between eff_prev and eff_next?
@@ -5164,9 +5187,10 @@ function! s:cleanup_ws(start, ps, ...)
             " If next isn't comment and there are multiple whitespace chars between
             " eff_prev and eff_next, collapse to a single whitespace.
             " Rationale: Only before comment does extra (non-leading) ws make sense.
-            " FIXME: Refusing to collapse whitespace *immediately* preceding comment
-            " doesn't really solve anything, since collapsing ws earlier on the line will
-            " still break alignment. Really need to add the eol comment alignment logic...
+            " Note: Refusing to collapse whitespace *immediately* preceding comment
+            " isn't a complete solution, since collapsing ws earlier on the line will
+            " still break alignment. Now that we support auto comment alignment, we could
+            " make the comment test conditional...
             " Cursor Logic: If cursor is in whitespace to be contracted, but not on
             " *first* whitespace in the range, we want it to end up *past* the single
             " remaining space; otherwise, on it. FIXME: Currently, this can mean past end

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2924,25 +2924,19 @@ endfunction
 " value into account.
 "   0 = exclusive
 "   1 = inclusive (nop)
-"   2 = exclusive of whitespace up to and including newline at EOL
-"       Note: Equivalent to inc==0 if not in whitespace at EOL
+"   2 = exclusive of adjacent non-NL whitespace
+"       Note: Equivalent to inc==0 if no adjacent whitespace
 " Example:
-" foo)|<SPC>   ==>   foo)<SPC>
-" bar                |bar
+" foo|)   bar   ==>   foo)   |bar
 function! s:yankdel_range__preadjust_range_start(start, inc)
     let ret = a:start[:]
-    if a:inc == 2 && getline(ret[1])[ret[2] - 1:] =~ '^.\?\s*$'
-        " Move to start of next line (if it exists).
-        if ret[1] < line('$')
-            let ret[1] += 1
-            let ret[2] = 1
-        else
-            " EOF
-            " Question: Should we return start of nonexistent line past end (analogous to
-            " position before BOF returned by *_range_end())?
-            let ret = getpos([line('$'), '$'])
-        endif
-    elseif a:inc != 1 " 0 or 2
+    if a:inc == 2
+        " Get index of whatever (possibly NL) follows whitespace adjacent to start.
+        " This match produces results identical to normal-exclusive if no adjacent ws.
+        " Note: The dot in pattern must be optional to handle empty line case.
+        let eidx = match(getline(ret[1])[ret[2] - 1:], '\v^.?\s*\zs(.|$)')
+        let ret[2] = eidx + 1
+    elseif !a:inc " normal-exclusive
         " Move to next position, including newline.
         let ret = s:offset_char(ret, 1, 1)
     endif
@@ -2953,47 +2947,38 @@ endfunction
 " value into account.
 "   0 = exclusive
 "   1 = inclusive (nop)
-"   2 = exclusive of whitespace back to and including newline at BOL
-"       Note: Equivalent to inc==0 if not in whitespace at BOL
+"   2 = exclusive of whitespace back to but not including newline at BOL
+"       Note: Equivalent to inc==0 if no adjacent whitespace
 " Example:
-" foo)        ==>   foo)|
-" <SPC>|bar         <SPC>bar
+" foo)   |bar       ==>   foo|)   bar
 " Special Case: If end is BOF and adjustment is exclusive, return special
 " non-physical position [0, 1, -1, 0].
 " Caveat: Callers requiring physical positions will need to check for this.
+" TODO: Make this a script constant (like nullpos - eg, bofpos).
 function! s:yankdel_range__preadjust_range_end(end, inc)
     let ret = a:end[:]
-    if a:inc == 2 && getline(ret[1])[:ret[2] - 1] =~ '^\s*.\?$'
-        " Move to end of prev line, excluding newline.
-        if ret[1] > 1
-            let ret[1] -= 1
-            let ret[2] = col([ret[1], '$']) - 1
-            if !ret[2]
-                " Empty line is special.
-                let ret[2] = 1
-                if ret[1] > 1
-                    " Special Case: We want to exclude the newline preceding end, but
-                    " col==1 on an empty line would include it; thus, back up one
-                    " additional line, including its newline.
-                    let ret[1] -= 1
-                    let ret[2] = col([ret[1], '$'])
-                endif
+    " Adjust input position for non-inclusive inc.
+    if a:inc == 2
+        " adjacent whitespace-exclusive
+        " Caveat: Using strpart rather than [:] indexing to avoid problems with negative
+        " indices.
+        let sidx = match(strpart(getline(ret[1]), 0, ret[2] - 1), '\v\S\s*$')
+        if sidx < 0
+            " Adjacent whitespace extends back to BOL.
+            if ret[1] > 1
+                " Use previous line's NL.
+                let ret = [0, ret[1] - 1, col([ret[1] - 1, '$']), 0]
+            else
+                " BOF sentinel
+                let ret = [0, 1, -1, 0]
             endif
         else
-            " BOF
-            " As a special case, return sentinel (non-physical) position just
-            " before beginning of first line.
-            let ret[1:2] = [1, -1]
+            " Use position of found non-ws.
+            let ret[2] = sidx + 1
         endif
-    elseif a:inc != 1 " 0 or 2
+    elseif !a:inc " normal-exclusive
         " Move to prev position, including newline.
-        if ret[1:2] == [1, 1]
-            " Already at BOF, so return the special sentinel position just
-            " prior to first char.
-            let ret[2] = -1
-        else
-            let ret = s:offset_char(ret, 0, 1)
-        endif
+        let ret = s:offset_char(ret, 0, 1)
     endif
     return ret
 endfunction
@@ -3011,18 +2996,28 @@ endfunction
 "              Note: May or may not equal the actual Vim command used.
 "   err:       1 iff inputs are invalid
 "   errmsg:    error description iff err == 1, else ""
+" Args: See descriptions in s:yankdel_range() header comment.
 function! s:yankdel_range__preadjust_range(start, end, del_or_spl, inc)
     if s:compare_pos(a:start, a:end) > 0
         " Shouldn't happen! How to handle? Internal error?
         " 'err' flag with msg?
         return {'err': 1, 'errmsg': 'Invalid (reversed) range'}
+    elseif a:start == a:end
+        \ && ((a:inc[0] == 1 && a:inc[1] == 2)
+        \     || (a:inc[0] == 2 && a:inc[1] == 1))
+        " Ambiguous Intent: a:inc requests both inclusion and exclusion of common
+        " start/end position, but this is valid only for a directed put, which, by
+        " convention, uses normal-exclusive mode.
+        return {'err': 1, 'errmsg': 'Ambiguous intent'}
     endif
-    " If here, range was sane.
+    let [NL, SPC, EMPTY] = ["\n", " ", ""]
+    " If here, input range seems sane; make it inclusive.
     let start = s:yankdel_range__preadjust_range_start(a:start, a:inc[0])
     let end = s:yankdel_range__preadjust_range_end(a:end, a:inc[1])
-    " Note: Initial setting of 'cmd' flag will never indicate directed put.
     let [is_str, is_num] =
         \ [type(a:del_or_spl) == type(''), type(a:del_or_spl) == type(0)]
+    " Initialize return dict; positions and cmd may be adjusted below.
+    " Note: Initial setting of 'cmd' flag will never indicate directed put.
     let ret = {
         \ 'start': s:nullpos, 'end': s:nullpos, 'pos': s:nullpos,
         \ 'text': is_str ? a:del_or_spl : '',
@@ -3032,8 +3027,7 @@ function! s:yankdel_range__preadjust_range(start, end, del_or_spl, inc)
     " Is adjusted (inclusive) range empty?
     if s:compare_pos(start, end) > 0
         " Adjusted start/end are reversed, yielding empty target region.
-        " Treat *non-empty* splice as either a directed put or (EOL-exclusive case only)
-        " a splice, everything else as NO-OP.
+        " Treat *non-empty* splice as a directed put, everything else as NO-OP.
         if ret.cmd != 's' || len(ret.text) == 0
             " Empty range is NO-OP for all but non-empty splice!
             let ret.cmd = ''
@@ -3042,50 +3036,31 @@ function! s:yankdel_range__preadjust_range(start, end, del_or_spl, inc)
         " We have a non-empty splice.
         let [i0, i1] = a:inc
         if i0 == 1 || i1 == 1
-            if i0 == 2 || i1 == 2
-                " EOL-exclusive is disallowed when the other end is inclusive and range is
-                " reversed.
-                " Rationale: ambiguous intent
-                return {'err': 1, 'errmsg': 'invalid EOL-exclusive range'}
-            endif
-            " By convention, empty range with one side inclusive requests a directed put
-            " with direction given by the inclusive side.
-            let [ret.pos, ret.cmd] = i0 == 1 ? [start, 'P'] : [end, 'p']
-        else
-            " Both sides exclusive
-            " Convert pointless EOL-exclusive to (simpler) normal-exclusive.
-            let i0 = i0 == 0 || a:start[1] == start[1] ? 0 : 2
-            let i1 = i1 == 0 || a:end[1] == end[1] ? 0 : 2
-            " EOL-exclusive should never be used with colinear start/end.
-            " Design Decision: Defer validation till after simplifying pointless
-            " EOL-exclusive to normal-exclusive.
-            if (i0 == 2 || i1 == 2) && a:end[1] <= a:start[1]
-                " Invalid!
-                return {'err': 1, 'errmsg': 'Invalid EOL-exclusive range'}
-            endif
-            if i0 == 2 || i1 == 2
-                " At least one end is (still) EOL-exclusive, so we know a:start and a:end
-                " are separated by at least a NL, guaranteeing our ability to determine
-                " non-empty splice range (even if only a NL). Handle as a splice using
-                " corresponding normal-exclusive range, with NL's prepended/appended to
-                " the splice text as required.
-                let [pre_nl, post_nl] = ['', '']
-                if i0 == 2
-                    let start = s:yankdel_range__preadjust_range_start(a:start, 0)
-                    let pre_nl = "\n"
-                endif
-                if i1 == 2
-                    let end = s:yankdel_range__preadjust_range_end(a:end, 0)
-                    let post_nl = "\n"
-                endif
-                " Treat like splice, with adjusted splice text.
-                let [ret.start, ret.end] = [start, end]
-                let ret.text = pre_nl . ret.text . post_nl
+            " One side inclusive, the other side some form of exclusive
+            if i0 != 2 && i1 != 2
+                " By convention, empty range with one side inclusive and the other side
+                " normal-exclusive requests a directed put with direction given by the
+                " inclusive side.
+                let [ret.pos, ret.cmd] = i0 == 1 ? [start, 'P'] : [end, 'p']
             else
-                " Both ends normal-exclusive implies original a:start/a:end were adjacent.
-                " Directed put from unadjusted start
-                let [ret.pos, ret.cmd] = [a:start, 'p']
+                " One side inclusive, the other side adjacent whitespace-exclusive.
+                " Design Decision: Treat like splice over inclusive position.
+                " Rationale: Initial validation guarantees input start was *before* input
+                " end; thus, the fact that adjusted positions overlap implies that the
+                " inclusive end was *within* the whitespace excluded by the other end.
+                " There's probably no real use case for this, but safest and most natural
+                " thing is just to exclude only the whitespace in the open range
+                " determined by start..end: in other words, just splice over the inclusive
+                " position.
+                let [ret.start, ret.end] = i0 == 1 ? [a:start, a:start] : [a:end, a:end]
             endif
+        else
+            " Both sides some form of exclusive
+            " Handle as directed put from adjusted end.
+            " Rationale: Intended use cases of adjacent whitespace-exclusive are such that
+            " when a choice must be made (because adjacent start/end overlap), it's better to
+            " preserve all of the adjacent whitespace at end.
+            let [ret.pos, ret.cmd] = [end, 'p']
         endif
     else
         " Adjusted range non-empty; no need to adjust cmd, which is one of [yds]. (All

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -38,7 +38,7 @@ if !exists('g:sexp_maxlines')
     let g:sexp_maxlines = -1 " Use fast best-effort top list search
 endif
 
-let s:countindex = 0 " Stores current count index during sexp#docount
+let s:countindex = -1 " Stores current count index during sexp#docount
 let s:bracket = '\v\(|\)|\[|\]|\{|\}'
 let s:opening_bracket = '\v\(|\[|\{'
 let s:closing_bracket = '\v\)|\]|\}'
@@ -2412,90 +2412,144 @@ endif
 " the number of columns inwards from the brackets to set the marks.
 "
 " If allow_expansion is 1, the visual marks are set to the next outer pair of
-" brackets under the following circumstances:
+" brackets when either of the following conditions is met:
 "
-"   * Mode equals 'v', the cursor is on an opening bracket, the mark '< is
-"     valid, and the marks '< and '> are not equal. This occurs when calling
-"     this function while already having a list selected in visual mode.
+"   * Mode equals 'v', the visual selection is more than one column wide, and selecting
+"     the requested inner/outer list would not expand the visual selection.
+"     Note: The *current* inner/outer list is determined by the *cursor side* of the
+"     visual selection; this matters when the selection crosses list boundaries (i.e.,
+"     when the selection ends are not within the same sexp tree node).
+"     Example: With selection given by < > and cursor by |...
+"       <(foo (bar|>))
+"     ...the (bar) list will be selected: i.e., this function doesn't call super_range().
 "
-"   * s:countindex is greater than 0 and the mark '< is valid. Occurs when
-"     called by sexp#docount()
+"   * s:countindex is greater than 0 and the visual marks are valid.
+"     Use Case: Counted expansion by sexp#docount().
 "
-" Will set both to [0, 0, 0, 0] if none are found and mode does not equal 'v'.
+" Visual Marks: Both are deleted if there's no list to select and mode does not equal 'v'.
+" Rationale: Erase < > only to prevent operation (o-pending mode) on something that's not
+" a list. I could see an argument for erasing visual marks even in visual mode, but this
+" is the way it's always worked.
+" Note: If the optimal inner/outer list doesn't exist, but a suitable fallback does, set
+" both marks and the 'success' flag, but also set the 'stopiter' flag to allow a higher
+" level loop to terminate early.
 "
-" Returns 1 if marks were set successfully, and 0 if not.
+" Important Note: Originally, the first of the 2 expansion conditions listed above
+" worked only if cursor was at the *start* of the visual selection. This approach stopped
+" working when visual mode maps transitioned from using :<c-u> to <cmd>. The problem was
+" that :<c-u>, unlike <cmd>, forcibly sets cursor position to the start of the visual
+" region, whereas <cmd> leaves it unmodified. When visual mode mappings started using
+" <cmd>, cursor position was left at the end of the visual selection, with the result that
+" subsequent `af` commands didn't cause expansion (unless user hit `o` in between).
+" Possible Solutions: One possible solution would be to modify the command wrapper to
+" ensure that we always set cursor to the start of the visual region when executing a
+" visual mode map. However, this feels like a kludge. A better solution is to implement
+" the same expansion logic whether cursor is at start or end of visual selection. The
+" current version of this function takes this approach.
+" Return: Pair: [success, stopiter]
+"         success:  1 if visual marks were set
+"         stopiter: 1 if there's no point in continuing
 function! s:set_marks_around_current_list(mode, offset, allow_expansion)
-    " We may potentially move the cursor.
+    " Save/restore cursor.
     let cursor = getpos('.')
-    let cursor_moved = 0
-
-    " Prepare the entrails
-    let start = s:get_visual_beg_mark()
+    let [error, stopiter] = [0, 0]
     let visual = a:mode ==? 'v'
-    let counting = s:countindex > 0
-    let start_is_valid = start[1] > 0
-    let have_selection = start_is_valid
-        \ && sexp#compare_pos(start, s:get_visual_end_mark()) != 0
-    let expanding = a:allow_expansion && (counting || (visual && have_selection))
+    try
+        " Prepare the entrails
+        let [vs, ve] = s:get_visual_marks()
+        let counting = s:countindex > 0
+        " Note: Historically, single-char visual selection did not permit expansion.
+        " Rationale: Makes sense for non-list elements, as it would allow you to hit `v`
+        " and execute an inner/outer object without worrying about whether the element is
+        " single or multi-char. Not sure it makes as much sense for lists, but that's the
+        " way it's always worked.
+        let have_selection = vs[1] && ve[1] && sexp#compare_pos(vs, ve) != 0
+        " Note: This flag being set doesn't guarantee expansion; it's just a more
+        " restrictive version of the input flag.
+        let expanding = a:allow_expansion && have_selection && (counting || visual)
 
-    " When evaluating via sexp#docount the cursor position will not be updated
-    " to '<, so do it now.
-    if counting && start_is_valid
+        " To prevent unintentional changes to visual selection, make sure we're not in
+        " visual mode before moving cursor.
+        " Note: We'll be in visual mode at this point if we were invoked from the
+        " sexp#docount loop.
         if mode() ==? 'v' | execute "normal! \<Esc>" | endif
-        call s:setcursor(start)
-        let cursor = start
-        let cursor_moved = 1
-    endif
 
-    " Native object selections expand when repeating inner motions as well
-    if expanding
-        \ && a:offset == 1
-        \ && getline(cursor[1])[cursor[2] - 2] =~# s:opening_bracket
-        normal! h
-        let cursor = getpos('.')
-        let cursor_moved = 1
-    endif
-
-    let ignored = s:is_rgn_type('str_com_chr', cursor[1], cursor[2])
-    let char = getline(cursor[1])[cursor[2] - 1]
-
-    if !ignored && char =~# s:opening_bracket
-        if expanding
-            if s:move_to_nearest_bracket(1)[1] > 0
-                let cursor_moved = 1
-                call s:move_to_nearest_bracket(1) " Expansion step
-            endif
-            let open = s:pos_with_col_offset(s:nearest_bracket(0), a:offset)
-            let close = s:pos_with_col_offset(getpos('.'), -a:offset)
+        " Determine innermost containing list.
+        let isl = s:is_list(cursor[1], cursor[2])
+        if isl == 2
+            " Cursor on open
+            let [open, close] = [cursor, s:nearest_bracket(1)]
+        elseif isl == 3
+            " Cursor on close
+            let [open, close] = [s:nearest_bracket(0), cursor]
         else
-            let open = s:pos_with_col_offset(getpos('.'), a:offset)
-            let close = s:pos_with_col_offset(s:nearest_bracket(1), -a:offset)
+            " Not on list brackets, so look up.
+            let open = s:nearest_bracket(0)
+            let close = open[1] ? s:nearest_bracket(1) : s:nullpos
         endif
-    elseif !ignored && char =~# s:closing_bracket
-        let open = s:pos_with_col_offset(s:nearest_bracket(0), a:offset)
-        let close = s:pos_with_col_offset(getpos('.'), -a:offset)
-    else
-        let open = s:pos_with_col_offset(s:nearest_bracket(0), a:offset)
-        let close = s:pos_with_col_offset(s:nearest_bracket(1), -a:offset)
-    endif
+        if !open[1]
+            " Not on or in a list; nothing to do.
+            throw 'sexp-error'
+        endif
+        " Note: If we get here, we have something we can select, even if it's not optimal:
+        " i.e., error flag should not be set below.
 
-    let success = 0
+        if expanding && a:offset && (isl == 2 || isl == 3)
+            " Cursor is on a list bracket and we're looking for an *inner* list, so look
+            " higher.
+            call s:setcursor(open)
+            let p = s:move_to_nearest_bracket(0)
+            if p[1]
+                let [open, close] = [p, s:nearest_bracket(1)]
+            else
+                let stopiter = 1
+            endif
+        endif
+        " Determine a *candidate* range: either the containing list or just inside it.
+        " Design Decision: Don't inhibit inner selection here if stopiter was set above.
+        " Rationale: Might as well make the selection inner as requested, even if we would
+        " have preferred to expand: e.g., if on a toplevel list, hitting a sequence of
+        " `af` and `if` should toggle between inner/outer.
+        let s = a:offset ? sexp#offset_char(open, 1, 1) : open
+        let e = a:offset ? sexp#offset_char(close, 0, 1) : close
 
-    " Inner selection on adjacent brackets results in open being one character
-    " past close due to offset calculations
-    if open[1] > 0 && close[1] > 0 && sexp#compare_pos(open, close) < 0
-        call s:set_visual_marks([open, close])
-        let success = 1
-    " Don't erase marks when in visual mode
-    elseif !visual
-        delmarks < >
-    endif
+        " Native object selections expand when repeating inner motions, so we do too.
+        " Attempt expansion only if visual selection includes *all* of candidate range:
+        " i.e., only if selecting the current target would not expand visual selection.
+        if expanding && !stopiter
+            \ && sexp#compare_pos(vs, s) <= 0 && sexp#compare_pos(ve, e) >= 0
+            call s:setcursor(open)
+            let p = s:move_to_nearest_bracket(0)
+            if p[1]
+                " Adjust selection.
+                let [s, e] = [p, s:nearest_bracket(1)]
+                if a:offset
+                    let s = sexp#offset_char(s, 1, 1)
+                    let e = sexp#offset_char(e, 0, 1)
+                endif
+            else
+                let stopiter = 1
+            endif
+        endif
 
-    if cursor_moved
-        call s:setcursor(cursor)
-    endif
-
-    return success
+        if sexp#compare_pos(s, e) > 0
+            " Special Case: Inner selection on adjacent brackets results in s being one
+            " character past e. Handle by reversing range.
+            let [s, e] = [e, s]
+        endif
+        call s:set_visual_marks([s, e])
+    catch /sexp-error/
+        let [error, stopiter] = [1, 1]
+    finally
+        " Don't erase marks when in visual mode. (See note in header.)
+        if error && !visual
+            delmarks < >
+        endif
+        if getpos('.') != cursor
+            call s:setcursor(cursor)
+        endif
+        return [!error, stopiter]
+    endtry
 endfunction
 
 " Set visual marks to the positions of the outermost paired brackets from the
@@ -2909,19 +2963,27 @@ endfunction
 " that selection. Selects current element if cursor is not in a list.
 " -- Optional Args --
 " a:1  list_only - Set to inhibit fallback to element if no list.
+" TODO: Consider reworking commands to set list_only in more cases.
+" Rationale: I don't like the fact that something like daf will delete arbitrary,
+" non-listy forms.
 function! sexp#select_current_list(mode, offset, allow_expansion, ...)
     let list_only = a:0 && !!a:1
-    if !s:set_marks_around_current_list(a:mode, a:offset, a:allow_expansion)
-        \ && !list_only
-        " TODO: I'd really rather hard-code 1 for inner here, but need to
-        " consider backwards-compatability...
-        " FIXME: The thing is, "inner" means something different for lists:
-        " i.e., even outer doesn't select whitespace around the list, so if
-        " we're going to fall back to current element, I think it should be
-        " inner, regardless of a:offset.
-        call s:set_marks_around_current_element(a:mode, 1, 0, 0) "a:offset)
+    let [success, stopiter] =
+        \ s:set_marks_around_current_list(a:mode, a:offset, a:allow_expansion)
+    if !success && !list_only
+        " Fallback to current element (for historical reasons).
+        " Hard-code 1 for inner.
+        " Rationale: "inner" means something different for lists: i.e., even outer
+        " doesn't select whitespace around the list, so if we're going to fall back to
+        " current element, I think it should be inner, regardless of a:offset.
+        let success = !!s:set_marks_around_current_element(a:mode, 1, 0, 0)[0][1]
     endif
-    return s:select_current_marks(a:mode)
+    let success = success && s:select_current_marks(a:mode)
+    if stopiter && get(s:, 'countindex', -1) >= 0
+        " Don't continue sexp#docount() loop.
+        throw "stop-iter"
+    endif
+    return success
 endfunction
 
 " Set visual marks at current outermost list's brackets, then enter visual
@@ -7239,8 +7301,11 @@ function! sexp#docount(count, func, ...)
             let s:countindex = n
             call call(a:func, a:000)
         endfor
+    catch /stop-iter/
+        " Provide a way for funcs to request early termination when they know there's no
+        " point in continuing. So far, only select_current_list takes advantage of this.
     finally
-        let s:countindex = 0
+        let s:countindex = -1
     endtry
 endfunction
 

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -214,6 +214,28 @@ function! s:nearest_bracket(closing, ...)
     return call('s:invoke', ['nearest_bracket', a:closing] + a:000)
 endfunction
 
+" Return position representing the bracket that *contains* the cursor position, else
+" nullpos if top-level.
+" Note: Differs from s:nearest_bracket() only when reference pos is *on* bracket of type
+" corresponding to 'closing'.
+function! s:containing_bracket(closing, ...)
+    let save_cursor = getcurpos()
+    " TODO: Consider using s:is_list() to determine whether we need to look up a level.
+    try
+        let p = call('s:nearest_bracket', [a:closing] + a:000)
+        " Check to see whether this is the matching bracket of input pos.
+        call s:setcursor(p)
+        let opos = s:nearest_bracket([!a:closing] + a:000)
+        if !sexp#compare_pos(opos, save_cursor)
+            " We found matching bracket. Need to go up a level.
+            let p = call('s:nearest_bracket', [a:closing] + a:000)
+        endif
+        return p
+    finally
+        call s:setcursor(save_cursor)
+    endtry
+endfunction
+
 function! s:list_open()
     let cursor = getpos('.')
     let ret = [0, 0, 0, 0]
@@ -1698,11 +1720,15 @@ endfunction
 
 " Returns nonzero if input position is at toplevel.
 function! s:at_top(line, col)
-    let cursor = getpos('.')
-    call s:setcursor([0, a:line, a:col, 0])
-    let ret = !s:nearest_bracket(0)[1] || !s:nearest_bracket(1)[1]
-    call s:setcursor(cursor)
-    return ret
+    let save_cursor = getcurpos()
+    try
+        let cursor = getpos('.')
+        call s:setcursor([0, a:line, a:col, 0])
+        let ret = !s:nearest_bracket(0)[1] || !s:nearest_bracket(1)[1]
+        return ret
+    finally
+        call s:setcursor(save_cursor)
+    endtry
 endfunction
 
 " Returns nonzero if input position first non-ws on line
@@ -1760,12 +1786,15 @@ endfunction
 " whitespace that separates tokens.
 fu! sexp#range_has_ws(beg, end, check_ignored)
     let save_cursor = getcurpos()
-    call setpos('.', a:beg)
-    " Note: Empty 'skip' skips nothing.
-    let pos = searchpos('\s', 'nczW', a:end[1], 0, a:check_ignored ? s:match_ignored_region_fn : '')
-    let ret = pos[0] && sexp#compare_pos([0, pos[0], pos[1], 0], a:end) <= 0
-    call setpos('.', save_cursor)
-    return ret
+    try
+        call s:setcursor(a:beg)
+        " Note: Empty 'skip' skips nothing.
+        let pos = searchpos('\s', 'nczW', a:end[1], 0, a:check_ignored ? s:match_ignored_region_fn : '')
+        let ret = pos[0] && sexp#compare_pos([0, pos[0], pos[1], 0], a:end) <= 0
+        return ret
+    finally
+        call s:setcursor(save_cursor)
+    endtry
 endfu
 
 " Return true iff there's *any* non-whitespace in the range [beg,end].
@@ -1774,32 +1803,55 @@ endfu
 fu! sexp#range_has_non_ws(beg, end, check_ignored)
     let ret = 0
     let save_cursor = getcurpos()
-    call setpos('.', a:beg)
-    let pos = searchpos('\S', 'nczW', a:end[1])
-    let ret = pos[0] && sexp#compare_pos([0, pos[0], pos[1], 0], a:end) <= 0
-    if !ret && a:check_ignored
-        " No true non-ws, but check for "ignored" ws, which counts as the same thing...
-        let pos = searchpos('\s', 'nczW', a:end[1], 0, s:nomatch_ignored_region_fn)
-        " Return true iff we found ignored ws within region.
+    try
+        call s:setcursor(a:beg)
+        let pos = searchpos('\S', 'nczW', a:end[1])
         let ret = pos[0] && sexp#compare_pos([0, pos[0], pos[1], 0], a:end) <= 0
-    endif
-    call setpos('.', save_cursor)
-    return ret
+        if !ret && a:check_ignored
+            " No true non-ws, but check for "ignored" ws, which counts as the same thing...
+            let pos = searchpos('\s', 'nczW', a:end[1], 0, s:nomatch_ignored_region_fn)
+            " Return true iff we found ignored ws within region.
+            let ret = pos[0] && sexp#compare_pos([0, pos[0], pos[1], 0], a:end) <= 0
+        endif
+        return ret
+    finally
+        call s:setcursor(save_cursor)
+    endtry
+endfu
+
+" Return true iff both ends of the range are at the same level.
+fu! sexp#is_uniform_range(rng)
+    let save_cursor = getcurpos()
+    try
+        let open = [s:nullpos, s:nullpos]
+        " Find *containing* open for each end.
+        for i in range(2)
+            call s:setcursor(a:rng[i])
+            let open[i] = s:containing_bracket(0)
+        endfor
+        " Range is uniform if both ends are at same (possibly top) level.
+        return !open[0][1] && !open[1][1] || open[0] == open[1]
+    finally
+        call s:setcursor(save_cursor)
+    endtry
 endfu
 
 " Return true iff specified SexpPos is on whitespace (or blank if allow_blank).
 " Note: See previous function comment for usage of 'check_ignored'.
 fu! s:in_whitespace(pos, allow_blank, check_ignored)
-    local save_cursor = getcurpos()
-    call setpos('.', a:pos)
-    " Anchor search at cursor for efficiency (in case line is long).
-    " TODO: Consider different approach: e.g., grabbing and testing the char in lieu of
-    " search().
-    let re = '\v%.c\s' . (a:allow_blank ? '|^$' : '')
-    let pos = searchpos(re, 'nczW', a:pos[1], 0, a:check_ignored ? s:match_ignored_region_fn : '')
-    let ret = pos[0] && pos == save_cursor[1:2]
-    call setpos('.', save_cursor)
-    return ret
+    let save_cursor = getcurpos()
+    try
+        call s:setcursor(a:pos)
+        " Anchor search at cursor for efficiency (in case line is long).
+        " TODO: Consider different approach: e.g., grabbing and testing the char in lieu of
+        " search().
+        let re = '\v%.c\s' . (a:allow_blank ? '|^$' : '')
+        let pos = searchpos(re, 'nczW', a:pos[1], 0, a:check_ignored ? s:match_ignored_region_fn : '')
+        let ret = pos[0] && pos == save_cursor[1:2]
+        return ret
+    finally
+        call s:setcursor(save_cursor)
+    endtry
 endfu
 
 " Return input range adjusted inward such that start/end are both on non-whitespace.
@@ -3214,6 +3266,7 @@ function! s:regput__check_list_context(ctx, reg)
                 call add(ps, [sexp#current_element_terminal(0), prev_e])
                 let sidx += 1
             else
+                " FIXME: Check for `(' and return 0 if it's not what we hit!!!
                 break
             endif
         endwhile
@@ -3248,6 +3301,7 @@ function! s:regput__check_list_context(ctx, reg)
     " Special case requires at least 3 elements.
     " Rationale: We're looking for a list "shape" defined by 3 elements:
     "   (func arg1 arg2 NL arg3 ...)
+    " FIXME: Need to consider bracket type as well: only lists with ( ) should qualify.
     if eidx >= 3
         " TODO: Use s:is_list() and regex to test for (let* [ ...) here...
         " Cache some useful vars pertaining to the first 3 elements of list.
@@ -3297,11 +3351,13 @@ function! s:regput__get_seps(ctx, reg)
     let force_ml = g:sexp_regput_linewise_forces_multiline && reg.linewise
     " Determine whether put is into one of the special slots in a 'shaped' list.
     " Note: Inhibit this special case logic if more than one toplevel element in register.
+    " Also, inhibit for replace modes, in which case, we have an existing shape we don't
+    " really want to override.
     " Rationale: For the special logic to be meaningful in the multiple toplevel element
     " case, we'd need not only to parse the register text (already doing so), but also
     " potentially *modify* the whitespace between elements, which is analogous to the
     " 'interior separators' used for [count] > 1.
-    let lpi = g:sexp_regput_ignore_list_shape
+    let lpi = g:sexp_regput_ignore_list_shape || ctx.put_mode =~ 'replace'
         \ || reg.elem_count > 1 || ctx.empty_buffer || ctx.empty_list
         \ ? 0 : s:regput__check_list_context(ctx, reg)
     " Override the NL separators as needed.
@@ -3332,7 +3388,7 @@ function! s:regput__get_seps(ctx, reg)
                 let want_spc = !force_ml
                     \ && ctx.is_ele[i] && !ctx.alone[i] && !ctx.force_nl[i]
                     \ && !reg.is_ml && reg.elem_count <= 1
-                    \ && (tail != -1 && (i != tail || ctx.colinear[i]))
+                    \ && (tail == -1 || (i != tail || ctx.colinear[i]))
             endif
             " Override NL (if necessary).
             " Note: Special logic for replace mode puts may subsequently override this.
@@ -3763,6 +3819,9 @@ function! s:replace__get_tgt_visual(count, tgt)
     let curpos = getpos('.')
     try
         let [vs, ve] = s:get_visual_marks()
+        " TODO: Decide whether there should be any constraints on this: e.g., should we
+        " convert a range that crosses list boundaries (i.e., ends at different levels) to
+        " a super range, or should we warn and abort???
         let [s, e] = s:super_range(vs, ve)
         " Preceding call to s:super_range() obviates need for ignored region checking.
         if !sexp#range_has_non_ws(s, e, 0)
@@ -3796,6 +3855,29 @@ function! s:replace__get_tgt_normal(count, tgt)
     let a:tgt.inner_range = [p, sexp#current_element_terminal(1)]
 endfunction
 
+function! s:replace_mode__process_inner_range(tgt)
+    " Augment dict provided by caller.
+    let ret = a:tgt
+    " Determine the range that *contains* inner_range.
+    for i in range(2)
+        call s:setcursor(ret.inner_range[i])
+        let p = sexp#nearest_element_terminal(i, !i, 1, 1)
+        if p[1]
+            let ret.is_ele[i] = 1
+        else
+            let p = s:nearest_bracket(i)
+            if p[1]
+                let ret.is_bra[i] = 1
+            else
+                " Default to buffer extremity.
+                let p = i ? [0, line('$'), col([line('$'), '$']), 0] : s:BOF
+            endif
+        endif
+        let ret.range[i] = p
+    endfor
+    return ret
+endfunction
+
 " Note: To avoid duplication, both replace and replace_child are handled by this function.
 function! s:replace_mode__get_tgt(put_mode, mode, count, tail, P)
     let curpos = getpos('.')
@@ -3824,26 +3906,86 @@ function! s:replace_mode__get_tgt(put_mode, mode, count, tail, P)
             endif
             let ret.inner_range = cr.range
         endif
-        " Determine the range that *contains* inner_range.
-        for i in range(2)
-            call s:setcursor(ret.inner_range[i])
-            let p = sexp#nearest_element_terminal(i, !i, 1, 1)
-            if p[1]
-                let ret.is_ele[i] = 1
-            else
-                let p = s:nearest_bracket(i)
-                if p[1]
-                    let ret.is_bra[i] = 1
-                else
-                    " Default to buffer extremity.
-                    let p = i ? [0, line('$'), col([line('$'), '$']), 0] : s:BOF
-                endif
-            endif
-            let ret.range[i] = p
-        endfor
+        " Determine (outer) range from inner and set the is_{ele,bra}[] flags.
+        call s:replace_mode__process_inner_range(ret)
         return ret
     finally
         call s:setcursor(curpos)
+    endtry
+endfunction
+
+" TODO: Consider having this subsumed by s:replace_mode__get_tgt(), handled as just
+" another put_mode. If that's done, s:replace_mode__process_inner_range() could be
+" inlined.
+" ACTUALLY... Non-operator replace is going away...
+function! s:replace_op__get_tgt(ctx)
+    let ctx = a:ctx
+    let ret = {
+        \ 'mode': ctx.mode, 'put_mode': 'replace_op', 'count': ctx.count, 'P': ctx.P,
+        \ 'curpos': ctx.curpos, 'vrange': s:get_visual_marks(),
+        \ 'range': [s:nullpos, s:nullpos],
+        \ 'inner_range': [s:nullpos, s:nullpos],
+        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
+        \ 'tail': -1, 'force_nl': [0, 0]}
+    try
+        let [s, e] = [getpos("'["), getpos("']")]
+        let [s_orig, e_orig] = [s[:], e[:]]
+        if !sexp#range_has_non_ws(s, e, 1)
+            throw 'sexp-abort: Invalid attempt to apply replace operator'
+                \ . ' to pure whitespace'
+        endif
+        let rng = [s, e]
+        if !sexp#is_uniform_range(rng)
+            throw 'sexp-abort: Invalid attempt to apply replace operator'
+                \ . ' to range that crosses list boundaries'
+        endif
+        for i in range(2)
+            call s:setcursor(rng[i])
+            let rng[i] = sexp#move_to_current_element_terminal(i)
+            if !rng[i][1]
+                " Attempt to find nearest terminal in inward direction.
+                let rng[i] = sexp#move_to_adjacent_element_terminal(!i)
+            endif
+        endfor
+        let ret.inner_range = rng
+        " Determine (outer) range from inner and set the is_{ele,bra}[] flags.
+        call s:replace_mode__process_inner_range(ret)
+        return ret
+    finally
+        call s:setcursor(ctx.curpos)
+    endtry
+endfunction
+
+function! sexp#replace_op(mode, count, P, ...)
+    if !a:0
+        " Initial call
+        let ctx = {
+            \ 'curpos': getpos('.'),
+            \ 'mode': a:mode, 'count': a:count, 'P': a:P
+        \ }
+        " The call via 'opfunc' will get the original args + the context dict.
+        let &opfunc = function('sexp#replace_op', [a:mode, a:count, a:P, ctx])
+        return 'g@'
+    endif
+    try
+        " If here, we've been invoked by the 'opfunc' mechanism.
+        let [ctx, type] = a:000
+        if type != 'char'
+            call sexp#warn#msg("sexp#replace_op:"
+                \ " Invalid use of mode '" . type . "' with replace operator."
+                \ " Only charwise mode supported")
+            return
+        endif
+        "echomsg "replace_op:" string(ctx) "type=" type "'[:" getpos("'[") "']:" getpos("']")
+        let tgt = s:replace_op__get_tgt(ctx)
+        "echomsg "replace_op" string(tgt)
+        call s:regput__impl(tgt, a:count)
+
+    catch /sexp-\%(warning\|abort\):/
+        call sexp#warn#msg(v:exception)
+    catch
+        " Show throwpoint only for unexpected errors.
+        call sexp#warn#msg(v:exception . " at " . v:throwpoint)
     endtry
 endfunction
 
@@ -3856,6 +3998,7 @@ function! sexp#replace(mode, count, P)
         " Target determination is mode-specific.
         let tgt = s:replace_mode__get_tgt('replace', a:mode, cnt, -1, a:P)
         " Design Decision: Let tail==1 represent put with P.
+        echomsg "replace:" string(tgt)
         call s:regput__impl(tgt, cnt)
     catch /sexp-warning:/
         call sexp#warn#msg(v:exception)

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3369,16 +3369,20 @@ function! s:regput__get_context(tgt_info)
             " side. May be nullpos if current range endpoint is at buffer extremity.
             let [outer, outer_is_bra] = [s:nullpos, 0]
             if !ret.is_bra[i]
-                " Attempt to find outer adjacent.
-                call s:setcursor(ret.range[i])
-                let outer = sexp#nearest_element_terminal(i, !i, 1, 1)
-                if !outer[1]
-                    " Pre-position on outside of element to ensure that if element is
-                    " list, nearest_bracket doesn't find its match.
-                    call sexp#move_to_current_element_terminal(i)
-                    let outer = s:nearest_bracket(i)
-                    if outer[1]
-                        let outer_is_bra = 1
+                " No point in looking for adjacent or containing bracket if at BOF.
+                " TODO: Do we also need an EOF check?
+                if i || ret.range[i] != s:BOF
+                    " Attempt to find outer adjacent.
+                    call s:setcursor(ret.range[i])
+                    let outer = sexp#nearest_element_terminal(i, !i, 1, 1)
+                    if !outer[1]
+                        " Pre-position on outside of element to ensure that if element is
+                        " list, nearest_bracket doesn't find its match.
+                        call sexp#move_to_current_element_terminal(i)
+                        let outer = s:nearest_bracket(i)
+                        if outer[1]
+                            let outer_is_bra = 1
+                        endif
                     endif
                 endif
             endif
@@ -4586,6 +4590,8 @@ function! s:yankdel_range__preadjust_range(start, end, del_or_spl, inc)
         let [i0, i1] = a:inc
         if i0 == 1 || i1 == 1
             " One side inclusive, the other side some form of exclusive
+            " Rationale: Getting inside the empty range `if' above guarantees at least one
+            " side was exclusive.
             if i0 != 2 && i1 != 2
                 " By convention, empty range with one side inclusive and the other side
                 " normal-exclusive requests a directed put with direction given by the
@@ -4605,11 +4611,17 @@ function! s:yankdel_range__preadjust_range(start, end, del_or_spl, inc)
             endif
         else
             " Both sides some form of exclusive
-            " Handle as directed put from adjusted end.
+            " Handle as directed "put after" from adjusted end, unless adjusted end is
+            " before start of buffer, in which case we need to make it a "put before" from
+            " start.
             " Rationale: Intended use cases of adjacent whitespace-exclusive are such that
-            " when a choice must be made (because adjacent start/end overlap), it's better to
-            " preserve all of the adjacent whitespace at end.
-            let [ret.pos, ret.cmd] = [end, 'p']
+            " when a choice must be made (because adjacent whitespace start/end overlap),
+            " it's better to preserve all of the adjacent whitespace at end. As for
+            " special BOF case, consider that an adjusted end at virtual BOF position will
+            " be forcibly adjusted to [0,1,1,0] before the put, with the result that a
+            " forward put from adjusted end would leave the initial buffer char *before*
+            " the put text, which is definitely not what we want!
+            let [ret.pos, ret.cmd] = end == s:BOF ? [start, 'P'] : [end, 'p']
         endif
     else
         " Adjusted range non-empty; no need to adjust cmd, which is one of [yds]. (All

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -209,7 +209,7 @@ endfunction
 "
 " Accepts alternate beginning and ending patterns as optional parameters.
 function! s:nearest_bracket(closing, ...)
-    return call('s:invoke', ['nearest_bracket', a:closing] + a:000)
+    return call('sexp#invoke', ['nearest_bracket', a:closing] + a:000)
 endfunction
 
 " Return position representing the bracket that *contains* the cursor position, else
@@ -365,7 +365,7 @@ endfu
 " [0, 0, 0, 0] if not currently in an atom. Assumes atoms never span multiple
 " lines.
 function! s:current_atom_terminal(end)
-    return s:invoke('current_atom_terminal', a:end)
+    return sexp#invoke('current_atom_terminal', a:end)
 endfunction
 
 " Returns 1 if character at position is an atom.
@@ -677,7 +677,7 @@ let s:dispatch_warned = {'ts': {}, 'syn': {}}
 " function with the provided arguments, with fallback to the latter if the former returns
 " nil (indicating a missing tree or some other serious issue).
 " Warn user once-only about the following two conditions:
-" 1) We prefer to use Treesitter but the ts.lua method return nil (typically because
+" 1) We prefer to use Treesitter but the ts.lua method returns nil (typically because
 "    there's no language parser, though there could be other reasons).
 " 2) We need legacy syntax but it's not available: i.e., *neither* Treesitter *nor* legacy
 "    syntax.
@@ -688,7 +688,14 @@ let s:dispatch_warned = {'ts': {}, 'syn': {}}
 " checks at the point of individual implementation function invocations. Currently, this
 " approach is complicated by the existence of insert-mode maps, which have nothing
 " analogous to sexp#pre_op() but do invoke methods requiring dispatch.
-fu! s:invoke(fn, ...)
+" TODO: Considered providing mechanism for dispatch to modules other than ts.lua and
+" sexp#autoload; for now, it seems unnecesary.
+" Rationale: ts.lua and sexp#autoload essentially the api for the lua and vim pieces,
+" respectively. If the implementation requires functions in other modules, the
+" corresponding ts.lua or sexp#autoload function can wrap them.
+" Note: This function is part of the API to permit its name to be used as a callback from
+" other modules (currently only in sexp#parse).
+fu! sexp#invoke(fn, ...)
     if s:prefer_treesitter()
         let ret = luaeval(
                     \ "require'sexp.ts'." . a:fn . "(" . 
@@ -700,14 +707,16 @@ fu! s:invoke(fn, ...)
         endif
         " Warn once only.
         call sexp#warn#msg_once('missing_ts',
-            \ "Warning: Falling back to legacy syntax. Have you installed Treesitter parser for " . &filetype . "?")
+            \ "Warning: Falling back to legacy syntax."
+            \ . " Have you installed Treesitter parser for " . &filetype . "?")
     endif
     " Arrival here means we won't or can't use Treesitter. If we don't have legacy syntax,
     " we're going to have a problem, so warn...
     if empty(get(b:, 'current_syntax', ''))
         " Note: Display with error highlighting, as this is more serious than missing
         " Treesitter parser, since we have nothing to fallback to.
-        call sexp#warn#msg_once('missing_syn', "Warning: No syntax available for filetype '" . &filetype . "'", 1)
+        call sexp#warn#msg_once('missing_syn',
+            \ "Warning: No syntax available for filetype '" . &filetype . "'", 1)
         " Fall through to legacy function *without* syntax, since we've no better option.
     endif
     " Use legacy approach.
@@ -759,7 +768,7 @@ fu! s:current_region_terminal_legacy(rgn, dir)
 endfu
 
 fu! s:current_region_terminal(rgn, end)
-    return s:invoke('current_region_terminal', a:rgn, a:end)
+    return sexp#invoke('current_region_terminal', a:rgn, a:end)
 endfu
 
 " Return start of leading (0) or end of trailing (1) whitespace from pos.
@@ -1486,7 +1495,7 @@ function! s:super_range(start, end)
     endif
     " No short-circuit optimization was performed; call the more expensive function to
     " get a possibly expanded range.
-    let [start, end] = s:invoke('super_range', start, end)
+    let [start, end] = sexp#invoke('super_range', start, end)
     if !start[1]
         return s:nullpos_pair
     endif
@@ -1901,7 +1910,7 @@ fu! s:is_rgn_type_legacy(rgn, line, col)
 endfu
 
 fu! s:is_rgn_type(rgn, line, col)
-    return s:invoke('is_rgn_type', a:rgn, a:line, a:col)
+    return sexp#invoke('is_rgn_type', a:rgn, a:line, a:col)
 endfu
 
 """ CURSOR MOVEMENT {{{1
@@ -3110,10 +3119,40 @@ function! s:insert_brackets_around_current_element(bra, ket, at_tail, headspace)
     call s:insert_brackets_around_visual_marks(a:bra, a:ket, a:at_tail, a:headspace)
 endfunction
 
-" Simple pass-through to autoload function that puts the codestr in a temporary buffer for
-" parsing.
-function! s:analyze_codestr_legacy(codestr, filetype)
-    return sexp#parse#analyze_codestr(a:codestr, a:filetype)
+" Pass-through to sexp#parse autoload function, which wraps the call in a temporary parse
+" buffer resource if and only if the 'needbuf' flag is set.
+function! s:analyze_codestr_legacy(codestr, filetype, needbuf)
+    if a:needbuf
+        return sexp#parse#do_in_buf('sexp#parse#analyze_codestr', a:codestr, a:filetype,
+            \ a:codestr, a:filetype)
+    else
+        " Assumption: Already inside the temporary parse buffer
+        return sexp#parse#analyze_codestr(a:codestr, a:filetype)
+    endif
+endfunction
+
+" Parse the input 'codestr' as 'filetype' and return a dictionary whose format is
+" described by ts.lua.ParseResult.
+" Intended Use Case: Use the returned dictionary to validate a register put.
+function! s:analyze_codestr(codestr, filetype)
+    " Note: The final boolean arg to analyze_codestr() has a slightly different meaning
+    " for vim/lua:
+    "   vim: true => need to create the temporary buffer
+    "   lua: true => use string parser
+    if !s:prefer_treesitter() || !g:sexp_regput_use_string_parser
+        " Either we're using legacy syntax, which always uses a temporary buffer for
+        " parsing, or we're using Treesitter and user hasn't set the flag requesting use
+        " of a string parser. In either case, wrap the analyze_codestr invocation in a
+        " function that manages the temporary buffer as an RAII resource (think Python
+        " Context Manager).
+        return sexp#parse#do_in_buf('sexp#invoke', a:codestr, a:filetype,
+            \ 'analyze_codestr', a:codestr, a:filetype, v:false)
+    else
+        " Looks like a Treesitter string parse is in order; however, we still use
+        " sexp#invoke() (rather than calling sexp.ts.analyze_codestr() directly) to permit
+        " fallback in the event of Treesitter failure.
+        return sexp#invoke('analyze_codestr', a:codestr, a:filetype, v:true)
+    endif
 endfunction
 
 " Create and return a context dict with a superset of the keys required by the various
@@ -3146,10 +3185,10 @@ function! s:regput__ctx_init(mode, put_mode, count, ...)
     return ctx
 endfunction
 
-" Note: This version does everything manually, with no parsing.
-" It has been superseded by s:analyze_codestr_legacy(), which delegates the actual parsing
-" to sexp#parse#analyze_codestr(); however, I may allow it to be selected by expert (or
-" even hidden) option.
+" A simplistic version of analyze_codestr(), which performs some rudimentary regex
+" matching in lieu of a full parse. It is used as fallback if the Treesitter/legacy parse
+" fails *or* user has disabled register parsing via option.
+" Return: See sexp#parse#analyze_codestr() or sexp.ts.ParseResult.
 function! s:analyze_codestr_simple(codestr, filetype)
     " Note: Processed text added later.
     " TODO: Some of these fields won't be set properly until we're creating a hidden
@@ -3239,7 +3278,8 @@ function! s:regput__get_reginfo(regname)
         throw "sexp-noop"
     endif
     if !g:sexp_regput_inhibit_regparse
-        let ret = s:invoke('analyze_codestr', regstr, &ft)
+        " Attempt proper parse.
+        let ret = s:analyze_codestr(regstr, &ft)
     endif
     if empty(ret)
         " Either something went wrong or register parsing is inhibited by option.

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2925,6 +2925,7 @@ endfunction
 " Return Dict:
 "   Note: List keys are pairs whose indices correspond to the elements of range[].
 "   --[[ Beginning of merged-in tgt_info dict
+"   count:           [count] associated with the operation
 "   put_mode:        one of 'put', 'put_child', 'replace', 'replace_child'
 "   tail:            possibly adjusted version of the input flag
 "                    Note: Adjustment performed only when cursor not on element
@@ -3023,6 +3024,7 @@ endfunction
 " * First element is single-line (most likely name of function).
 " * First and second element are colinear.
 " * Third element is either nonexistent or non-colinear with second element.
+"   TODO: Consider requiring third element to exist.
 " * (optional) List is not a 'let' form.
 "   TODO: The 'reg' parameter, currently unused, was added to support this.
 " Rationale: This function is used to determine whether calculated separators may require
@@ -3131,29 +3133,41 @@ function! s:regput__get_seps(ctx, reg)
     if ctx.empty_buffer
         let ret[0:1] = [s:EMPTY, s:EMPTY]
     else
-        " Give list position logic a chance to request separator override.
-        " Supersedence Logic: Non-N/A values in returned lpi dict supersede the normal
-        " flag logic. Since the default separator is NL, a NL in lpi clears the
-        " corresponding *_side_spc flag and a SPC sets it.
-        let lpi = s:regput__check_list_context(ctx, reg)
+        " Determine whether put is into one of the special slots in a 'shaped' list.
+        " Note: Inhibit this special case logic if more than one toplevel element in
+        " register.
+        " Rationale: For the special logic to be meaningful in the multiple toplevel
+        " element case, we'd need not only to parse the register text (already doing so),
+        " but also potentially *modify* the whitespace between elements, which is
+        " analogous to the 'interior separators' used for [count] > 1.
+        let lpi = reg.elem_count > 1 ? 0 : s:regput__check_list_context(ctx, reg)
 
-        " Compute side-dependent flags used to determine SPC-insertion at both start/end.
-        " Note: These flags do not incorporate comment checks, which are applied below.
-        " Preserve colinearity at far side unless pasted text is ml.
-        " Note: There's a slight asymmetry between near/far side of range, but only for
-        " put modes that differentiate between tgt and adjacent. In these modes, the
-        " 'force_nl' flag is set only on the target side, and the colinearity check
-        " reflects our unwillingness to make put text colinear with adj unless adj was
-        " already colinear with target.
-        " Build want_spc array to support interior sep computation after loop.
         for i in range(2)
-            " Note: The ternary's first branch either inhibits SPC (ensuring default to
-            " NL) or requests SPC explicitly (subject to comment constraints).
-            let want_spc = lpi
-                \ ? lpi == 2 && !i
-                \ : ctx.is_ele[i] && !ctx.alone[i] && !ctx.force_nl[i] && !reg.is_ml
-                \   && (tail == -1 || i != tail || ctx.colinear[i])
+            " Compute side-dependent 'want_spc' flag used to determine SPC-insertion at both
+            " start/end.
+            " Note: These flags do not incorporate comment checks, which are applied in
+            " separate step.
+            " Note: There's a slight asymmetry between near/far side of range, but only for
+            " put modes that differentiate between tgt and adjacent (i.e., directional puts).
+            " In these modes, the 'force_nl' flag is set only on the target side, and the
+            " side-dependent colinearity check reflects our unwillingness to make put text
+            " colinear with adj unless adj was already colinear with target.
+            " Note: Interior sep(s) are handled by separate logic after the loop.
+            if lpi == 2
+                " Slot 2 needs a leading SPC and a trailing NL (the latter of which is
+                " requested implicitly by clearing this flag).
+                let want_spc = !i
+            elseif lpi == 3 && !i
+                " Slot 3 needs a NL at the leading side. The !i guard condition ensures
+                " that normal logic will apply to trailing side.
+                let want_spc = 0
+            else
+                let want_spc =
+                    \ ctx.is_ele[i] && !ctx.alone[i] && !ctx.force_nl[i] && !reg.is_ml
+                    \ && (tail != -1 && (i != tail || ctx.colinear[i]))
+            endif
             " Override NL (if necessary).
+            " Note: Special logic for replace mode puts may subsequently override this.
             " TODO: Change {e,s}_is_com to is_com[] to obviate need for this.
             let is_com = i ? reg.e_is_com : reg.s_is_com
             if ctx.is_bra[i]
@@ -3170,9 +3184,12 @@ function! s:regput__get_seps(ctx, reg)
             if ctx.put_mode =~ 'replace'
                 " Replace Mode Separator Adjustment: Inhibit separator unless it's a NL
                 " and we're currently colinear at this end.
-                if ret[i] != s:NL
-                    let ret[i] = s:EMPTY
-                elseif ctx.range[i] != ctx.inner_range[i]
+                " Rationale: Ideally, the put text would *exactly* replace the existing
+                " text (delineated by ctx.inner_range[]), thereby minimizing visual
+                " disturbance; however, if NL sep has been requested on a side whose range
+                " endpoint is currently colinear with its nearest innner_range endpoint,
+                " we need to leave the NL request intact to ensure separation.
+                if ret[i] != s:NL || ctx.range[i] != ctx.inner_range[i]
                     let ret[i] = s:EMPTY
                 endif
             endif
@@ -3190,10 +3207,12 @@ function! s:regput__get_seps(ctx, reg)
     "   but we definitely don't want multiple single line comments placed on the same
     "   line.
     " * register contains multiple toplevel forms
-    " * put is targeted and near side sep is NL
+    " * put is directional (tail != -1) and near side sep is NL
+    "   *OR* putting forward into slot 2 and 
     "   Rationale: Testing has shown that failing to separate the clones from each other
     "   when the entire put was separated from the target violates POLS: i.e., extending
-    "   the NL insertion down through the clones just feels right.
+    "   the NL insertion down through the clones just feels right, especially when putting
+    "   forward from head.
     " * (optional) register contains single toplevel form whose length (or possibly length
     "   x count) exceeds configurable threshold.
     " TODO: Add the textwidth condition after working out the details and adding option.
@@ -3202,7 +3221,7 @@ function! s:regput__get_seps(ctx, reg)
     " it would still make sense to keep it for the case in which we're putting onto the
     " same line as target.
     let ret[2] = reg.is_ml || reg.has_com || reg.elem_count > 1
-        \ || (tail != -1 && ret[!tail] == s:NL) ? s:NL : s:SPC
+        \ || (tail != -1 && (lpi == 2 && tail || ret[!tail] == s:NL)) ? s:NL : s:SPC
     " Provide distinct separator for 1st interior separator if applicable.
     " Note: This element will be N/A if [count] == 1
     let ret[3] = lpi == 2 ? s:NL : ''
@@ -3422,7 +3441,7 @@ endfunction
 function! s:put__get_tgt(count, tail)
     let curpos = getpos('.')
     let ret = {
-        \ 'put_mode': 'put',
+        \ 'put_mode': 'put', 'count': a:count,
         \ 'range': [s:nullpos, s:nullpos],
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
         \ 'tail': a:tail, 'force_nl': [0, 0]}
@@ -3492,10 +3511,35 @@ function! s:put__get_tgt(count, tail)
     endtry
 endfunction
 
+function! s:regput__handle_as_put_child_maybe(count, tail)
+    if g:sexp_put_treats_list_as_element
+        " Feature disabled by user config
+        return 0
+    endif
+    let isl = s:is_list(line('.'), col('.'))
+    if !isl
+        " Not *on* list
+        return 0
+    endif
+    " We're on list bracket or macro chars. Short-circuit if put is away from list
+    " interior.
+    if !a:tail && isl != 3 || a:tail && isl == 3
+        return 0
+    endif
+    " All conditions met for converting put to put_child!
+    " Caveat: Toggle tail due to change in meaning: e.g.,
+    "   put from open bracket (tail == 1) ==> put at head (tail == 0)
+    call sexp#put_child(a:count, !a:tail)
+    " Let caller know it's been handled.
+    return 1
+endfunction
+
 function! sexp#put(count, tail)
-    let count = a:count ? a:count : 1
-    let tgt = s:put__get_tgt(count, a:tail)
-    call s:regput__impl(tgt, count, a:tail)
+    if !s:regput__handle_as_put_child_maybe(a:count, a:tail)
+        let count = a:count ? a:count : 1
+        let tgt = s:put__get_tgt(count, a:tail)
+        call s:regput__impl(tgt, count, a:tail)
+    endif
 endfunction
 
 function! s:replace__get_tgt_visual(count)
@@ -3509,7 +3553,7 @@ function! s:replace__get_tgt_normal(count)
     " don't care...
     let ret = {
         \ 'error': '',
-        \ 'put_mode': 'replace',
+        \ 'put_mode': 'replace', 'count': a:count,
         \ 'range': [s:nullpos, s:nullpos],
         \ 'inner_range': [s:nullpos, s:nullpos],
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
@@ -3571,14 +3615,33 @@ endfunction
 
 " Calculate and return the tgt_info dict needed by s:regput__get_context() for the case of
 " a 'put_child' command.
-" Note: For details, see header of s:regput__get_context().
+" Note: For details on this dict, see header of s:regput__get_context().
+" Tail Logic: For a non-child put, 'tail' indicates the *direction* of the put; for child
+" put mode, however, 'tail' indicates the side of the list at which the insert occurs (or
+" from which the insert position is offset by [count]). Although we could treat a child
+" put as a non-directional put, doing so would lead to the following ambiguity: in the
+" absence of a target, how do we decide which existing element to append/prepend to when
+" our contextual logic indicates appending/prepending makes sense. OTOH, if we make the
+" put directional, which direction makese sense? I.e., which element should server as the
+" target? Any answer to this question is bound to be somewhat arbitrary, but here's what
+" I'm thinking makes sense: when the put is *between* elements, the target is the element
+" furthest from the reference bracket (i.e., the bracket on the side from which put
+" occurs). As long as we take this approach, it's not necessary to toggle 'flag' in the
+" nominal case (put between child elements):
+" return dict: consider...
+"   put at head (a:tail == 0) <==> P (tail == 0)
+"   put at tail (a:tail == 1) <==> p (tail == 1)
+" However, when the [count] is so large that the desired element doesn't exist, we put
+" between terminal child and list bracket, treating the terminal child as the target.
+" Since the put in this case is in the opposite direction relative to the target, we
+" toggle 'tail' in the return dict to reflect the reversal.
 function! s:put_child__get_tgt(count, tail)
     let cursor = getpos('.')
     let ret = {
-        \ 'put_mode': 'put_child',
+        \ 'put_mode': 'put_child', 'count': a:count,
         \ 'range': [s:nullpos, s:nullpos],
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
-        \ 'tail': a:tail, 'force_nl': 0}
+        \ 'tail': a:tail, 'force_nl': [0, 0]}
     try
         let li = s:list_info(a:tail) 
         if li.terminal_range[0][1]
@@ -3596,6 +3659,8 @@ function! s:put_child__get_tgt(count, tail)
                     let r[!a:tail] = li.brackets[!a:tail]
                     let ret.is_bra[!a:tail] = 1
                     let ret.is_ele[a:tail] = 1
+                    " See notes in header for rationale behind this toggle.
+                    let ret.tail = !ret.tail
                 else
                     " Requested child exists; use it and adjacent on near side.
                     let r[!a:tail] = c.range[a:tail]
@@ -3614,7 +3679,7 @@ function! s:put_child__get_tgt(count, tail)
                 endif
             else
                 " Terminal element requested.
-                " Use bracket and terminal element.
+                " Use bracket and terminal element, treating terminal element as target.
                 let r[!a:tail] = li.terminal_range[a:tail]
                 let r[a:tail] = li.brackets[a:tail]
                 let ret.is_bra[a:tail] = 1

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3058,6 +3058,53 @@ function! s:analyze_codestr_simple(codestr, filetype)
     return ret
 endfunction
 
+function! s:regput__get_curpos_opt(put_mode)
+    let default = g:sexp_regput_curpos
+    " Just in case user has set to something invalid...
+    if default < 0 || default > 2
+        " Note: Warning will come later.
+        let default = 0
+    endif
+    " Map put_mode's to the corresponding option tags.
+    let optkeys = {'put': '', 'put_child': 'into', 'replace_op': 'op', 'replace_op_ep': 'op_ep'}
+    " Define the following option dependencies as a reversed tree, pre-selecting the one
+    " that applies to the specified put_mode.
+    "   <empty> (base g:sexp_regput_curpos)
+    "   into
+    "   op
+    "     op_ep
+    let deps = {'': [], 'into': [], 'op_ep': ['op'], 'op': []}[optkeys[a:put_mode]]
+    " If we finish loop without finding anything more specific, use default.
+    let [v, i] = [default, -1]
+    let k = optkeys[a:put_mode]
+    try
+        " First iteration will use the most specific key (initialized above, not pulled
+        " from deps list).
+        while i < len(deps)
+            if i >= 0
+                let k = deps[i]
+            endif
+            let optname = 'sexp_regput_' . k . (!empty(k) ? '_' : '') . 'curpos'
+            let v_ = get(g:, optname, -1)
+            let i += 1
+            if v_ < 0 || v_ > 2
+                if v_ != -1
+                    throw "sexp-warning: Invalid option setting for g:" . optname
+                        \ . " (" . v_ . ") defaulting to " . default
+                        \ . " (:help sexp-regput-cursor-positioning)"
+                endif
+                continue
+            endif
+            " Found valid override. Use it.
+            let v = v_
+            break
+        endwhile
+    catch /sexp-warning/
+        call sexp#warn#msg_once("regput 'curpos'", v:exception, 1)
+    endtry
+    return v
+endfu
+
 " Build and return a dict characterizing the text in the put register and canonicalize the
 " register contents. Use Treesitter if applicable, falling back to legacy syntax
 " highlighting, and even to simplistic regex-based parser if neither Treesitter nor legacy
@@ -3589,7 +3636,8 @@ function! s:regput__postop(ctx, sep, orig_range)
         endif
     endfor
     " If put mode-specific option requests curpos target of head or tail, make adjustment.
-    let opt = a:ctx.put_mode =~ 'child' ? g:sexp_regput_into_curpos : g:sexp_regput_curpos
+    " FIXME: Several more modes to consider: op and op_ep
+    let opt = s:regput__get_curpos_opt(a:ctx.put_mode)
     let idx = !!opt
     if opt == idx
         " Desired position is 0 (head) or 1 (tail).
@@ -3625,6 +3673,8 @@ function! s:regput__impl(tgt, count)
         " Analyze the register.
         " Note: This function can throw sexp-abort and sexp-noop; in the case of
         " sexp-abort, its responsible for any associated warnings to user.
+        " Caveat: Due to the indirect ways we can get here (e.g., using TextYankPost
+        " autocmd), it's important that we use saved regname, not v:register.
         let reg = s:regput__get_reginfo(a:tgt.regname)
         let ctx = s:regput__get_context(a:tgt)
         let sep = s:regput__get_seps(ctx, reg)
@@ -3815,6 +3865,7 @@ function! sexp#put(count, tail)
 endfunction
 
 function! s:replace_mode__process_inner_range(tgt)
+    let tgt = a:tgt
     " Determine the range that *contains* inner_range.
     for i in range(2)
         call s:setcursor(tgt.inner_range[i])
@@ -3892,20 +3943,30 @@ function! s:replace__get_tgt(put_mode, mode, count, tail, P)
 endfunction
 
 " Assuming operator motion was exclusive, convert range to fiducial inclusive.
-function! s:fix_operator_range(rng)
+function! s:fix_operator_range(rng, inclusive)
+    let ret = deepcopy(a:rng)
+    if !a:inclusive
+        " Offset final position in range.
+        let ret = sexp#offset_char(ret, 1)
+    endif
+    return ret
 endfunction
 
-function! s:replace_op__try_get_endpoint_tgt(ctx, s, e, allow_same_level)
-    echomsg "c:" getpos('.') "[:" getpos("'[") "]:" getpos("']")
+function! s:replace_op__try_get_endpoint_tgt(ctx, s, e, inclusive)
+    "echomsg "c:" getpos('.') "[:" getpos("'[") "]:" getpos("']")
     let [ctx] = [a:ctx]
     let rng = [a:s, a:e]
+    if a:inclusive != -1
+        let rng = s:fix_operator_range(rng, a:inclusive)
+    endif
+
     " Which direction was the motion search? (-1 indicates 'object' not motion).
-    let dir = a:s == ctx.curpos ? 1 : s:e == ctx.curpos ? 0 : -1
+    let dir = a:s == ctx.curpos ? 1 : a:e == ctx.curpos ? 0 : -1
     if dir == -1
         " Motion not anchored at curpos; thus, endpoint mode not in effect.
         return 0
     endif
-    if !a:allow_same_level && sexp#is_uniform_range(rng)
+    if sexp#is_uniform_range(rng)
         " Motion did not cross levels; endpoint mode not in effect.
         return 0
     endif
@@ -3922,13 +3983,18 @@ function! s:replace_op__try_get_endpoint_tgt(ctx, s, e, allow_same_level)
     " Post-process inner range.
     call s:replace_mode__process_inner_range(ctx)
     " Return true to prevent fallback to non-endpoint mode.
+    " Also, change the put_mode to reflect "endpoint mode", which will matter for post-op
+    " cursor positioning.
+    let ctx.put_mode = "replace_op_ep"
     return 1
 endfunction
 
-function! s:replace_op__get_tgt(ctx)
-    let ctx = a:ctx
+function! s:replace_op__get_tgt(ctx, inclusive)
+    let [ctx, inclusive] = [a:ctx, a:inclusive]
     " Note: For replace operator, use the register/count saved in the context dict at
     " operator invocation, *not* current v:register/v:count.
+    " Note: put_mode will be adjusted if we end up handling this with the special
+    " "endpoint mode".
     let ret = {
         \ 'mode': ctx.mode, 'put_mode': 'replace_op', 'count': ctx.count, 'P': ctx.P,
         \ 'regname': ctx.regname,
@@ -3939,11 +4005,8 @@ function! s:replace_op__get_tgt(ctx)
         \ 'tail': -1, 'force_nl': [0, 0]}
     try
         let [s, e] = [getpos("'["), getpos("']")]
-        "let [s_orig, e_orig] = [s[:], e[:]]
         " First, attempt to process as "endpoint" motion (unless inhibited by option).
-        " TODO: 0 is placeholder; eventually, explicit endpoint mode operator will cause
-        " it to be set.
-        if !s:replace_op__try_get_endpoint_tgt(ret, s, e, 0)
+        if !s:replace_op__try_get_endpoint_tgt(ret, s, e, inclusive)
             " Fallback to non-endpoint mode.
             call s:replace_mode__get_tgt(ret, s, e)
         endif
@@ -3963,20 +4026,28 @@ function! sexp#replace_op(mode, count, P, ...)
             \ 'backtick': getpos("'`"),
             \ 'mode': a:mode, 'count': a:count, 'P': a:P
         \ }
-        " The call via 'opfunc' will get the original args + the context dict.
-        return function('sexp#replace_op', [a:mode, a:count, a:P, ctx])
+        " Important Note: Ideally, we'd use the black hole register for this, but we need
+        " TextYankPost to fire, and it doesn't for the black hole register; thus, use z
+        " register and ensure the handlers save/restore both it and the unnamed register.
+        " TODO: Consider just returning boolean flag indicating the mode to use and
+        " letting opfunc handle the details?
+        let op = has('nvim-0.5') && g:sexp_regput_op_tele ? '"zyv' : 'g@v'
+        " The call via 'opfunc' or TextYankPost will get the original args + the context
+        " dict and the operator itself.
+        return [op, function('sexp#replace_op', [a:mode, a:count, a:P, ctx, op])]
     endif
     try
-        " We've been invoked by our opfunc wrapper, called as 'opfunc' (not invoked
-        " explicitly by sexp#plug_runtime()).
-        let [ctx, type] = a:000
+        " We've been invoked by our opfunc wrapper, called either as true 'opfunc' or in
+        " response to a TextYankPost: in either case, we're not invoked directly by
+        " sexp#plug_runtime()).
+        let [ctx, op, type, inclusive] = a:000
         if type != 'char'
             call sexp#warn#msg("sexp#replace_op:"
                 \ " Invalid use of mode '" . type . "' with replace operator."
                 \ " Only charwise mode supported")
             return
         endif
-        let tgt = s:replace_op__get_tgt(ctx)
+        let tgt = s:replace_op__get_tgt(ctx, inclusive)
         call s:regput__impl(tgt, a:count)
 
     catch /sexp-\%(warning\|abort\):/
@@ -4406,7 +4477,9 @@ function! s:yankdel_range__postadjust_positions(adj)
     " delta in preadjust function).
     let delta = s:total_bytes_in_file() - a:adj.bytes_in_file
     if delta != a:adj.delta
-        throw "Mismatch in calculated deltas: post-delta=" . delta . " pre-delta=" . a:adj.delta
+        " FIXME: Resolve this!!!!!!
+        let delta = a:adj.delta
+        "throw "Mismatch in calculated deltas: post-delta=" . delta . " pre-delta=" . a:adj.delta
     endif
     let [op, ps, offs] = [a:adj.op, a:adj.ps, a:adj.byte_offs]
     let [anchor, anchor_byte] = [a:adj.anchor, a:adj.anchor_byte]

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2882,16 +2882,17 @@ function! s:analyze_codestr_legacy(codestr, filetype)
     " TODO: Some of these fields won't be set properly until we're creating a hidden
     " buffer in which to perform the analysis.
     let ret = {
-        \ 'err_count': 0, 'elem_count': 1, 'is_ml': 0,
+        \ 'err_count': 0, 'elem_count': 1, 'is_ml': 0, 'linewise': 0,
         \ 'has_com': 0, 's_is_com': 0, 'e_is_com': 0,
         \ 'node_ranges': [],
         \ 'error_ranges': [],
         \ 'text': ''
     \ }
-    " Caveat: Vim =~ operator treats rhs like a single line; thus, literal NL ("\n") (not
-    " '\n') must be used to match interior NLs. Also, ^ and $ work only at beginning/end
-    " of multiline string.
-    let ret.is_ml = codestr =~ "\n"
+    " TODO: This should really be handled by a parser to ensure we don't treat *ignored*
+    " whitespace at the end of the register as whitespace.
+    let ret.linewise = g:sexp_regput_untrimmed_is_linewise
+        \ ? ret.text =~ '^\s\|\s$' ? 1 : 0
+        \ : ret.text =~ '\n$' ? 1 : 0
     let ret.s_is_com = codestr =~ '^\s*;'
     let ret.e_is_com = codestr =~ ';.*$'
     " TODO: Come up with less simple patterns that at least attempt to differentiate
@@ -2901,13 +2902,16 @@ function! s:analyze_codestr_legacy(codestr, filetype)
     " TODO: Decide whether this should be single line only, given use case.
     " TODO: If this is not needed, remove!
     let ret.is_com = codestr =~ '\(\_^\s*;.*\_$\)\+'
-    " Trim whitespace at both ends since we're adding deterministic amount.
-    " Design Decision: Putting this here ensures presence of NL in raw register text will
-    " influence 'is_ml'.
-    " Rationale: If user performs (eg) linewise yank on comment, respect that.
+    " Trim *all* whitespace at both ends since we're adding deterministic amount.
     " FIXME: Needs to account for possibility of escaped whitespace; have this done by
     " function that performs language-specific validation.
-    let ret.text = substitute(codestr, '^\s\+\|\s\+$', '', 'g')
+    let ret.text = substitute(codestr, '^\_s\+\|\_s\+$', '', 'g')
+    " Design Decision: Stripped leading/trailing whitespace should not influence
+    " multline test.
+    " Caveat: Vim =~ operator treats rhs like a single line; thus, literal NL ("\n") (not
+    " '\n') must be used to match interior NLs. Also, ^ and $ work only at beginning/end
+    " of multiline string.
+    let ret.is_ml = ret.text =~ "\n"
     return ret
 endfunction
 
@@ -2921,7 +2925,6 @@ function! s:regput__get_reginfo()
         return {}
     endif
     let ret = s:invoke('analyze_codestr', regstr, &ft)
-    "echomsg string(ret)
     return ret
 endfunction
 
@@ -3139,13 +3142,18 @@ function! s:regput__get_seps(ctx, reg)
     let [ctx, reg] = [a:ctx, a:reg]
     let tail = ctx.tail
     let ret = [s:NL, s:NL, s:NL, '']
+    if g:sexp_regput_linewise_forces_multiline && reg.linewise
+        " Force multi-line due to linewise register.
+        return ret
+    endif
     " Determine whether put is into one of the special slots in a 'shaped' list.
     " Note: Inhibit this special case logic if more than one toplevel element in register.
     " Rationale: For the special logic to be meaningful in the multiple toplevel element
     " case, we'd need not only to parse the register text (already doing so), but also
     " potentially *modify* the whitespace between elements, which is analogous to the
     " 'interior separators' used for [count] > 1.
-    let lpi = reg.elem_count > 1 || ctx.empty_buffer || ctx.empty_list
+    let lpi = g:sexp_regput_ignore_list_shape
+        \ || reg.elem_count > 1 || ctx.empty_buffer || ctx.empty_list
         \ ? 0 : s:regput__check_list_context(ctx, reg)
     " TODO: Make global option for this?
     let g:append_sl_comment = get(g:, 'append_sl_comment', 1)
@@ -3173,14 +3181,18 @@ function! s:regput__get_seps(ctx, reg)
                 " that normal logic will apply to trailing side.
                 let want_spc = 0
             else
+                " TODO: Decide on elem_count criterion.
                 let want_spc =
-                    \ ctx.is_ele[i] && !ctx.alone[i] && !ctx.force_nl[i] && !reg.is_ml
+                    \ ctx.is_ele[i] && !ctx.alone[i] && !ctx.force_nl[i]
+                    \ && !reg.is_ml && reg.elem_count <= 1
                     \ && (tail != -1 && (i != tail || ctx.colinear[i]))
             endif
             " Override NL (if necessary).
             " Note: Special logic for replace mode puts may subsequently override this.
             " TODO: Change {e,s}_is_com to is_com[] to obviate need for this.
             let is_com = i ? reg.e_is_com : reg.s_is_com
+            let allow_com_append = g:sexp_regput_allow_comment_append == 2
+                \ || g:sexp_regput_allow_comment_append == 1 && !reg.linewise
             if ctx.is_bra[i]
                 " No override for post sep if reg ends in comment.
                 if !is_com || !i
@@ -3189,7 +3201,7 @@ function! s:regput__get_seps(ctx, reg)
             elseif !ctx.is_ele[i]
                 " No bracket or element requiring separation on this side
                 let ret[i] = s:EMPTY
-            elseif want_spc && (i == 0 && g:append_sl_comment || !is_com)
+            elseif want_spc && (i == 0 && allow_com_append || !is_com)
                 let ret[i] = s:SPC
             endif
             if ctx.put_mode =~ 'replace'
@@ -3522,8 +3534,10 @@ function! s:put__get_tgt(count, tail)
     endtry
 endfunction
 
+" If all conditions are met, convert a put before/after to the corresponding put child,
+" returning 1 let caller know the command was handled.
 function! s:regput__handle_as_put_child_maybe(count, tail)
-    if g:sexp_put_treats_list_as_element
+    if !g:sexp_regput_bracket_is_target
         " Feature disabled by user config
         return 0
     endif

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3098,61 +3098,32 @@ function! s:analyze_codestr_simple(codestr, filetype)
     return ret
 endfunction
 
-" Return option value that applies to the specified put_mode.
-" TODO: This function is complicated by an option inheritance scheme, which may be going
-" away, in favor of a simpler one.
+" Return 'curpos' option value that applies to the specified put_mode.
 function! s:regput__get_curpos_opt(put_mode)
-    let default = g:sexp_regput_curpos
-    " Just in case user has set to something invalid...
-    if default < 0 || default > 2
-        " Note: Warning will come later.
-        let default = 0
+    " Default values
+    let optdefs = {
+        \ 'sexp_regput_curpos': 0,
+        \ 'sexp_regput_curpos_child': 0,
+        \ 'sexp_regput_curpos_op': 2
+    \ }
+    " Get applicable option name.
+    let optname = a:put_mode =~ 'op'
+        \ ? 'sexp_regput_curpos_op'
+        \ : a:put_mode == 'put_child'
+            \ ? 'sexp_regput_curpos_child'
+            \ : 'sexp_regput_curpos'
+    " Get and validate the applicable option value.
+    let ret = get(g:, optname, optname)
+    if !(type(ret) == type(0) && ret >=0 && ret <= 2)
+        " User provided invalid value!
+        let def = get(optdefs, optname)
+        call sexp#warn#msg_once(optname,
+            \ printf("sexp-warning: Ignoring invalid option setting: %s=%s."
+                \ . " Defaulting to %d",
+                \ optname, string(ret), def))
+        let ret = def
     endif
-    " Define the following option dependencies as a reversed tree, pre-selecting the one
-    " that applies to the specified put_mode.
-    "   <empty> (base g:sexp_regput_curpos)
-    "   into
-    "   op
-    "     op_tele
-    let optkey = a:put_mode =~ 'op'
-        \ ? a:put_mode =~ '_tele'
-            \ ? 'op_tele'
-            \ : 'op'
-        \ : a:put_mode =~ '_into'
-        \ ? 'into'
-        \ : ''
-    let deps = {'': [], 'into': [], 'op_tele': ['op'], 'op': []}[optkey]
-    " If we finish loop without finding anything more specific, use default.
-    let [v, i] = [default, -1]
-    let k = optkey
-    try
-        " First iteration uses one of the keys from deps; subsequent interations use keys
-        " from the list selected by that initial key.
-        while i < len(deps)
-            if i >= 0
-                let k = deps[i]
-            endif
-            let optname = 'sexp_regput_' . k . (!empty(k) ? '_' : '') . 'curpos'
-            let v_ = get(g:, optname, -1)
-            " Make sure next iteration considers less specific optkey (if applicable).
-            let i += 1
-            if v_ < 0 || v_ > 2
-                if v_ != -1
-                    throw "sexp-warning: Invalid option setting for g:" . optname
-                        \ . " (" . v_ . ") defaulting to " . default
-                        \ . " (:help sexp-regput-cursor-positioning)"
-                endif
-                " Ignore unset option.
-                continue
-            endif
-            " Found valid override. Use it.
-            let v = v_
-            break
-        endwhile
-    catch /sexp-warning/
-        call sexp#warn#msg_once("regput 'curpos'", v:exception, 1)
-    endtry
-    return v
+    return ret
 endfu
 
 " Build and return a dict characterizing the text in the put register and canonicalize the
@@ -4069,10 +4040,10 @@ function! s:regput_op__process_motion(ctx, inclusive, motion)
         let tail = a:ctx.tail != -1 ? a:ctx.tail : 0
         if a:inclusive != -1
             " TextYankPost (not g@) mechanism was used.
-            if g:sexp_regput_enable_teleop && !is_sexp_motion && dir != -1
+            if g:sexp_regput_tele_motion && !is_sexp_motion && dir != -1
                 " Telescopic mode enabled, not sexp object/motion, and motion anchored at
                 " curpos.
-                if g:sexp_regput_enable_teleop >= (a:ctx.put_mode =~ 'replace_op' ? 3 : 2)
+                if g:sexp_regput_tele_motion >= (a:ctx.put_mode =~ 'replace_op' ? 3 : 2)
                     \ || !sexp#is_uniform_range(rng)
                     " Either telescopic mode unconditionally enabled or tree levels crossed.
                     " Treat as telescopic, provided the reached position is actually *on* a
@@ -4105,7 +4076,7 @@ function! s:regput_op__process_motion(ctx, inclusive, motion)
             if !sexp#is_uniform_range(a:ctx.orange)
                 throw "sexp-abort: put operator requires uniform range."
                     \ . " Did you mean to enable telescopic mode?"
-                    \ . " (:help g:sexp_regput_enable_teleop)"
+                    \ . " (:help g:sexp_regput_tele_motion)"
             endif
             if !sexp#range_has_non_ws(a:ctx.orange[0], a:ctx.orange[1], 1)
                 throw "sexp-abort: put operator requires non-empty range"
@@ -4180,7 +4151,7 @@ function! sexp#regput_op(is_replace, P, ...)
         " register and ensure the handlers save/restore both it and the unnamed register.
         " TODO: Consider just returning boolean flag indicating the mode to use and
         " letting opfunc handle the details?
-        let op = v:version >= 801 && g:sexp_regput_enable_teleop ? '"zy' : 'g@'
+        let op = v:version >= 801 && g:sexp_regput_tele_motion ? '"zy' : 'g@'
         " The call via 'opfunc' or TextYankPost will get the original args + the context
         " dict and the operator itself.
         return [op, function('sexp#regput_op', [a:is_replace, a:P, ctx, op])]

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -460,6 +460,15 @@ function! s:current_macro_character_terminal(end)
     return [0, termline, termcol, 0]
 endfunction
 
+" Return range [start,end] for element under the cursor, else [nullpos, nullpos].
+function! sexp#current_element_terminals()
+    let s = sexp#current_element_terminal(0)
+    if s[1]
+        return [s, sexp#current_element_terminal(1)]
+    endif
+    return [s:nullpos, s:nullpos]
+endfunction
+
 " Position of start/end of current element: 0 for start, 1 for end. Returns
 " [0, 0, 0, 0] if not currently in an element.
 "
@@ -3065,27 +3074,33 @@ function! s:regput__get_curpos_opt(put_mode)
         " Note: Warning will come later.
         let default = 0
     endif
-    " Map put_mode's to the corresponding option tags.
-    let optkeys = {'put': '', 'put_child': 'into', 'replace_op': 'op', 'replace_op_ep': 'op_ep'}
     " Define the following option dependencies as a reversed tree, pre-selecting the one
     " that applies to the specified put_mode.
     "   <empty> (base g:sexp_regput_curpos)
     "   into
     "   op
-    "     op_ep
-    let deps = {'': [], 'into': [], 'op_ep': ['op'], 'op': []}[optkeys[a:put_mode]]
+    "     op_tele
+    let optkey = a:put_mode =~ 'op'
+        \ ? a:put_mode =~ '_tele'
+            \ ? 'op_tele'
+            \ : 'op'
+        \ : a:put_mode =~ '_into'
+        \ ? 'into'
+        \ : ''
+    let deps = {'': [], 'into': [], 'op_tele': ['op'], 'op': []}[optkey]
     " If we finish loop without finding anything more specific, use default.
     let [v, i] = [default, -1]
-    let k = optkeys[a:put_mode]
+    let k = optkey
     try
-        " First iteration will use the most specific key (initialized above, not pulled
-        " from deps list).
+        " First iteration uses one of the keys from deps; subsequent interations use keys
+        " from the list selected by that initial key.
         while i < len(deps)
             if i >= 0
                 let k = deps[i]
             endif
             let optname = 'sexp_regput_' . k . (!empty(k) ? '_' : '') . 'curpos'
             let v_ = get(g:, optname, -1)
+            " Make sure next iteration considers less specific optkey (if applicable).
             let i += 1
             if v_ < 0 || v_ > 2
                 if v_ != -1
@@ -3093,6 +3108,7 @@ function! s:regput__get_curpos_opt(put_mode)
                         \ . " (" . v_ . ") defaulting to " . default
                         \ . " (:help sexp-regput-cursor-positioning)"
                 endif
+                " Ignore unset option.
                 continue
             endif
             " Found valid override. Use it.
@@ -3180,7 +3196,7 @@ endfunction
 "   Note: List keys are pairs whose indices correspond to the elements of range[].
 "   --[[ Beginning of merged-in tgt_info dict
 "   count:           [count] associated with the operation
-"   put_mode:        one of 'put', 'put_child', 'replace', 'replace_child'
+"   put_mode:        one of 'put', 'put_child', 'replace', 'replace_op', 'replace_op_tele'
 "   tail:            At the time of command invocation, 'tail' indicates either the put
 "                    *direction* (non-child put) or the *side* of the list from which the
 "                    insert location is calculated (child put). At this point, however,
@@ -3556,13 +3572,13 @@ endfunction
 " of arguments to s:yankdel_range().
 function! s:regput__get_splice_info(count, ctx, reg, sep, flags)
     let ret = {
-        \ 'range': a:ctx.put_mode =~ 'repl' ? a:ctx.inner_range : a:ctx.range,
+        \ 'range': a:ctx.put_mode =~ 'replace' ? a:ctx.inner_range : a:ctx.range,
         \ 'text': '', 'inc': [0, 0]
     \ }
     let [ctx, reg, sep] = [a:ctx, a:reg, a:sep]
     let tail = ctx.tail
     " TODO: Perhaps these flags should be added to ctx for convenience.
-    let [is_repl, has_tgt] = [ctx.put_mode =~ 'repl', ctx.put_mode == 'put']
+    let [is_repl, has_tgt] = [ctx.put_mode =~ 'replace', ctx.put_mode =~ 'put']
 
     " No range/inclusivity adjustments required in empty buffer case.
     if !ctx.empty_buffer
@@ -3636,7 +3652,7 @@ function! s:regput__postop(ctx, sep, orig_range)
         endif
     endfor
     " If put mode-specific option requests curpos target of head or tail, make adjustment.
-    " FIXME: Several more modes to consider: op and op_ep
+    " FIXME: Several more modes to consider: op and op_tele
     let opt = s:regput__get_curpos_opt(a:ctx.put_mode)
     let idx = !!opt
     if opt == idx
@@ -3726,6 +3742,10 @@ endfunction
 " Calculate and return the tgt_info dict needed by s:regput__get_context() for a 'put'
 " command.
 " Note: For details, see header of s:regput__get_context().
+" -- Args --
+" count:        the sexp command count
+" tail:         put direction flag (0=before 1=after)
+" [ctx]:        (optional) dict this function should augment
 " -- Logic --
 " Nominal Case: If cursor is *on* element, use that element as the target, and let
 " direction be determined by put command (p/P).
@@ -3755,15 +3775,11 @@ endfunction
 " Design Decision: Although we could handle p and P the same way in the 2 ElseIf's above,
 " treating the one that puts *away from* the colinear target as a request for extra
 " separation seems intuitive and gives extra flexibility.
-function! s:put__get_tgt(count, tail)
-    let curpos = getpos('.')
-    let ret = {
-        \ 'curpos': curpos, 'mode': 'n', 'put_mode': 'put', 'count': a:count,
-        \ 'regname': v:register,
-        \ 'vrange': s:get_visual_marks(),
-        \ 'range': [s:nullpos, s:nullpos],
-        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
-        \ 'tail': a:tail, 'force_nl': [0, 0]}
+function! s:put__get_tgt(count, tail, ...)
+    let save_curpos = getpos('.')
+    let ret = a:0 && !empty(a:1)
+        \ ? a:1
+        \ : s:regput__ctx_init('n', a:tail ? 'put_after' : 'put_before', a:count)
     try
         " First, attempt to get natural target: i.e., side of *current* element in
         " direction of put. If no such element, special logic will determine a 'virtual'
@@ -3826,13 +3842,14 @@ function! s:put__get_tgt(count, tail)
         endif
         return ret
     finally
-        call s:setcursor(curpos)
+        call s:setcursor(save_curpos)
     endtry
 endfunction
 
-" If all conditions are met, convert a put before/after to the corresponding put child,
-" returning 1 let caller know the command was handled.
-function! s:regput__handle_as_put_child_maybe(count, tail)
+" If all conditions are met for converting a put before/after to the corresponding put
+" child, return 1.
+" FIXME: This is going away, obsoleted by the put operators.
+function! s:regput__handle_as_put_into_empty_list(count, tail)
     if !g:sexp_regput_bracket_is_target
         " Feature disabled by user config
         return 0
@@ -3847,23 +3864,28 @@ function! s:regput__handle_as_put_child_maybe(count, tail)
     if !a:tail && isl != 3 || a:tail && isl == 3
         return 0
     endif
-    " All conditions met for converting put to put_child!
-    " Caveat: Toggle tail due to change in meaning: e.g.,
-    "   put from open bracket (tail == 1) ==> put at head (tail == 0)
-    call sexp#put_child(a:count, !a:tail)
-    " Let caller know it's been handled.
+    " Treat as put into empty list!
     return 1
 endfunction
 
-" Put before/after
-function! sexp#put(count, tail)
-    if !s:regput__handle_as_put_child_maybe(a:count, a:tail)
+" Put before/after (both normal and operator variants)
+" Note: Optional ctx dict provided by caller if invoked internally by operator mechanism.
+function! sexp#put(count, tail, ...)
+    if s:regput__handle_as_put_into_empty_list(a:count, a:tail)
+        " All conditions met for converting put to put_child!
+        " Caveat: Toggle tail due to change in meaning: i.e.,
+        "   put (forwards) from open bracket (tail == 1) ==> put at head (tail == 0)
+        "   put (backwards) from close bracket (tail == 0) ==> put at tail (tail == 1)
+        call sexp#put_child(a:count, !a:tail, a:0 ? a:1 : {})
+    else
         let cnt = a:count ? a:count : 1
-        let tgt = s:put__get_tgt(cnt, a:tail)
+        let tgt = s:put__get_tgt(cnt, a:tail, a:0 ? a:1 : {})
         call s:regput__impl(tgt, cnt)
     endif
 endfunction
 
+" Augment provided 'tgt' dict with several range related fields, which are calculated from
+" the raw input range, which might represent a visual selection, a motion or sexp object.
 function! s:replace_mode__process_inner_range(tgt)
     let tgt = a:tgt
     " Determine the range that *contains* inner_range.
@@ -3885,58 +3907,79 @@ function! s:replace_mode__process_inner_range(tgt)
     endfor
 endfunction
 
-" Augment provided 'tgt' dict with several range related fields, which are calculated
-" from the raw input range, which might represent a visual selection, a motion or sexp
-" object.
-" Note: This is factored into its own function because it's used by several replace modes.
-function! s:replace_mode__get_tgt(tgt, s, e)
-    " Augment provided dict.
-    let [tgt, s, e] = [a:tgt, a:s, a:e]
-    if !sexp#range_has_non_ws(s, e, 1)
-        throw 'sexp-abort: Invalid attempt to perform replacement'
-            \ . ' on pure whitespace'
-    endif
-    let rng = [s, e]
-    if !sexp#is_uniform_range(rng)
-        throw 'sexp-abort: Invalid attempt to perform replacement'
-            \ . ' on range that crosses list boundaries.'
-            \ . ' Did you mean to set g:sexp_regput_enable_teleop?'
-    endif
-    for i in range(2)
-        call s:setcursor(rng[i])
-        let rng[i] = sexp#move_to_current_element_terminal(i)
-        if !rng[i][1]
-            " Attempt to find nearest terminal in inward direction.
-            let rng[i] = sexp#move_to_adjacent_element_terminal(!i)
-        endif
-    endfor
-    let tgt.inner_range = rng
-    if !g:sexp_regput_replace_expanded
-        " Make sure original selection contained only complete S-Expressions.
-        if sexp#compare_pos(s, tgt.inner_range[0]) > 0
-            \ || sexp#compare_pos(e, tgt.inner_range[1]) < 0
-            throw 'sexp-abort: Current setting of g:sexp_regput_replace_expanded prohibits'
-                \ . ' selecting only part of an S-Expression for replacement.'
-        endif
-    endif
-    " Post-process inner_range.
-    call s:replace_mode__process_inner_range(tgt)
-endfunction
-
-function! s:replace__get_tgt(put_mode, mode, count, tail, P)
-    let curpos = getpos('.')
-    let ret = {
-        \ 'mode': a:mode, 'put_mode': a:put_mode, 'count': a:count, 'P': a:P,
+" TODO: Move this...
+function! s:regput__ctx_init(mode, put_mode, count, ...)
+    " Create dict with superset of keys required for various regput modes.
+    " Provide reasonable defaults where they exist, giving precedence to any defaults
+    " provided by caller in optional override dict.
+    let ctx = {
+        \ 'mode': a:mode,
+        \ 'put_mode': a:put_mode,
+        \ 'count': a:count,
+        \ 'curpos': getpos('.'),
         \ 'regname': v:register,
-        \ 'curpos': curpos, 'vrange': s:get_visual_marks(),
+        \ 'backtick': getpos("'`"),
+        \ 'P': -1,
+        \ 'tail': -1,
+        \ 'vrange': s:get_visual_marks(),
+        \ 'orange': [getpos("'["), getpos("']")],
         \ 'range': [s:nullpos, s:nullpos],
         \ 'inner_range': [s:nullpos, s:nullpos],
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
-        \ 'tail': -1, 'force_nl': [0, 0]}
+        \ 'force_nl': [0, 0],
+    \ }
+    if a:0
+        let ctx = extend(ctx, a:1)
+    endif
+    return ctx
+endfunction
+
+function! s:replace__get_tgt(mode, count, tail, P, ...)
+    let ret = a:0 && !empty(a:1) ? a:1 : s:regput__ctx_init(a:mode, 'replace', a:count)
+    let curpos = getpos('.')
     try
-        " Augment dict with the inner_range.
-        let [s, e] = ret.vrange
-        call s:replace_mode__get_tgt(ret, s, e)
+        if a:mode ==? 'n' && ret.put_mode != 'replace_op'
+            " Assumption: Caller has positioned cursor correctly.
+            let rng = sexp#current_element_terminals()
+            if !rng[0][1]
+                throw 'sexp-abort: No valid target for sexp replace'
+            endif
+        else " visual mode or non-telescopic replace operator.
+            " Validate and adjust range to include only complete forms.
+            let [s, e] = ret.put_mode == 'replace_op' ? ret.orange : ret.vrange
+            if !sexp#range_has_non_ws(s, e, 1)
+                throw 'sexp-abort: Invalid attempt to perform replacement'
+                    \ . ' on pure whitespace'
+            endif
+            let rng = [s, e]
+            if !sexp#is_uniform_range(rng)
+                throw 'sexp-abort: Invalid attempt to perform replacement'
+                    \ . ' on range that crosses list boundaries'
+            endif
+            for i in range(2)
+                call s:setcursor(rng[i])
+                let rng[i] = sexp#move_to_current_element_terminal(i)
+                if !rng[i][1]
+                    " Attempt to find nearest terminal in inward direction.
+                    let rng[i] = sexp#move_to_adjacent_element_terminal(!i)
+                endif
+            endfor
+            " Design Decision: Be less strict with visual selections.
+            " Rationale: Errors are less likely when selection is visually apparent before
+            " command execution.
+            if !g:sexp_regput_replace_expanded && ret.put_mode =~ 'replace_op'
+                " Make sure original selection contained only complete S-Expressions.
+                if sexp#compare_pos(s, rng[0]) > 0
+                    \ || sexp#compare_pos(e, rng[1]) < 0
+                    throw 'sexp-abort: Current setting of g:sexp_regput_replace_expanded prohibits'
+                        \ . ' selecting only part of an S-Expression for replacement.'
+                        \ . ' :help g:sexp_regput_replace_expanded'
+                endif
+            endif
+        endif
+        let ret.inner_range = rng
+        " Post-process inner_range.
+        call s:replace_mode__process_inner_range(ret)
         return ret
     finally
         call s:setcursor(curpos)
@@ -3953,88 +3996,86 @@ function! s:fix_operator_range(rng, inclusive)
     return ret
 endfunction
 
-function! s:replace_op__try_get_endpoint_tgt(ctx, s, e, inclusive)
-    "echomsg "c:" getpos('.') "[:" getpos("'[") "]:" getpos("']")
-    let [ctx] = [a:ctx]
-    let rng = [a:s, a:e]
-    if a:inclusive != -1
-        let rng = s:fix_operator_range(rng, a:inclusive)
-    endif
-
-    " Which direction was the motion search? (-1 indicates 'object' not motion).
-    let dir = a:s == ctx.curpos ? 1 : a:e == ctx.curpos ? 0 : -1
-    if dir == -1
-        " Motion not anchored at curpos; thus, endpoint mode not in effect.
-        return 0
-    endif
-    if sexp#is_uniform_range(rng)
-        " Motion did not cross levels; endpoint mode not in effect.
-        return 0
-    endif
-    " Determine the target sexp.
-    call s:setcursor(rng[dir])
-    let p = sexp#current_element_terminal(0)
-    if !p[1]
-        " Endpoint mode requires an endpoint strictly *on* an element; since we don't have
-        " that, just fallback to non-endpoint processing.
-        return 0
-    endif
-    " We're on an element; use its range.
-    let ctx.inner_range = [p, sexp#current_element_terminal(1)]
-    " Post-process inner range.
-    call s:replace_mode__process_inner_range(ctx)
-    " Return true to prevent fallback to non-endpoint mode.
-    " Also, change the put_mode to reflect "endpoint mode", which will matter for post-op
-    " cursor positioning.
-    let ctx.put_mode = "replace_op_ep"
-    return 1
-endfunction
-
-function! s:replace_op__get_tgt(ctx, inclusive)
-    let [ctx, inclusive] = [a:ctx, a:inclusive]
-    " Note: For replace operator, use the register/count saved in the context dict at
-    " operator invocation, *not* current v:register/v:count.
-    " Note: put_mode will be adjusted if we end up handling this with the special
-    " "endpoint mode".
-    let ret = {
-        \ 'mode': ctx.mode, 'put_mode': 'replace_op', 'count': ctx.count, 'P': ctx.P,
-        \ 'regname': ctx.regname,
-        \ 'curpos': ctx.curpos, 'vrange': s:get_visual_marks(),
-        \ 'range': [s:nullpos, s:nullpos],
-        \ 'inner_range': [s:nullpos, s:nullpos],
-        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
-        \ 'tail': -1, 'force_nl': [0, 0]}
-    try
-        let [s, e] = [getpos("'["), getpos("']")]
-        " First, attempt to process as "endpoint" motion (unless inhibited by option).
-        if !g:sexp_regput_enable_teleop
-            \ || !s:replace_op__try_get_endpoint_tgt(ret, s, e, inclusive)
-            " Fallback to non-endpoint mode.
-            call s:replace_mode__get_tgt(ret, s, e)
+" FIXME: This is intended to replace the subsequent function.
+function! s:regput_op__try_get_tele_pos(ctx, inclusive)
+    let ret = s:nullpos
+    let curpos = a:ctx.curpos
+    let [s, e] = [getpos("'["), getpos("']")]
+    if g:sexp_regput_enable_teleop
+        " Telescopic operators enabled.
+        let rng = [s[:], e[:]]
+        if a:inclusive != -1
+            let rng = s:fix_operator_range(rng, a:inclusive)
         endif
-        return ret
-    finally
-        call s:setcursor(ctx.curpos)
-    endtry
+        " Which direction was the motion search? (-1 indicates 'object' not motion).
+        let dir = rng[0] == curpos ? 1 : rng[1] == curpos ? 0 : -1
+        if dir != -1
+            " Motion anchored at curpos; telescopic mode may be in effect.
+            if !sexp#is_uniform_range(rng)
+                " Tree levels crossed. Treat as telescopic.
+                let ret = rng[dir]
+            endif
+        endif
+    endif
+    return ret
 endfunction
 
-" TODO: Probably add a parameter for the motion mode.
-function! sexp#replace_op(mode, count, P, ...)
-    " Replace operator doesn't use a count.
+" Augment the provided context dict, taking the type of regput operator, and if
+" applicable, the 'inclusive' flag extracted from the TextYankPost autocmd event, into
+" account.
+function! s:replace_op__handle(ctx, inclusive)
+    let ctx = a:ctx
+    " Check to see whether telescopic mode selected a non-local position.
+    let tele_pos = s:regput_op__try_get_tele_pos(ctx, a:inclusive)
+    if tele_pos[1]
+        " TODO: Consider not changing put_mode, but having distinct is_tele flag.
+        let ctx.put_mode .= "_tele"
+        call s:setcursor(tele_pos)
+    endif
+    call sexp#replace('n', 1, ctx.P, ctx)
+endfunction
+
+function! s:put_op__handle(ctx, inclusive)
+    " Check to see whether telescopic mode selected a non-local position.
+    let tele_pos = s:regput_op__try_get_tele_pos(a:ctx, a:inclusive)
+    " Let the non-operator put_{before,after} function augment context dict.
+    " Rationale: Its logic is *precisely* what we want, but we want to use the
+    " searched position, not original (saved) cursor pos.
+    if tele_pos[1]
+        let a:ctx.put_mode .= "_tele"
+        " TODO: Consider not changing put_mode, but having distinct is_tele flag.
+        call s:setcursor(tele_pos)
+    else
+        " Sanity-check the selection to see whether it makes sense to support put
+        " before/after on it.
+        if !sexp#is_uniform_range(a:ctx.orange)
+            throw "Ooops! Non-uniform range can't be used here!"
+        endif
+        " Let sexp#put handle the rest.
+        call s:setcursor(a:ctx.orange[a:ctx.tail])
+    endif
+    call sexp#put(1, a:ctx.tail, a:ctx)
+endfunction
+
+" Note: This function used for both replace_op and put_op and "P" has meaning (albeit
+" different meaning) for both.
+function! sexp#regput_op(is_replace, P, ...)
+    " Sexp operators don't use counts.
     " TODO: Currently, warning is given by plug wrapper, but consider creating a
     " sexp#warn#if_count_provided() or some such, which could eventually be easily invoked
     " from other sexp operators (but only the ones for which it makes sense).
     " TODO: Consider whether the aforementioned warning would be best coming before or
     " after the motion/object.
-    let cnt = 1
     if !a:0
         " Initial call (invoked explicitly, not via Vim's opfunc engine)
-        let ctx = {
-            \ 'curpos': getpos('.'),
-            \ 'regname': v:register,
-            \ 'backtick': getpos("'`"),
-            \ 'mode': a:mode, 'count': cnt, 'P': a:P
-        \ }
+        " Note: Set tail to -1 for inherently non-directional replace op; otherwise, determine
+        " its value from the P flag (P=before p=after - note the inversion).
+        " TODO: Consider an init function that creates these for everyone, with default
+        " values, or perhaps allowing optional list of keys to be passed in.
+        let ctx = s:regput__ctx_init('n', a:is_replace ? 'replace_op' : 'put_op', 1, {
+            \ 'P': a:is_replace ? a:P : -1,
+            \ 'tail': a:is_replace ? -1 : !a:P,
+        \ })
         " Important Note: Ideally, we'd use the black hole register for this, but we need
         " TextYankPost to fire, and it doesn't for the black hole register; thus, use z
         " register and ensure the handlers save/restore both it and the unnamed register.
@@ -4043,7 +4084,7 @@ function! sexp#replace_op(mode, count, P, ...)
         let op = v:version >= 801 && g:sexp_regput_enable_teleop ? '"zyv' : 'g@v'
         " The call via 'opfunc' or TextYankPost will get the original args + the context
         " dict and the operator itself.
-        return [op, function('sexp#replace_op', [a:mode, cnt, a:P, ctx, op])]
+        return [op, function('sexp#regput_op', [a:is_replace, a:P, ctx, op])]
     endif
     try
         " We've been invoked by our opfunc wrapper, called either as true 'opfunc' or in
@@ -4056,9 +4097,15 @@ function! sexp#replace_op(mode, count, P, ...)
                 \ " Only charwise mode supported")
             return
         endif
-        let tgt = s:replace_op__get_tgt(ctx, inclusive)
-        call s:regput__impl(tgt, a:count)
-
+        " Update 'orange' to reflect motion/object.
+        " TODO: Decide whether we want to preserve new visual range or visual range at
+        " time operator was invoked.
+        let ctx.orange = [getpos("'["), getpos("']")]
+        if a:is_replace
+            call s:replace_op__handle(ctx, inclusive)
+        else
+            call s:put_op__handle(ctx, inclusive)
+        endif
     catch /sexp-\%(warning\|abort\):/
         call sexp#warn#msg(v:exception)
     catch
@@ -4067,14 +4114,15 @@ function! sexp#replace_op(mode, count, P, ...)
     endtry
 endfunction
 
+" Perform both replace and replace_op: in the latter case, ctx dict is provided by caller.
 " Note: For replace modes, P indicates which p command was used: 0 == 'p', 1 == 'P'.
 " Although it doesn't affect the result of the put, it does determine whether the unnamed
 " register is updated.
-function! sexp#replace(mode, count, P)
+function! sexp#replace(mode, count, P, ...)
     try
         let cnt = a:count ? a:count : 1
         " Target determination is mode-specific.
-        let tgt = s:replace__get_tgt('replace', a:mode, cnt, -1, a:P)
+        let tgt = s:replace__get_tgt(a:mode, cnt, -1, a:P, a:0 ? a:1 : {})
         " Design Decision: Let tail==1 represent put with P.
         call s:regput__impl(tgt, cnt)
     catch /sexp-warning:/
@@ -4105,15 +4153,13 @@ endfunction
 " between terminal child and list bracket, treating the terminal child as the target.
 " Since the put in this case is in the opposite direction relative to the target, we
 " toggle 'tail' in the return dict to reflect the reversal.
-function! s:put_child__get_tgt(count, tail)
+function! s:put_child__get_tgt(count, tail, ...)
     let cursor = getpos('.')
-    let ret = {
-        \ 'mode': 'n', 'put_mode': 'put_child', 'count': a:count,
-        \ 'regname': v:register,
-        \ 'curpos': cursor, 'vrange': s:get_visual_marks(),
-        \ 'range': [s:nullpos, s:nullpos],
-        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
-        \ 'tail': a:tail, 'force_nl': [0, 0]}
+    let ret = a:0 && !empty(a:1)
+        \ ? a:1
+        \ : s:regput__ctx_init('n', 'put_child', a:count, {
+            \ 'tail': a:tail
+        \ })
     try
         let li = s:list_info(a:tail, {'inner_only': g:sexp_regput_bracket_is_child}) 
         if li.terminal_range[0][1]
@@ -4170,9 +4216,9 @@ function! s:put_child__get_tgt(count, tail)
     endtry
 endfunction
 
-function! sexp#put_child(count, tail)
+function! sexp#put_child(count, tail, ...)
     let cnt = a:count ? a:count : 1
-    let tgt = s:put_child__get_tgt(cnt, a:tail)
+    let tgt = s:put_child__get_tgt(cnt, a:tail, a:0 ? a:1 : {})
     " Note: [count] is used only for child location, so hardcode to 1.
     call s:regput__impl(tgt, 1)
 endfunction

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -131,8 +131,6 @@ endfunction
 function! sexp#pre_op(mode, name)
     let s:sexp_ve_save = &ve
     set ve=onemore
-    " May be used by command handlers to figure out how to leave view.
-    let s:win_view = winsaveview()
     " Create the msg queue used by sexp#warn#msg().
     call sexp#warn#create_msg_q()
     " TODO: Consider removing or simplifying the cache, which is currently needed only for
@@ -3074,9 +3072,9 @@ endfunction
 "                possibly user response to input()) prohibit proceeding with paste.
 "                buffer's 'filetype
 "   sexp-noop:   register is empty (or whitespace-only); no reason to continue with put
-function! s:regput__get_reginfo()
+function! s:regput__get_reginfo(regname)
     let ret = {}
-    let regstr = getreg(v:register)
+    let regstr = getreg(a:regname)
     if regstr =~ '^\s*$'
         " No-op!
         throw "sexp-noop"
@@ -3627,7 +3625,7 @@ function! s:regput__impl(tgt, count)
         " Analyze the register.
         " Note: This function can throw sexp-abort and sexp-noop; in the case of
         " sexp-abort, its responsible for any associated warnings to user.
-        let reg = s:regput__get_reginfo()
+        let reg = s:regput__get_reginfo(a:tgt.regname)
         let ctx = s:regput__get_context(a:tgt)
         let sep = s:regput__get_seps(ctx, reg)
         let spl = s:regput__get_splice_info(a:count, ctx, reg, sep, {})
@@ -3711,6 +3709,7 @@ function! s:put__get_tgt(count, tail)
     let curpos = getpos('.')
     let ret = {
         \ 'curpos': curpos, 'mode': 'n', 'put_mode': 'put', 'count': a:count,
+        \ 'regname': v:register,
         \ 'vrange': s:get_visual_marks(),
         \ 'range': [s:nullpos, s:nullpos],
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
@@ -3806,6 +3805,7 @@ function! s:regput__handle_as_put_child_maybe(count, tail)
     return 1
 endfunction
 
+" Put before/after
 function! sexp#put(count, tail)
     if !s:regput__handle_as_put_child_maybe(a:count, a:tail)
         let cnt = a:count ? a:count : 1
@@ -3814,114 +3814,85 @@ function! sexp#put(count, tail)
     endif
 endfunction
 
-" Set inner_range of the input tgt dict.
-function! s:replace__get_tgt_visual(count, tgt)
-    let curpos = getpos('.')
-    try
-        let [vs, ve] = s:get_visual_marks()
-        " TODO: Decide whether there should be any constraints on this: e.g., should we
-        " convert a range that crosses list boundaries (i.e., ends at different levels) to
-        " a super range, or should we warn and abort???
-        let [s, e] = s:super_range(vs, ve)
-        " Preceding call to s:super_range() obviates need for ignored region checking.
-        if !sexp#range_has_non_ws(s, e, 0)
-            " Nothing to replace.
-            " Design Decision Needed: Should we a) throw and warn user or b) convert to
-            " normal put. (And if (b), should we try to ensure the put is non-directional,
-            " given that this might not happen naturally?)
-            throw "sexp-warning: "
-                \ . "visual mode 'replace with register' requires selection of"
-                \ . " something other than whitespace!"
-        endif
-        " We have a non-empty set of elements to replace.
-        let a:tgt.inner_range = [s, e]
-    finally
-        call s:setcursor(curpos)
-    endtry
-endfunction
-
-" Set inner_range of the input tgt dict.
-" Note: This mode is almost unnecessary, since the same effect could be achieved simply by
-" hitting v before the visual mapping.
-function! s:replace__get_tgt_normal(count, tgt)
-    " Look for element under cursor.
-    let p = sexp#current_element_terminal(0)
-    if !p[1]
-        " Refuse to do anything if no element under cursor!
-        " TODO: Need a way to communicate noop/error back to caller.
-        throw "sexp-warning: 'Replace with register' requires element under cursor!"
+" Augment provided 'tgt' dict with several range related fields, which are calculated
+" from the raw input range, which might represent a visual selection, a motion or sexp
+" object.
+" Note: This is factored into its own function because it's used by several replace modes.
+function! s:replace_mode__get_tgt(tgt, s, e)
+    " Augment provided dict.
+    let [tgt, s, e] = [a:tgt, a:s, a:e]
+    if !sexp#range_has_non_ws(s, e, 1)
+        throw 'sexp-abort: Invalid attempt to perform replacement'
+            \ . ' on pure whitespace'
     endif
-    " We have a current element to replace.
-    let a:tgt.inner_range = [p, sexp#current_element_terminal(1)]
-endfunction
-
-function! s:replace_mode__process_inner_range(tgt)
-    " Augment dict provided by caller.
-    let ret = a:tgt
+    let rng = [s, e]
+    if !sexp#is_uniform_range(rng)
+        throw 'sexp-abort: Invalid attempt to perform replacement'
+            \ . ' on range that crosses list boundaries'
+    endif
+    for i in range(2)
+        call s:setcursor(rng[i])
+        let rng[i] = sexp#move_to_current_element_terminal(i)
+        if !rng[i][1]
+            " Attempt to find nearest terminal in inward direction.
+            let rng[i] = sexp#move_to_adjacent_element_terminal(!i)
+        endif
+    endfor
+    let tgt.inner_range = rng
     " Determine the range that *contains* inner_range.
     for i in range(2)
-        call s:setcursor(ret.inner_range[i])
+        call s:setcursor(tgt.inner_range[i])
         let p = sexp#nearest_element_terminal(i, !i, 1, 1)
         if p[1]
-            let ret.is_ele[i] = 1
+            let tgt.is_ele[i] = 1
         else
             let p = s:nearest_bracket(i)
             if p[1]
-                let ret.is_bra[i] = 1
+                let tgt.is_bra[i] = 1
             else
                 " Default to buffer extremity.
                 let p = i ? [0, line('$'), col([line('$'), '$']), 0] : s:BOF
             endif
         endif
-        let ret.range[i] = p
+        let tgt.range[i] = p
     endfor
-    return ret
+    if !g:sexp_regput_replace_expanded
+        " Make sure original selection contained only complete S-Expressions.
+        if sexp#compare_pos(s, tgt.inner_range[0]) > 0
+            \ || sexp#compare_pos(e, tgt.inner_range[1]) < 0
+            throw 'sexp-abort: Current setting of g:sexp_regput_replace_expanded prohibits'
+                \ . ' selecting only part of an S-Expression for replacement.'
+        endif
+    endif
 endfunction
 
-" Note: To avoid duplication, both replace and replace_child are handled by this function.
-function! s:replace_mode__get_tgt(put_mode, mode, count, tail, P)
+function! s:replace__get_tgt(put_mode, mode, count, tail, P)
     let curpos = getpos('.')
     let ret = {
         \ 'mode': a:mode, 'put_mode': a:put_mode, 'count': a:count, 'P': a:P,
+        \ 'regname': v:register,
         \ 'curpos': curpos, 'vrange': s:get_visual_marks(),
         \ 'range': [s:nullpos, s:nullpos],
         \ 'inner_range': [s:nullpos, s:nullpos],
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
         \ 'tail': -1, 'force_nl': [0, 0]}
     try
-        if a:put_mode == 'replace'
-            " Allow mode-specific function to augment dict with the inner_range.
-            if a:mode == 'v'
-                call s:replace__get_tgt_visual(a:count, ret)
-            else
-                call s:replace__get_tgt_normal(a:count, ret)
-            endif
-        else " 'replace_child'
-            let ret.tail = a:tail
-            let cr = s:child_range(a:count, a:tail, 1,
-                \ {'exact_count': 1, 'inner_only': g:sexp_regput_bracket_is_child})
-            if cr.missing
-                " Requested child doesn't exist!
-                throw "sexp-abort: 'replace_child': the requested child does not exist!"
-            endif
-            let ret.inner_range = cr.range
-        endif
-        " Determine (outer) range from inner and set the is_{ele,bra}[] flags.
-        call s:replace_mode__process_inner_range(ret)
+        " Augment dict with the inner_range.
+        let [s, e] = ret.vrange
+        call s:replace_mode__get_tgt(ret, s, e)
         return ret
     finally
         call s:setcursor(curpos)
     endtry
 endfunction
 
-" TODO: Consider having this subsumed by s:replace_mode__get_tgt(), handled as just
-" another put_mode. If that's done, s:replace_mode__process_inner_range() could be
-" inlined.
-" ACTUALLY... Non-operator replace is going away...
 function! s:replace_op__get_tgt(ctx)
     let ctx = a:ctx
+    " Note: For replace operator, use the register saved in the context dict at operator
+    " invocation, *not* current v:register.
     let ret = {
         \ 'mode': ctx.mode, 'put_mode': 'replace_op', 'count': ctx.count, 'P': ctx.P,
+        \ 'regname': ctx.regname,
         \ 'curpos': ctx.curpos, 'vrange': s:get_visual_marks(),
         \ 'range': [s:nullpos, s:nullpos],
         \ 'inner_range': [s:nullpos, s:nullpos],
@@ -3929,27 +3900,8 @@ function! s:replace_op__get_tgt(ctx)
         \ 'tail': -1, 'force_nl': [0, 0]}
     try
         let [s, e] = [getpos("'["), getpos("']")]
-        let [s_orig, e_orig] = [s[:], e[:]]
-        if !sexp#range_has_non_ws(s, e, 1)
-            throw 'sexp-abort: Invalid attempt to apply replace operator'
-                \ . ' to pure whitespace'
-        endif
-        let rng = [s, e]
-        if !sexp#is_uniform_range(rng)
-            throw 'sexp-abort: Invalid attempt to apply replace operator'
-                \ . ' to range that crosses list boundaries'
-        endif
-        for i in range(2)
-            call s:setcursor(rng[i])
-            let rng[i] = sexp#move_to_current_element_terminal(i)
-            if !rng[i][1]
-                " Attempt to find nearest terminal in inward direction.
-                let rng[i] = sexp#move_to_adjacent_element_terminal(!i)
-            endif
-        endfor
-        let ret.inner_range = rng
-        " Determine (outer) range from inner and set the is_{ele,bra}[] flags.
-        call s:replace_mode__process_inner_range(ret)
+        "let [s_orig, e_orig] = [s[:], e[:]]
+        call s:replace_mode__get_tgt(ret, s, e)
         return ret
     finally
         call s:setcursor(ctx.curpos)
@@ -3958,17 +3910,19 @@ endfunction
 
 function! sexp#replace_op(mode, count, P, ...)
     if !a:0
-        " Initial call
+        " Initial call (invoked explicitly, not via Vim's opfunc engine)
         let ctx = {
             \ 'curpos': getpos('.'),
+            \ 'regname': v:register,
+            \ 'backtick': getpos("'`"),
             \ 'mode': a:mode, 'count': a:count, 'P': a:P
         \ }
         " The call via 'opfunc' will get the original args + the context dict.
-        let &opfunc = function('sexp#replace_op', [a:mode, a:count, a:P, ctx])
-        return 'g@'
+        return function('sexp#replace_op', [a:mode, a:count, a:P, ctx])
     endif
     try
-        " If here, we've been invoked by the 'opfunc' mechanism.
+        " We've been invoked by our opfunc wrapper, called as 'opfunc' (not invoked
+        " explicitly by sexp#plug_runtime()).
         let [ctx, type] = a:000
         if type != 'char'
             call sexp#warn#msg("sexp#replace_op:"
@@ -3976,9 +3930,7 @@ function! sexp#replace_op(mode, count, P, ...)
                 \ " Only charwise mode supported")
             return
         endif
-        "echomsg "replace_op:" string(ctx) "type=" type "'[:" getpos("'[") "']:" getpos("']")
         let tgt = s:replace_op__get_tgt(ctx)
-        "echomsg "replace_op" string(tgt)
         call s:regput__impl(tgt, a:count)
 
     catch /sexp-\%(warning\|abort\):/
@@ -3996,9 +3948,8 @@ function! sexp#replace(mode, count, P)
     try
         let cnt = a:count ? a:count : 1
         " Target determination is mode-specific.
-        let tgt = s:replace_mode__get_tgt('replace', a:mode, cnt, -1, a:P)
+        let tgt = s:replace__get_tgt('replace', a:mode, cnt, -1, a:P)
         " Design Decision: Let tail==1 represent put with P.
-        echomsg "replace:" string(tgt)
         call s:regput__impl(tgt, cnt)
     catch /sexp-warning:/
         call sexp#warn#msg(v:exception)
@@ -4032,6 +3983,7 @@ function! s:put_child__get_tgt(count, tail)
     let cursor = getpos('.')
     let ret = {
         \ 'mode': 'n', 'put_mode': 'put_child', 'count': a:count,
+        \ 'regname': v:register,
         \ 'curpos': cursor, 'vrange': s:get_visual_marks(),
         \ 'range': [s:nullpos, s:nullpos],
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
@@ -4097,20 +4049,6 @@ function! sexp#put_child(count, tail)
     let tgt = s:put_child__get_tgt(cnt, a:tail)
     " Note: [count] is used only for child location, so hardcode to 1.
     call s:regput__impl(tgt, 1)
-endfunction
-
-function! sexp#replace_child(count, tail, P)
-    try
-        let cnt = a:count ? a:count : 1
-        let tgt = s:replace_mode__get_tgt('replace_child', 'n', cnt, a:tail, a:P)
-        " Note: [count] is used only for child location, so hardcode to 1.
-        call s:regput__impl(tgt, 1)
-    catch /sexp-warning:/
-        call sexp#warn#msg(v:exception)
-    catch
-        " Show throwpoint only for non-warning errors.
-        call sexp#warn#msg(v:exception . " at " . v:throwpoint)
-    endtry
 endfunction
 
 " Swap current visual selection with adjacent element. If pairwise is true,

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -142,6 +142,8 @@ function! sexp#post_op(mode, name)
     " Restore original 'virtualedit' setting.
     " Assumption: This is called from finally block.
     let &ve = s:sexp_ve_save
+    " Perform once-per-session new feature notification iff appropriate.
+    call sexp#feat#notify_maybe(a:mode, a:name)
     " This is done last to ensure no redraws can be queue after msgs are echoed.
     call sexp#warn#echo_queued_msgs()
     " Caveat: Make sure the queue is used only when we're inside {pre,post}_op() calls
@@ -706,17 +708,19 @@ fu! sexp#invoke(fn, ...)
             return ret
         endif
         " Warn once only.
-        call sexp#warn#msg_once('missing_ts',
+        call sexp#warn#msg(
             \ "Warning: Falling back to legacy syntax."
-            \ . " Have you installed Treesitter parser for " . &filetype . "?")
+            \ . " Have you installed Treesitter parser for " . &filetype . "?",
+            \ {'once': 'missing_ts'})
     endif
     " Arrival here means we won't or can't use Treesitter. If we don't have legacy syntax,
     " we're going to have a problem, so warn...
     if empty(get(b:, 'current_syntax', ''))
         " Note: Display with error highlighting, as this is more serious than missing
         " Treesitter parser, since we have nothing to fallback to.
-        call sexp#warn#msg_once('missing_syn',
-            \ "Warning: No syntax available for filetype '" . &filetype . "'", 1)
+        call sexp#warn#msg(
+            \ "Warning: No syntax available for filetype '" . &filetype . "'",
+            \ {'once': 'missing_syn', 'err': 1})
         " Fall through to legacy function *without* syntax, since we've no better option.
     endif
     " Use legacy approach.
@@ -3247,10 +3251,11 @@ function! s:regput__get_curpos_opt(put_mode)
     if !(type(ret) == type(0) && ret >=0 && ret <= 2)
         " User provided invalid value!
         let def = get(optdefs, optname)
-        call sexp#warn#msg_once(optname,
+        call sexp#warn#msg(
             \ printf("sexp-warning: Ignoring invalid option setting: %s=%s."
                 \ . " Defaulting to %d",
-                \ optname, string(ret), def))
+                \ optname, string(ret), def)
+            \ {'once': optname})
         let ret = def
     endif
     return ret

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2436,6 +2436,10 @@ endfunction
 " -- Optional Dict --
 " top_is_list      Treat toplevel as list if cursor at toplevel
 " list_info        If not empty or omitted, use to skip call to s:list_info()
+" exact_count      If the requested child does not exist, return nullpos pair: i.e., don't
+"                  simply return the terminal element.
+" TODO: Add option that won't consider a list whose brackets/macros we're on.
+" TODO: Probably accept position other than curpos.
 function! s:child_range(count, tail, inner, ...)
     let cursor = getpos('.')
     let ret = {'range': [s:nullpos, s:nullpos], 'missing': a:count}
@@ -2443,21 +2447,25 @@ function! s:child_range(count, tail, inner, ...)
         if a:0
             let top_is_list = get(a:1, 'top_is_list', 0)
             let li = get(a:1, 'list_info', {})
+            let exact_count = get(a:1, 'exact_count', 0)
         endif
         " Get relevant info about current list, including desired terminal.
         let li = empty(li) ? s:list_info(a:tail) : li
-        let ret.range = li.terminal_range
-        if !ret.range[0][1] && !li.brackets[0][1] && top_is_list
+        " Attempt to get non-null terminal range as starting point for search.
+        " Caveat: Don't update return dict till desired child is found.
+        let range = li.terminal_range
+        if !range[0][1] && !li.brackets[0][1] && top_is_list
             " Check for buffer head/tail.
-            let ret = s:buffer_terminal(a:tail)
+            let range = s:buffer_terminal(a:tail)
         endif
-        if ret.range[0][1]
+        " Do we have a starting point?
+        if range[0][1]
             " Assumption: We're sitting on head/tail element.
             " If count > 1, find count-1'th adjacent element.
             let cnt = a:count ? a:count - 1 : 0
             if cnt
                 " Start on outside of terminal element and search inward.
-                let p = ret.range[a:tail]
+                let p = range[a:tail]
                 call s:setcursor(p)
                 while cnt
                     " Land on outside of elements.
@@ -2469,17 +2477,20 @@ function! s:child_range(count, tail, inner, ...)
                     let cnt -= 1
                 endwhile
                 " We're positioned on outside of desired element (or if count was too
-                " high, the final element in list in desired direction).
-                let ret.range[a:tail] = getpos('.')
-                let ret.range[!a:tail] = sexp#current_element_terminal(!a:tail)
+                " high, the terminal element in desired direction).
+                if !cnt || !exact_count
+                    " Assign to return dict.
+                    let ret.range[a:tail] = getpos('.')
+                    let ret.range[!a:tail] = sexp#current_element_terminal(!a:tail)
+                endif
                 let ret.missing = cnt
             else
                 " Terminal is sought child.
-                let ret.missing = 0
+                let [ret.range, ret.missing] = [range, 0]
             endif
             if !a:inner
                 " Perform whitespace cleanup.
-                let ret.range = s:terminals_with_whitespace(ret[0], ret[1])
+                let ret.range = s:terminals_with_whitespace(ret.range[0], ret.range[1])
             endif
         endif
     finally
@@ -2783,7 +2794,7 @@ endfunction
 " count backwards from tail, 1 to count forwards from head. If no such child element
 " exists, selects closest one (i.e., last in the specified direction).
 function! sexp#select_child(mode, count, next, inner)
-    let [s, e] = s:child_range(a:count, a:next, a:inner)
+    let [s, e] = s:child_range(a:count, a:next, a:inner, {'exact_child': 0})
     if s[1]
         " Note: Although we may be called from visual mode, child selection ignores
         " current selection by definition.
@@ -2971,7 +2982,7 @@ function! s:regput__get_context(tgt_info)
     if !ret.empty_buffer && !ret.empty_list
         " Set side-specific 'alone' flags in loop.
         for i in range(2)
-            if ret.put_mode == 'replace'
+            if ret.put_mode =~ 'replace'
                 " Cache range comprising the current outer range endpoint and the inner
                 " range endpoint closest to it.
                 let range = i
@@ -2979,8 +2990,6 @@ function! s:regput__get_context(tgt_info)
                     \ : [ret.range[0], ret.inner_range[0]]
                 let is_ele = i ? [1, ret.is_ele[1]] : [ret.is_ele[0], 1]
                 let is_bra = i ? [0, ret.is_bra[1]] : [ret.is_bra[0], 0]
-            elseif ret.put_mode == 'replace_child'
-                " TODO!!!!
             else " put_mode in ['put', 'put_child']
                 let range = ret.range
                 let [is_ele, is_bra] = [ret.is_ele, ret.is_bra]
@@ -3130,21 +3139,20 @@ function! s:regput__get_seps(ctx, reg)
     let [ctx, reg] = [a:ctx, a:reg]
     let tail = ctx.tail
     let ret = [s:NL, s:NL, s:NL, '']
+    " Determine whether put is into one of the special slots in a 'shaped' list.
+    " Note: Inhibit this special case logic if more than one toplevel element in register.
+    " Rationale: For the special logic to be meaningful in the multiple toplevel element
+    " case, we'd need not only to parse the register text (already doing so), but also
+    " potentially *modify* the whitespace between elements, which is analogous to the
+    " 'interior separators' used for [count] > 1.
+    let lpi = reg.elem_count > 1 || ctx.empty_buffer || ctx.empty_list
+        \ ? 0 : s:regput__check_list_context(ctx, reg)
     " TODO: Make global option for this?
     let g:append_sl_comment = get(g:, 'append_sl_comment', 1)
     " Override the NL separators as needed.
     if ctx.empty_buffer
         let ret[0:1] = [s:EMPTY, s:EMPTY]
     else
-        " Determine whether put is into one of the special slots in a 'shaped' list.
-        " Note: Inhibit this special case logic if more than one toplevel element in
-        " register.
-        " Rationale: For the special logic to be meaningful in the multiple toplevel
-        " element case, we'd need not only to parse the register text (already doing so),
-        " but also potentially *modify* the whitespace between elements, which is
-        " analogous to the 'interior separators' used for [count] > 1.
-        let lpi = reg.elem_count > 1 ? 0 : s:regput__check_list_context(ctx, reg)
-
         for i in range(2)
             " Compute side-dependent 'want_spc' flag used to determine SPC-insertion at both
             " start/end.
@@ -3572,63 +3580,76 @@ endfunction
 " Note: This mode is almost unnecessary, since the same effect could be achieved simply by
 " hitting v before the visual mapping.
 function! s:replace__get_tgt_normal(count, tgt)
-    let curpos = getpos('.')
-    try
-        " Look for element under cursor.
-        let p = sexp#current_element_terminal(0)
-        if !p[1]
-            " Refuse to do anything if no element under cursor!
-            " TODO: Need a way to communicate noop/error back to caller.
-            throw "sexp-warning: 'Replace with register' requires element under cursor!"
-        endif
-        " We have a current element to replace.
-        let a:tgt.inner_range = [p, sexp#current_element_terminal(1)]
-    finally
-        call s:setcursor(curpos)
-    endtry
+    " Look for element under cursor.
+    let p = sexp#current_element_terminal(0)
+    if !p[1]
+        " Refuse to do anything if no element under cursor!
+        " TODO: Need a way to communicate noop/error back to caller.
+        throw "sexp-warning: 'Replace with register' requires element under cursor!"
+    endif
+    " We have a current element to replace.
+    let a:tgt.inner_range = [p, sexp#current_element_terminal(1)]
 endfunction
 
-function! s:replace__get_tgt(mode, count)
+" Note: To avoid duplication, both replace and replace_child are handled by this function.
+" TODO: Decide about arg P, which is needed only for replace_child, and probably needs to
+" make it into the dict, since it will be needed downstream.
+function! s:replace_mode__get_tgt(put_mode, mode, count, tail, P)
     let ret = {
-        \ 'put_mode': 'replace', 'count': a:count,
+        \ 'put_mode': a:put_mode, 'count': a:count,
         \ 'range': [s:nullpos, s:nullpos],
         \ 'inner_range': [s:nullpos, s:nullpos],
         \ 'is_bra': [0, 0], 'is_ele': [0, 0],
         \ 'tail': -1, 'force_nl': [0, 0]}
-    " Allow mode-specific function to augment dict with the inner_range.
-    if a:mode == 'v'
-        call s:replace__get_tgt_visual(a:count, ret)
-    else
-        call s:replace__get_tgt_normal(a:count, ret)
-    endif
-    " Determine the range that contains inner_range.
-    for i in range(2)
-        call s:setcursor(ret.inner_range[i])
-        let p = s:nearest_element_terminal(i, !i, 1, 1)
-        if p[1]
-            let ret.is_ele[i] = 1
-        else
-            let p = s:nearest_bracket(i)
-            if p[1]
-                let ret.is_bra[i] = 1
+    let curpos = getpos('.')
+    try
+        if a:put_mode == 'replace'
+            " Allow mode-specific function to augment dict with the inner_range.
+            if a:mode == 'v'
+                call s:replace__get_tgt_visual(a:count, ret)
             else
-                " Default to buffer extremity.
-                let p = i ? [0, line('$'), col([line('$'), '$']), 0] : s:BOF
+                call s:replace__get_tgt_normal(a:count, ret)
             endif
+        else " 'replace_child'
+            let ret.tail = a:tail
+            let cr = s:child_range(a:count, a:tail, 1, {'exact_count': 1})
+            if cr.missing
+                " Requested child doesn't exist!
+                throw "sexp-warning: 'replace_child': the requested child does not exist!"
+            endif
+            let ret.inner_range = cr.range
         endif
-        let ret.range[i] = p
-    endfor
-    return ret
+        " Determine the range that *contains* inner_range.
+        for i in range(2)
+            call s:setcursor(ret.inner_range[i])
+            let p = s:nearest_element_terminal(i, !i, 1, 1)
+            if p[1]
+                let ret.is_ele[i] = 1
+            else
+                let p = s:nearest_bracket(i)
+                if p[1]
+                    let ret.is_bra[i] = 1
+                else
+                    " Default to buffer extremity.
+                    let p = i ? [0, line('$'), col([line('$'), '$']), 0] : s:BOF
+                endif
+            endif
+            let ret.range[i] = p
+        endfor
+    finally
+        call s:setcursor(curpos)
+        return ret
+    endtry
 endfunction
 
-" Note: For replace mode puts, tail indicates which p command was used:
-"   0 == 'p', 1 == 'P'
+" Note: For replace modes, tail indicates which p command was used: 0 == 'p', 1 == 'P'.
+" Although it doesn't affect the result of the put, it does determine whether the unnamed
+" register is updated.
 function! sexp#replace(mode, count, tail)
     try
         let count = a:count ? a:count : 1
         " Target determination is mode-specific.
-        let tgt = s:replace__get_tgt(a:mode, count)
-
+        let tgt = s:replace_mode__get_tgt('replace', a:mode, count, -1, -1)
         " Design Decision: Let tail==1 represent put with P.
         call s:regput__impl(tgt, count, a:tail)
     catch /sexp-warning:/
@@ -3676,7 +3697,8 @@ function! s:put_child__get_tgt(count, tail)
             if a:count > 1
                 " Child other than terminal element requested.
                 " Find element before/after which to insert.
-                let c = s:child_range(a:count, a:tail, 0, {'list_info': li})
+                let c = s:child_range(a:count, a:tail, 0,
+                    \ {'list_info': li, 'exact_count': 0})
                 if c.missing
                     " Requested child doesn't exist, so use limiting list bracket and
                     " bracket end of terminal child.
@@ -3730,7 +3752,42 @@ function! sexp#put_child(count, tail)
     call s:regput__impl(tgt, 1, a:tail)
 endfunction
 
-function! sexp#replace_child(count, dir, tail)
+" Calculate and return the tgt_info dict needed by s:regput__get_context() for the case of
+" a 'replace_child' command.
+" Note: For details on this dict, see header of s:regput__get_context().
+" Note: For details on the meaning of 'tail', see header of put_child__get_tgt().
+function! s:replace_child__get_tgt(count, tail, P)
+    let cursor = getpos('.')
+    let ret = {
+        \ 'put_mode': 'put_child', 'count': a:count,
+        \ 'range': [s:nullpos, s:nullpos],
+        \ 'inner_range': [s:nullpos, s:nullpos],
+        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
+        \ 'tail': a:tail, 'force_nl': [0, 0]}
+    try
+        let ret.inner_range = s:child_range(a:count, a:tail, 0, {'exact_count': 1})
+        if !ret.inner_range[0][1]
+            " Requested child doesn't exist!
+            throw "sexp-warning: 'replace_child': the requested child does not exist!"
+        endif
+    finally
+        call s:setcursor(cursor)
+        return ret
+    endtry
+endfunction
+
+function! sexp#replace_child(count, tail, P)
+    try
+        let count = a:count ? a:count : 1
+        let tgt = s:replace_mode__get_tgt('replace_child', 'n', count, a:tail, a:P)
+        " Note: [count] is used only for child location, so hardcode to 1.
+        call s:regput__impl(tgt, 1, a:tail)
+    catch /sexp-warning:/
+        call sexp#warn#msg(v:exception)
+    catch
+        " Show throwpoint only for non-warning errors.
+        call sexp#warn#msg(v:exception . " at " . v:throwpoint)
+    endtry
 endfunction
 
 " Swap current visual selection with adjacent element. If pairwise is true,

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -1296,94 +1296,6 @@ function! s:offset_char(pos, dir, ...)
     return pos
 endfunction
 
-" See s:super_range() for function description.
-function! s:super_range_legacy(start, end)
-    let cursor = getpos('.')
-    let [start, end] = [a:start[:], a:end[:]]
-    " Find matching pair of brackets (if one exists) that contains both start and end. Set
-    " shared_close to the close position, or null if no such pair exists.
-    " Note: In this context, a bracket "contains" itself.
-    call s:setcursor(start)
-    " Seed the loop position with an open containing start (possibly start itself).
-    let shared_open = s:is_list(start[1], start[2]) == 2 ? start : s:move_to_nearest_bracket(0)
-    while shared_open[1]
-        let shared_close = s:nearest_bracket(1)
-        " Note: Null shared close implies end at top level due to unbalanced open.
-        let cmp = !shared_close[1] ? 1 : s:compare_pos(shared_close, end)
-        if cmp >= 0
-            " Either we found shared close or we're not going to.
-            break
-        endif
-        " Haven't yet found shared close (and haven't hit top-level trying). Adjust
-        " start to current open bracket before looking higher.
-        let start = shared_open
-        let shared_open = s:move_to_nearest_bracket(0)
-    endwhile
-    " Assumptions:
-    " * Null shared_open implies null shared_close
-    " * shared_open == start implies end equal to a *non-null* shared_close.
-    " * shared_close == end implies start equal to a *non-null* shared_open.
-    " Enforce the associated constraints, with possibly redundant assignments.
-    if !shared_open[1]
-        " We hit top level looking for shared open containing end.
-        " Note: In case of unbalanced open, this assignment will be redundant.
-        let shared_close = [0, 0, 0, 0]
-    elseif shared_open == start
-        if shared_close[1]
-            let end = shared_close
-        endif
-    elseif shared_close == end
-        if shared_open[1]
-            let start = shared_open
-        endif
-    endif
-    " If on element, find its start.
-    " Rationale: Prefer start of macro chars to open bracket.
-    call s:setcursor(start)
-    let p = sexp#current_element_terminal(0)
-    if p[1]
-        let start = p
-    endif
-    " Is it possible we need to adjust end upward?
-    if end != shared_close
-        " Special Cases:
-        "   (shared_close == null)   => shared close is top-level
-        "       Don't look up any further; just find end terminal
-        "   (shared_close == a:end)    => end requires no adjustment
-        "       The next two loops will be skipped.
-        call s:setcursor(end)
-        " Note: compare_pos() < 0 could be simplified to p != shared_close.
-        " Rationale: Prior logic guarantees that p will eventually land *on* a non-null
-        " shared_close.
-        " Seed prev position var.
-        let p = end
-        " Treat null shared close like shared close past EOF.
-        while !shared_close[1] || s:compare_pos(p, shared_close) < 0
-            let end = p
-            let p = s:move_to_nearest_bracket(1)
-            if !p[1]
-                " Top level is common ancestor
-                break
-            endif
-        endwhile
-        " As long as we can assume a form always ends with a closing bracket (e.g., no macro
-        " chars following close), we can skip looking for terminal whenever the preceding loop
-        " has adjusted end to a closing bracket (i.e., end != a:end).
-        if end == a:end
-            call s:setcursor(end)
-            " Ensure end is a terminal.
-            let p = sexp#current_element_terminal(1)
-            if p[1]
-                let end = p
-            endif
-        endif
-    endif
-
-    " Restore saved position.
-    call s:setcursor(cursor)
-    return [start, end]
-endfunction
-
 " Return a superset range containing no unbalanced brackets by adjusting one or both sides
 " of the input range upward till both sides are at same level (i.e., have same parent) and
 " no elements are partially included in the range.
@@ -1500,6 +1412,106 @@ function! s:constrained_range(start, end, keep_end)
     endif
     call s:setcursor(cursor)
     return ret
+endfunction
+
+" Calculate *effective* auto-indent range calculation level, taking
+" g:sexp_auto_indent_range and any other relevant options into account.
+" Note: Levels 1 and 3 specify conditional fall forward or fall back as a function of
+" other options. Thus, this function returns a value from the following set: [0, 2, 4].
+function! s:get_effective_ai_range()
+    let val = get(g:, 'sexp_auto_indent_range', 1)
+    let [typ, ityp] = [type(val), type(0)]
+    if typ != ityp || val < 0 || val > 4
+        " If user set to something larger than 4, cap it at 4; otherwise, default to 1.
+        let bad = val
+        let val = typ == ityp && val > 4 ? 4 : 1
+        call sexp#warn#msg_once(
+            \ "Ignoring invalid g:sexp_auto_indent_range setting: "
+            \ . bad . ". Defaulting to " . string(val))
+        " Design Decision: Wouldn't need to set global here, since msg_once() ensures we
+        " won't keep warning; still, there's no harm in doing so, as user can override at
+        " any time.
+        let g:sexp_auto_indent_range = val
+    endif
+    if val == 1 || val == 3
+        " Increment 1 up or down
+        let val += g:sexp_indent_does_clean || g:sexp_indent_aligns_comments ? 1 : -1
+    endif
+    return val
+endfunction
+
+" TODO: Comment!!!
+" Return dict with the following keys:
+"   start
+"   end
+"   top
+"   cnt
+function! s:get_reindent_range(s, e)
+    let cursor = getpos('.')
+    let ai_range = s:get_effective_ai_range()
+    " Return range may be adjusted below.
+    let [s, e] = [a:s, a:e]
+    " These will be adjusted later if parent list is to be used in lieu of explicit range.
+    let [top, cnt] = [-1, 1]
+    try
+        " Position at start of first element of input range.
+        let [s, e] = s:super_range(s, e)
+        " If at top, just use [s,e].
+        if !s:at_top(s[1], s[2])
+            if !ai_range && s:is_list_terminal(s, 0)
+                " Changes to list head can propagate to the end of a list, so constrain to
+                " level >= 1.
+                let ai_range = max([1, ai_range])
+            endif
+            " Assumption: Containing if guard obviates need to validate bracket searches.
+            " Note: We're on tail end of input end element.
+            if ai_range == 4
+                " containing top-level form
+                let top = 1
+            elseif ai_range == 2
+                " containing form only
+                let top = 0
+                " If start is open bracket, use count of 2 to reindent that list's parent.
+                if s:is_list(s[1], s[2]) == 2
+                    let cnt = 2
+                endif
+            else
+                " Calculate impacted range.
+                " Logic: We know s is not list head, so as long as indentation was correct
+                " before the operation, we should be able to keep it so by indenting up to
+                " the first 'clean point' (i.e., line break between elements) after e.
+                call s:setcursor(e)
+                let [p, d] = s:last_colinear_sibling(1)
+                let e = d.brkt[1] ? d.brkt : p
+            endif
+        endif
+    finally
+        call s:setcursor(cursor)
+    endtry
+    return {'top': top, 'cnt': cnt, 'start': s, 'end': e}
+endfunction
+
+" TODO: Comment!!!
+function! s:post_op_reindent(s, e, ps)
+    let rng = s:get_reindent_range(a:s, a:e)
+    " Skip single-line, explicit range indents.
+    if rng.top >= 0 || rng.start[1] != rng.end[1]
+        if rng.top >= 0
+            " Indenting a parent (or ancestor) list rather than explicit range.
+            " Position cursor on start and let sexp#indent() find applicable parent.
+            let mode = 'n'
+            call s:setcursor(rng.start)
+        else
+            let mode = 'v'
+            " Re-indent explicit range.
+            call s:set_visual_marks([rng.start, rng.end])
+            " Note: Though we use visual marks, it's important that we be in normal mode.
+            call sexp#ensure_normal_mode()
+        endif
+        " sexp#indent() will use mode and top to determine operating mode.
+        " Caveat: Convert rng.top == -1 (explicit range) to 0.
+        call sexp#indent(mode, rng.top == 1, rng.cnt, -1, 1, a:ps)
+    endif
 endfunction
 
 """ PREDICATES AND COMPARATORS {{{1
@@ -2930,11 +2942,11 @@ endfunction
 "   ctx:  put context dict
 "   reg:  register characterization dict
 " Return Dict:
-"   near_sep:     text to put between target and register contents
-"   far_sep:      text to put between register contents and element that *was* adjacent to
-"                 target
-"   interior_sep: text to join the individual instances of register contents in case of a
-"                 [count]
+"   near_sep:      text to put between target and register contents
+"   far_sep:       text to put between register contents and element that *was* adjacent
+"                  to target
+"   interior_sep:  text to join the individual instances of register contents in case of a
+"                  [count]
 function! s:put__get_seps(tail, ctx, reg)
     let ret = {'near_sep': '', 'far_sep': '', 'interior_sep': ''}
     let [tail, ctx, reg] = [a:tail, a:ctx, a:reg]
@@ -3081,132 +3093,10 @@ function! s:last_colinear_sibling(tail)
     endtry
 endfunction
 
-" Reindent range affected by sexp#put.
-" Logic:
-" -- Put into empty list --
-"   Re-indent the list
-" -- Put into empty buffer --
-"   Re-indent the put text
-" -- Head --
-"   if put into list head context
-"     Re-indent parent
-"   else
-"     Adjacent element never requires reindent.
-"     Target element requires reindent iff not separated by NL from put text.
-"     Away element requires reindent iff target element requires reindent AND away element
-"     not separated by NL from target, and so on, recursively to close bracket.
-"     Question: Would it be better just to reindent parent in this case (or possibly just
-"     use close bracket), given that the traversal of siblings could end up taking longer
-"     than the time saved?
-" -- Tail --
-"   Assumption: Put into list head handled separately.
-"   Target and away elements never require reindent.
-"   Put text always requires reindent.
-"   Immediately adjacent element always requires reindent.
-"   Rationale: Even if it's separated by NL from put text and was properly indented before
-"   the put, NL may have replaced all its leading indent.
-"   Adjacent to adjacent requires reindent iff not separated from immediate adjacent, and
-"   so on, recursively to close bracket.
-"   Rationale: Head is not changing, so put text shouldn't be able to change indent
-"   context of subsequent, non-colinear forms.
-"   Assumption: Adjacent text was aligned correctly before the put!
-"   TODO: Should we assume this?
-" Important TODO!!! Create more generic (non-put-specific) function to subsume a lot of
-" this logic!!!
-function! s:put__reindent(tail, ctx, reg, sep, ps)
-    let [NL, SPC, EMPTY] = ["\n", " ", ""]
-    let [tail, ctx, reg, sep] = [a:tail, a:ctx, a:reg, a:sep]
-    let irange = [s:nullpos, s:nullpos]
-    let indent_parent = 0
-    if ctx.empty_list
-        let indent_parent = 1
-        let irange[0] = ctx.tgt
-    elseif ctx.empty_buffer
-        " TODO: Do we need to take this range as input arg, or is it safe to use marks?
-        let [irange[0], irange[1]] = [getpos("'["), getpos("']")]
-    elseif tail
-        " Put after
-        let irange[0] = getpos("'[")
-        " End of range will be last colinear sibling, else enclosing bracket, else end of
-        " put text.
-        let p = ctx.adj[1] ? ctx.adj : ctx.adj_bracket[1] ? ctx.adj_bracket : getpos("']")
-        if ctx.adj[1] && sep.far_sep != NL
-            " Start at near side of adjacent and find far side of last colinear sibling.
-            call s:setcursor(p)
-            let [p, d] = s:last_colinear_sibling(1)
-            if d.brkt[1]
-                " Use an enclosing bracket if no non-colinear sibling.
-                let p = d.brkt
-            endif
-        endif
-        let irange[1] = p
-    else
-        " Put before
-        if ctx.tgt_is_terminal
-            " Put into head context; re-indent parent
-            let indent_parent = 1
-            let irange[0] = ctx.tgt
-        else
-            " Head not changing; need NL between elements to establish 'clean point'.
-            let irange[0] = getpos("'[")
-            if sep.near_sep != NL
-                " At least target requires reindent, maybe more...
-                let p = ctx.tgt
-                call s:setcursor(p)
-                " TODO: Consider storing ranges rather than positions to obviate need for
-                " this here.
-                " Move to away side of target.
-                " TODO: The call to s:last_colinear_sibling() could be used to
-                " obviate the need for much of the logic in the if block below. It's done
-                " this way only to use information we already have whenever possible.
-                let p = s:move_to_current_element_terminal(1)
-                if !ctx.away[1]
-                    " No away element; use bracket if it exists.
-                    if ctx.away_bracket[1]
-                        let irange[1] = ctx.away_bracket
-                    else
-                        " Nothing on away side, not even bracket, so just use tgt.
-                        let irange[1] = p
-                    endif
-                elseif ctx.away[1] > ctx.tgt[1]
-                    " Safe to stop with away side of target since away is not colinear
-                    let irange[1] = p
-                else
-                    " Can't stop with near side of away because it's colinear with target.
-                    " Look for a line break between siblings (or end of list).
-                    call s:setcursor(ctx.away)
-                    call s:move_to_current_element_terminal(1)
-                    let [p, d] = s:last_colinear_sibling(1)
-                    let irange[1] = d.brkt[1] ? d.brkt : p
-                endif
-            else
-                " No need to go past away edge of target
-                " TODO: Consider storing both sides in a range in the context function.
-                call s:setcursor(ctx.tgt)
-                let irange[1] = sexp#current_element_terminal(1)
-            endif
-        endif
-    endif
-
-    " Skip single-line indents.
-    if indent_parent || irange[0][1] != irange[1][1]
-        if indent_parent
-            " Assumption: Cursor is positioned on parent list bracket.
-            let mode = 'n'
-        else
-            let mode = 'v'
-            " Range spans multiple lines, so re-indent.
-            call s:set_visual_marks(irange)
-            " Note: Though we use visual marks, it's important that we be in normal mode.
-            call sexp#ensure_normal_mode()
-        endif
-        call sexp#indent(mode, 0, 1, -1, 1, a:ps)
-    endif
-endfunction
-
 function! s:put__get_splice_info(count, tail, ctx, reg, sep, flags)
     let ret = { 'range': [s:nullpos, s:nullpos], 'text': '', 'inc': 0}
     let [ctx, reg, sep] = [a:ctx, a:reg, a:sep]
+    let [NL, SPC, EMPTY] = ["\n", " ", ""]
 
     " Set the target-side splice position.
     " Assumption: Currently, ctx.tgt is always set to something non-null.
@@ -3233,12 +3123,20 @@ function! s:put__get_splice_info(count, tail, ctx, reg, sep, flags)
             " There's something adjacent to target to anchor splice at other end.
             let ret.range[a:tail] = adj_pos
             let [near_sep, far_sep] = [sep.near_sep, sep.far_sep]
-            if far_sep == "\n"
+            " May be set to 2 (EOL-exclusive) later.
+            let exc_typ = 0
+            if far_sep == NL
                 " Determine number of newlines to prepend/append on far side of put text,
                 " as function of number of blank lines between target and adjacent (taking
                 " options into account).
                 let gap = ret.range[1][1] - ret.range[0][1]
                 let num_nl = min([gap, g:sexp_cleanup_keep_empty_lines + 1])
+                if a:tail
+                    " Keep the final NL to avoid clobbering leading indent.
+                    " Rationale: Permits earlier "clean point" for re-indent.
+                    let exc_typ = 2
+                    let num_nl -= 1
+                endif
                 let far_sep = repeat("\n", num_nl)
             endif
             " Build splice string.
@@ -3249,7 +3147,7 @@ function! s:put__get_splice_info(count, tail, ctx, reg, sep, flags)
             let t = join(t, sep.interior_sep)
             let t = a:tail ? near_sep . t . far_sep : far_sep . t . near_sep
             let ret.text = t
-            let ret.inc = [0, 0]
+            let ret.inc = [0, exc_typ]
         endif
     endif
     return ret
@@ -3263,9 +3161,8 @@ function! sexp#put(count, tail)
     let reg = s:put__get_reginfo()
     let ctx = s:put__get_context(count, a:tail)
     let sep = s:put__get_seps(a:tail, ctx, reg)
-    " TODO: Review the reindent range calculation logic.
-    "let irange = s:put__get_reindent_range(a:tail, ctx, reg, sep)
     let spl = s:put__get_splice_info(count, a:tail, ctx, reg, sep, {})
+    let ps = [vs, ve]
     if !spl.range[1][1]
         " TODO: Consider handling this with simple p/P: i.e., without yankdel_range().
         " Question: Do we need yankdel_range for position adjustments?
@@ -3292,8 +3189,9 @@ function! sexp#put(count, tail)
             call setpos("']", curpos)
         endif
     endif
-    " FIXME: Make sure all branches above set curpos!
-    call s:put__reindent(a:tail, ctx, reg, sep, [ps, curpos])
+    let [s, e] = [getpos("'["), getpos("']")]
+    " FIXME: Make sure all branches above set curpos.
+    call s:post_op_reindent(s, e, [ps, curpos])
     " !!!!! WIP !!!!!
     call s:setcursor(curpos)
     call s:set_visual_marks([vs, ve])
@@ -3474,8 +3372,7 @@ function! s:yankdel_range__preadjust_range_end(end, inc)
     return ret
 endfunction
 
-" Build and return a dict with information required to adjust arbitrary buffer positions
-" after yank/splice/del has been performed.
+" Build and return a dict with information designed to facilitate requested yank/splice/del.
 " Return Dict:
 "   start:     start of inclusive range for operation (N/A for directed put)
 "   end:       end of inclusive range for operation (N/A for directed put)
@@ -3493,6 +3390,7 @@ function! s:yankdel_range__preadjust_range(start, end, del_or_spl, inc)
         " 'err' flag with msg?
         return {'err': 1, 'errmsg': 'Invalid (reversed) range'}
     endif
+    let [NL, SPC, EMPTY] = ["\n", " ", ""]
     " If here, range was sane.
     let start = s:yankdel_range__preadjust_range_start(a:start, a:inc[0])
     let end = s:yankdel_range__preadjust_range_end(a:end, a:inc[1])
@@ -3818,6 +3716,7 @@ function! s:yankdel_range(start, end, del_or_spl, ...)
                 " always sets/gets '[ and '] (not `[ and `]).
                 " Solution: Use getpos('.') to obtain positions reached by `[ and `], then
                 " m[ and m] to set `[ and `] to those positions after the deletion.
+                " TODO: Decide whether ] should be backed up to end of preceding line.
                 execute 'normal! `[' | let smark = getpos('.')
                 execute 'normal! `]' | let emark = getpos('.')
                 " Cleanup the space that was appended to inhibit linewise put.

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -2971,7 +2971,6 @@ function! s:regput__get_context(tgt_info)
     if !ret.empty_buffer && !ret.empty_list
         " Set side-specific 'alone' flags in loop.
         for i in range(2)
-
             if ret.put_mode == 'replace'
                 " Cache range comprising the current outer range endpoint and the inner
                 " range endpoint closest to it.
@@ -3023,8 +3022,7 @@ endfunction
 " List Position Special Case Conditions: (all must be met)
 " * First element is single-line (most likely name of function).
 " * First and second element are colinear.
-" * Third element is either nonexistent or non-colinear with second element.
-"   TODO: Consider requiring third element to exist.
+" * Third element *not* colinear with second element.
 " * (optional) List is not a 'let' form.
 "   TODO: The 'reg' parameter, currently unused, was added to support this.
 " Rationale: This function is used to determine whether calculated separators may require
@@ -3083,27 +3081,32 @@ function! s:regput__check_list_context(ctx, reg)
         let eidx = sidx
     endif
 
-    " Cache some useful vars pertaining to the first 3 elements of list.
-    let [s1, e1] = eidx > 0 ? ps[0] : s:nullpos_pair
-    let [s2, e2] = eidx > 1 ? ps[1] : s:nullpos_pair
-    let [s3, e3] = eidx > 2 ? ps[2] : s:nullpos_pair
-    " Design Decision: Special case applies only to single-line head elements.
-    let colinear12 = eidx > 1 && s1[1] == e1[1] && e1[1] == s2[1]
-    let colinear23 = eidx > 2 && e2[1] == s3[1]
-    " Note: The colinear12 condition will rule out scenarios with too few elements.
-    if colinear12 && !colinear23
-        if sidx == 0
-            " Inserting to head position.
-            " Design Decision: Don't treat as special case.
-            " Rationale: Handling would entail inserting a line break after the current
-            " head element, which can't be accomplished with separators around the put
-            " text. Keep it simple. Users don't often paste the name of a function
-            " anyways...
-            return 1
-        elseif sidx == 1
-            return 2
-        elseif sidx == 2
-            return 3
+    " Special case requires at least 3 elements.
+    " Rationale: We're looking for a list "shape" defined by 3 elements:
+    "   (func arg1 arg2 NL arg3 ...)
+    if eidx >= 3
+        " TODO: Use s:is_list() and regex to test for (let* [ ...) here...
+        " Cache some useful vars pertaining to the first 3 elements of list.
+        let [s1, e1] = ps[0]
+        let [s2, e2] = ps[1]
+        let [s3, e3] = ps[2]
+        " Design Decision: Special case applies only to single-line head elements.
+        let colinear12 = s1[1] == e1[1] && e1[1] == s2[1]
+        let colinear23 = e2[1] == s3[1]
+        if colinear12 && !colinear23
+            if sidx == 0
+                " Inserting to head position.
+                " Design Decision: Don't treat as special case.
+                " Rationale: Handling would entail inserting a line break after the
+                " current head element, which can't be accomplished with separators around
+                " the put text. Keep it simple. Users don't often paste the name of a
+                " function anyways...
+                return 1
+            elseif sidx == 1
+                return 2
+            elseif sidx == 2
+                return 3
+            endif
         endif
     endif
     " Nothing special.
@@ -3542,22 +3545,34 @@ function! sexp#put(count, tail)
     endif
 endfunction
 
-function! s:replace__get_tgt_visual(count)
+" Set inner_range of the input tgt dict.
+function! s:replace__get_tgt_visual(count, tgt)
+    let curpos = getpos('.')
+    try
+        let [vs, ve] = s:get_visual_marks()
+        let [s, e] = s:super_range(vs, ve)
+        " Preceding call to s:super_range() obviates need for ignored region checking.
+        if !s:range_has_non_ws(s, e, 0)
+            " Nothing to replace.
+            " Design Decision Needed: Should we a) throw and warn user or b) convert to
+            " normal put. (And if (b), should we try to ensure the put is non-directional,
+            " given that this might not happen naturally?)
+            throw "sexp-warning: "
+                \ . "visual mode 'replace with register' requires selection of"
+                \ . " something other than whitespace!"
+        endif
+        " We have a non-empty set of elements to replace.
+        let a:tgt.inner_range = [s, e]
+    finally
+        call s:setcursor(curpos)
+    endtry
 endfunction
 
+" Set inner_range of the input tgt dict.
 " Note: This mode is almost unnecessary, since the same effect could be achieved simply by
 " hitting v before the visual mapping.
-function! s:replace__get_tgt_normal(count)
+function! s:replace__get_tgt_normal(count, tgt)
     let curpos = getpos('.')
-    " TODO: Make sure it's safe to set tail to -1; I don't like setting it to 0..1 if it's
-    " don't care...
-    let ret = {
-        \ 'error': '',
-        \ 'put_mode': 'replace', 'count': a:count,
-        \ 'range': [s:nullpos, s:nullpos],
-        \ 'inner_range': [s:nullpos, s:nullpos],
-        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
-        \ 'tail': -1, 'force_nl': [0, 0]}
     try
         " Look for element under cursor.
         let p = sexp#current_element_terminal(0)
@@ -3567,38 +3582,47 @@ function! s:replace__get_tgt_normal(count)
             throw "sexp-warning: 'Replace with register' requires element under cursor!"
         endif
         " We have a current element to replace.
-        let ret.inner_range = [p, sexp#current_element_terminal(1)]
+        let a:tgt.inner_range = [p, sexp#current_element_terminal(1)]
     finally
         call s:setcursor(curpos)
-        return ret
     endtry
 endfunction
 
 function! s:replace__get_tgt(mode, count)
-    let tgt = a:mode == 'v'
-        \ ? s:replace__get_tgt_visual(a:count)
-        \ : s:replace__get_tgt_normal(a:count)
+    let ret = {
+        \ 'put_mode': 'replace', 'count': a:count,
+        \ 'range': [s:nullpos, s:nullpos],
+        \ 'inner_range': [s:nullpos, s:nullpos],
+        \ 'is_bra': [0, 0], 'is_ele': [0, 0],
+        \ 'tail': -1, 'force_nl': [0, 0]}
+    " Allow mode-specific function to augment dict with the inner_range.
+    if a:mode == 'v'
+        call s:replace__get_tgt_visual(a:count, ret)
+    else
+        call s:replace__get_tgt_normal(a:count, ret)
+    endif
     " Determine the range that contains inner_range.
     for i in range(2)
-        call s:setcursor(tgt.inner_range[i])
+        call s:setcursor(ret.inner_range[i])
         let p = s:nearest_element_terminal(i, !i, 1, 1)
         if p[1]
-            let tgt.is_ele[i] = 1
+            let ret.is_ele[i] = 1
         else
             let p = s:nearest_bracket(i)
             if p[1]
-                let tgt.is_bra[i] = 1
+                let ret.is_bra[i] = 1
             else
                 " Default to buffer extremity.
                 let p = i ? [0, line('$'), col([line('$'), '$']), 0] : s:BOF
             endif
         endif
-        let tgt.range[i] = p
+        let ret.range[i] = p
     endfor
-    return tgt
+    return ret
 endfunction
 
-" Note: tail == 1 ==> 'P'
+" Note: For replace mode puts, tail indicates which p command was used:
+"   0 == 'p', 1 == 'P'
 function! sexp#replace(mode, count, tail)
     try
         let count = a:count ? a:count : 1
@@ -3607,9 +3631,11 @@ function! sexp#replace(mode, count, tail)
 
         " Design Decision: Let tail==1 represent put with P.
         call s:regput__impl(tgt, count, a:tail)
-    catch
-        " FIXME!!!!!
+    catch /sexp-warning:/
         call sexp#warn#msg(v:exception)
+    catch
+        " Show throwpoint only for non-warning errors.
+        call sexp#warn#msg(v:exception . " at " . v:throwpoint)
     endtry
 endfunction
 
@@ -5427,6 +5453,7 @@ endfunction
 " duplication as it is now.
 " Partial Solution: child_range() accepts this function's return as optional arg, thereby
 " avoiding most of the duplication.
+" TODO: Consider having this accept a position.
 function! s:list_info(tail)
     let cursor = getpos('.')
     let ret = {

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3099,6 +3099,8 @@ function! s:analyze_codestr_simple(codestr, filetype)
 endfunction
 
 " Return 'curpos' option value that applies to the specified put_mode.
+" TODO: Consider whether curpos_child should inherit from curpos if user has set only the
+" latter.
 function! s:regput__get_curpos_opt(put_mode)
     " Default values
     let optdefs = {
@@ -4049,9 +4051,11 @@ function! s:regput_op__process_motion(ctx, inclusive, motion)
                     " Treat as telescopic, provided the reached position is actually *on* a
                     " sexp.
                     call s:setcursor(rng[dir])
-                    " If this is a put, tail should indicate the side of the element from
-                    " which put will occur, so might as well pick that side.
-                    let p = sexp#move_to_current_element_terminal(tail)
+                    " Make sure we're on a sexp.
+                    " Note: Intentionally keeping the searched position (not the terminal)
+                    " since it can matter for downstream logic (e.g., in put mode, if
+                    " target was open/close bracket).
+                    let p = sexp#current_element_terminal(0)
                     if !p[1]
                         throw "sexp-abort: Regput telescopic mode motion must target non-ws."
                     endif
@@ -4217,11 +4221,11 @@ endfunction
 " toggle 'tail' in the return dict to reflect the reversal.
 function! s:put_child__get_tgt(count, tail, ...)
     let cursor = getpos('.')
+    " Note: Because we may be converting an existing context dict to a put_child one, we
+    " need to ensure 'tail' and 'put_mode' fields are overridden.
     let ret = a:0 && !empty(a:1)
-        \ ? a:1
-        \ : s:regput__ctx_init('n', 'put_child', a:count, {
-            \ 'tail': a:tail
-        \ })
+        \ ? extend(a:1, {'tail': a:tail, 'put_mode': 'put_child'})
+        \ : s:regput__ctx_init('n', 'put_child', a:count, { 'tail': a:tail })
     try
         let li = s:list_info(a:tail, {'inner_only': g:sexp_regput_bracket_is_child}) 
         if li.terminal_range[0][1]

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -88,6 +88,7 @@ let s:aligncom_weights = {
 
 let s:nullpos = [0,0,0,0]
 let s:nullpos_pair = [s:nullpos, s:nullpos]
+let s:bof = [0, 1, -1, 0]
 
 " Since v:maxcol wasn't added till Vim9
 let s:MAXCOL = 2147483647
@@ -1226,8 +1227,11 @@ function! s:offset_char(pos, dir, ...)
     let inc_nl = a:0 && !!a:1
     let eol = col([a:pos[1], '$'])
     try
-        if a:pos[2] >= eol
-            " Input position past EOL
+        if a:pos == s:bof
+            " Input position is before BOF.
+            let pos = [0, 1, 1, 0]
+        elseif a:pos[2] >= eol
+            " Input position is past EOL
             " Handle input positions past EOL require special handling.
             " Rationale: We can't begin a searchpos() from positions that don't correspond
             " to a legal cursor position.
@@ -1249,8 +1253,8 @@ function! s:offset_char(pos, dir, ...)
                 else
                     " Empty line
                     if a:pos[1] == 1
-                        " Special Case: BOF
-                        let pos = [0, 1, -1, 0]
+                        " Special Case: before BOF
+                        let pos = s:bof
                     else
                         " Need to consider inc_nl
                         let prev_eol = col([a:pos[1] - 1, '$'])
@@ -1268,7 +1272,7 @@ function! s:offset_char(pos, dir, ...)
         else
             " Input position on *actual* char.
             " Move to input pos and find next non-NL char (or NUL char on empty line).
-            keepjumps call s:setcursor(a:pos)
+            call s:setcursor(a:pos)
             " Note: 'z' flag has different meaning for forward/backward search.
             let [l, c] = searchpos('\v.|^$', 'Wn' . (a:dir ? 'z' : 'b'))
             if l
@@ -1411,6 +1415,22 @@ function! s:constrained_range(start, end, keep_end)
     endif
     call s:setcursor(cursor)
     return ret
+endfunction
+
+function! sexp#check_balance()
+    let lz_save = &lz
+    try
+        "set lz
+        new
+        a|one
+two
+.
+        redraw
+        sleep 1
+        q
+    finally
+        let &lz = lz_save
+    endtry
 endfunction
 
 " Return *effective* auto-indent range calculation method, taking g:sexp_auto_indent_range
@@ -2835,119 +2855,153 @@ endfunction
 
 " Build and return dict characterizing the context in which a register put occurs.
 " Field Descriptions:
-"   tgt:             the put side of the target element, else curpos if no such element
+"   tgt:             the put side of the target element, else virtual target
+"                    May be 'virtual' in special case scenarios.
 "   adj:             the target side of the element adjacent to target on put side, else
-"                    nullpos
+"                    BOF/EOF sentinel, else nullpos
 "   adj_bracket:     if target is terminal element, position of bracket on put side of
 "                    target, else nullpos
-"   away:            the target side of the element adjacent to target on side opposite
-"                    put, else nullpos
-"   away_bracket:    if target is terminal element, position of bracket on side of target
-"                    away from put, else nullpos
-"   tgt_is_alone:    target is alone on its line, with possible exception of open or
-"                    close, but not both
-"   tgt_is_terminal: target is head or tail of list in put direction
-"   tgt_is_open:     determines whether tgt represents position of element or open bracket
-"   adj_colinear:    element adjacent to target on put side is colinear with target
 "   empty_list:      putting into empty list
 "   empty_buffer:    putting into empty buffer
-" Note: Skipping documentation of several of the more obvious flags. 
+"   -- Flags: The following flags are N/A if either of empty_{list,buffer} set.
+"   tgt_is_alone:    1 iff target is alone on its line, with possible exception of open or
+"                    close, but not both
+"   tgt_is_terminal: 1 iff target is head or tail of list in put direction
+"   adj_colinear:    1 iff element adjacent to target on put side is colinear with target
+"   force_nl:        1 iff subsequent processing should force 'near sep' of NL.
+"                    Used only when cursor is not on element.
+" Position Note: In the current approach, mutually-exclusive fields are maintained for
+" elements and brackets in a given direction, with the unused field set to nullpos:
+" e.g., non-null adj implies null adj_bracket and vice-versa. An equally valid (and
+" possibly simpler) approach would be to maintain a single position var to hold either
+" element or bracket pos, along with a dedicated 'is_bracket' flag.
 " Cursor Preservation: Caller handles.
+" Special Logic: There are 3 distinct scenarios in which cursor is not *on* an element:
+"   1. cursor inside (not on brackets of) empty list
+"   2. cursor in empty (apart from whitespace) buffer
+"   3. cursor in whitespace adjacent to one or more elements
+" In the interest of simplifying downstream logic, we attempt to make the special cases
+" look somewhat like the nominal case (e.g., by allowing tgt to be a bracket or a special
+" BOF/EOF sentinel), but we also set flags (e.g., empty_{list,buffer}, force_nl) that
+" allow downstream logic to discriminate when necessary.
+" The handling of case 3 depends on the colinearity of cursor pos with whatever comes
+" before/after (i.e., effective prev/next, which can be either element or bracket, or even
+" BOF/EOF) and is outlined below:
+" If cursor colinear with both effective prev/next
+"   p = put after effective prev
+"   P = put before effective next
+" ElseIf cursor colinear with effective prev
+"   put after effective prev
+"   force NL between effective prev and put text iff op == 'p'
+" ElseIf cursor colinear with effective next
+"   put before effective next
+"   force NL between effective next and put text iff op == 'P'
+" Else
+"   put after effective prev
+" Design Decision: Although we could handle p and P the same way in the 2 ElseIf's above,
+" treating the one that puts *away from* the colinear target as a request for extra
+" separation seems intuitive and gives extra flexibility.
 function! s:put__get_context(count, tail)
+    " Bool flags all initialized to 0 and set subsequently as needed.
     let ret = {
         \ 'tgt': s:nullpos, 'adj': s:nullpos, 'adj_bracket': s:nullpos,
         \ 'away': s:nullpos, 'away_bracket': s:nullpos,
         \ 'tgt_is_alone': 0, 'tgt_is_ml': 0, 'tgt_is_terminal': 0,
         \ 'adj_colinear': 0, 'adj_is_ml': 0,
         \ 'empty_list': 0, 'empty_buffer': 0,
-        \ 'at_top': 0,
+        \ 'at_top': 0, 'force_nl': 0,
+        \ 'tail': a:tail
     \ }
-    let count = a:count ? a:count : 1
-    " Determine the target element.
-    " Start with cursor position.
-    let t = sexp#current_element_terminal(a:tail)
-    if !t[1]
-        " Nothing under cursor; see if there's a next element.
-        let t = s:nearest_element_terminal(1, a:tail, 1, 1)
-        if !t[1]
-            " Fall back to prev element.
-            let t = s:nearest_element_terminal(0, a:tail, 1, 1)
-            if !t[1]
-                " Must be empty list or empty buffer.
-                " Design Decision: Let tgt/adj brackets be determined by put direction.
-                " Rationale: Minimizes need for special handling downstream.
-                let t = s:nearest_bracket(!a:tail)
-                if t[1]
-                    " Treat like 'put after' with cursor on virtual element located at
-                    " open bracket.
-                    " Note: This type of put would be more likely to use the "put into
-                    " list" put variant.
-                    let [ret.tgt_is_terminal, ret.tgt_is_open] = [1, 1]
-                    let ret.empty_list = 1
-                else
-                    " Empty buffer?
-                    let ret.empty_buffer = 1
-                    " Design Decision: Don't make caller look at several fields to find
-                    " put location.
-                    let t = getcurpos()
-                endif
-            endif
+    let curpos = getpos('.')
+    " First, attempt to get natural target: i.e., side of current element in direction of
+    " put. If no such element, special logic will determine a 'virtual' target.
+    let [ts, te] = [sexp#current_element_terminal(0), s:nullpos]
+    if ts[1]
+        " Get end of natural (real) target element.
+        let te = sexp#current_element_terminal(1)
+        " Set tgt to put side.
+        let ret.tgt = a:tail ? te : ts
+    endif
+    " Get some other useful positions relative to cursor.
+    let next = s:nearest_element_terminal(1, 0, 1, 1)
+    let prev = s:nearest_element_terminal(0, 1, 1, 1)
+    " Caveat: Must pre-position on correct side of element prior to nearest_bracket() call
+    " to properly handle case of list target.
+    " TODO: Consider skipping unnecessary s:setcursor() calls.
+    if !next[1] && ret.tgt[1] | call s:setcursor(te) | endif
+    let next_bracket = !next[1] ? s:nearest_bracket(1) : s:nullpos
+    if !prev[1] && ret.tgt[1] | call s:setcursor(ts) | endif
+    let prev_bracket = !prev[1] ? s:nearest_bracket(0) : s:nullpos
+    let ret.empty_list = !ret.tgt[1] && next_bracket[1] && prev_bracket[1]
+    let ret.empty_buffer = !ret.tgt[1] && !next[1] && !prev[1] && !ret.empty_list
+    " Use special logic to determine target in the 'no current element' scenario unless
+    " superseded by empty_{list,buffer} special logic.
+    " Note: This logic may set tgt to BOF/EOF sentinel position.
+    if !ret.empty_list && !ret.empty_buffer && !ret.tgt[1]
+        " No current element. Set tgt using special logic described in header and, if
+        " applicable, set flag to cause put__get_splice_info() to insert a NL at near
+        " side.
+        " TODO: Consider using effective positions at BOF/EOF in lieu of nullpos.
+        let eff_prev = prev[1] ? prev : prev_bracket[1]
+            \ ? prev_bracket : [0, 1, -1, 0]
+        let eff_next = next[1] ? next : next_bracket[1]
+            \ ? next_bracket : [0, line('$'), col([line('$'), '$']), 0]
+        if curpos[1] == eff_prev[1] && curpos[1] == eff_next[1]
+            let ret.tgt = a:tail ? eff_prev : eff_next
+        elseif curpos[1] == eff_prev[1] && curpos[1] != eff_next[1]
+            let ret.tgt = eff_prev
+            let [ret.force_nl, ret.tail] = [a:tail, 1]
+        elseif curpos[1] == eff_next[1] && curpos[1] != eff_prev[1]
+            let ret.tgt = eff_next
+            let [ret.force_nl, ret.tail] = [!a:tail, 0]
+        else
+            let ret.tgt = eff_prev
+            let ret.tail = 1
         endif
     endif
-    " Assumption: t is on desired (put) side of tgt (or on open/close bracket in case of
-    " empty list).
-    let ret.tgt = t
-    call s:setcursor(ret.tgt)
+    " Assign the generic next/prev vars to direction-dependent (e.g., tgt/adj/away) vars.
     if ret.empty_list
-        " Treat empty list as special case to avoid complicating the logic for case
-        " involving actual (non-bracket) target. See earlier comment regarding rationale
-        " behind use of a:tail.
-        let ret.adj_bracket = s:nearest_bracket(a:tail)
-        " Design Decision: Treat empty list as having colinear open/close.
-        " Rationale: With no contained elements, there's no reason to force multi-line
-        " context.
-        let ret.adj_colinear = ret.tgt[1] == ret.adj_bracket[1]
-        let [ret.tgt_is_terminal, ret.tgt_is_alone, ret.at_top] = [1, 0, 0]
-    elseif !ret.empty_buffer
-        " Find near side of adjacent (else closing bracket).
-        " Note: Optional flags force return of nullpos if no adjacent.
-        let adj = s:nearest_element_terminal(a:tail, !a:tail, 1, 1)
-        if adj[1]
-            " Found an adjacent element.
-            let ret.adj = adj
-            " TODO: Consider not adding easily expressible flags like this.
-            let ret.adj_colinear = ret.tgt[1] == ret.adj[1]
-            let adj_bracket = s:nullpos
-        else
-            " No adjacent; look for adjacent bracket (which won't exist at toplevel).
-            let ret.adj = s:nullpos
-            let adj_bracket = s:nearest_bracket(a:tail)
-        endif
-        let ret.adj_bracket = adj_bracket
+        " Assumption: Cursor position unchanged.
+        " Treat empty list as special case to avoid complicating the logic for nominal
+        " case.
+        let ret.tgt = a:tail ? prev_bracket : next_bracket
+        let ret.adj_bracket = a:tail ? next_bracket : prev_bracket
+    elseif ret.empty_buffer
+        " Don't bother setting tgt/adj/etc, as this will be handled as special case.
+        let ret.at_top = 1
+    else
+        " Account for possibility direction has been adjusted by special logic.
+        let tail = ret.tail
+        let [ret.adj, ret.adj_bracket] = tail
+            \ ? [next, next_bracket]
+            \ : [prev, prev_bracket]
+        " TODO: Consider not adding easily expressible flags like this.
+        let ret.adj_colinear = ret.tgt[1] == ret.adj[1]
+
+        " Move to target since we could be in whitespace.
+        call s:setcursor(ret.tgt)
         " Check other (away) side of target, passing 'ignore_current' and
         " 'nullpos_on_fail' to ensure nullpos returned if no adjacent.
-        let away = s:nearest_element_terminal(!a:tail, a:tail, 1, 1)
+        let away = s:nearest_element_terminal(!tail, tail, 1, 1)
         " Find away bracket unconditionally (even if away is not nullpos) to obviate need
         " for at_top() call; however, put nullpos in return dict if away is non-null.
         " Note: Must position on far side of away element before looking for bracket.
         " Rationale: If away element is a list, we want parent bracket, not the list's
         " other terminal.
-        call s:move_to_current_element_terminal(!a:tail)
-        let away_bracket = s:nearest_bracket(!a:tail)
-        let [ret.away, ret.away_bracket] = [away, away[1] ? s:nullpos : away_bracket]
+        call s:move_to_current_element_terminal(!tail)
+        let away_bracket = s:nearest_bracket(!tail)
         let ret.at_top = !away_bracket[1]
+        let [away, away_bracket] = [away, away[1] ? s:nullpos : away_bracket]
         " Is tgt alone on its line, with possible exception of open or close (but not
         " both)?
+        " Note: Both adj and away can be nullpos here.
         let ret.tgt_is_alone =
-            \ !(adj_bracket[1] && away_bracket[1] == adj_bracket[1])
-            \ && adj[1] != t[1] && away[1] != t[1]
+            \ !(ret.adj_bracket[1] && away_bracket[1] == ret.adj_bracket[1])
+            \ && ret.adj[1] != ret.tgt[1] && away[1] != ret.tgt[1]
         " Is tgt head/tail of list (in direction of put)?
         " Assumption: adj_bracket will be nullpos if adj is not. This is fine because the
         " bracket is irrelevant if the intervening element exists.
-        let ret.tgt_is_terminal = !adj[1] && adj_bracket[1]
-    else
-        " Special Case: empty buffer
-        let ret.at_top = ret.empty_buffer
+        let ret.tgt_is_terminal = !!ret.adj_bracket[1]
     endif
     return ret
 endfunction
@@ -2955,7 +3009,6 @@ endfunction
 " Return a dict containing 3 types of separators required for the put indicated by the
 " inputs.
 " Args:
-"   tail: put direction
 "   ctx:  put context dict
 "   reg:  register characterization dict
 " Return Dict:
@@ -2964,9 +3017,10 @@ endfunction
 "                  to target
 "   interior_sep:  text to join the individual instances of register contents in case of a
 "                  [count]
-function! s:put__get_seps(tail, ctx, reg)
+function! s:put__get_seps(ctx, reg)
     let ret = {'near_sep': '', 'far_sep': '', 'interior_sep': ''}
-    let [tail, ctx, reg] = [a:tail, a:ctx, a:reg]
+    let [ctx, reg] = [a:ctx, a:reg]
+    let tail = ctx.tail
     let [NL, SPC, EMPTY] = ["\n", " ", ""]
 
     " -- Near separator
@@ -2984,7 +3038,7 @@ function! s:put__get_seps(tail, ctx, reg)
         " Note: Separators are actually N/A for this case.
         let ret.near_sep = EMPTY
     " For the remaining cases, we have an actual target element.
-    elseif !ctx.tgt_is_alone && !reg.is_ml && (tail || !reg.e_is_com)
+    elseif !ctx.tgt_is_alone && !ctx.force_nl && !reg.is_ml && (tail || !reg.e_is_com)
         " Target isn't on line by itself and register is sl; additionally, we're not
         " prepending a comment to the target. Note that it's ok to *append* a single line
         " comment to target, since far separator logic will will insert NL *after* the
@@ -3007,7 +3061,7 @@ function! s:put__get_seps(tail, ctx, reg)
     elseif ctx.adj_colinear && !reg.is_ml
         " Preserve colinearity unless pasted text is ml.
         let ret.far_sep = SPC
-    elseif ctx.tgt_is_terminal && !tail && reg.s_is_com
+    elseif (ctx.empty_list || ctx.tgt_is_terminal) && !tail && reg.s_is_com
         " Start of comment can be separated from terminal by single space.
         let ret.far_sep = SPC
     else
@@ -3070,17 +3124,17 @@ endfunction
 
 " Return a dict that characterizes the splice (or directed put) to be performed as the set
 " of arguments to s:yankdel_range().
-function! s:put__get_splice_info(count, tail, ctx, reg, sep, flags)
-    let ret = { 'range': [s:nullpos, s:nullpos], 'text': '', 'inc': 0}
+function! s:put__get_splice_info(count, ctx, reg, sep, flags)
+    let ret = { 'range': [s:nullpos, s:nullpos], 'text': '', 'inc': [0, 0]}
     let [ctx, reg, sep] = [a:ctx, a:reg, a:sep]
+    let tail = ctx.tail
     let [NL, SPC, EMPTY] = ["\n", " ", ""]
     let [near_sep, interior_sep, far_sep] = [sep.near_sep, sep.interior_sep, sep.far_sep]
 
     " Set the target-side splice position.
     " Assumption: Currently, ctx.tgt is always set to something non-null.
     " TODO: Decide whether put__get_context should allow nullpos tgt.
-    let ret.range[!a:tail] = ctx.tgt
-    call s:setcursor(ctx.tgt)
+    let ret.range[!tail] = ctx.tgt
     " Determine the range.
     " Nominal case: we have a target to put before/after.
     " Note: Target could be element or open bracket.
@@ -3091,18 +3145,20 @@ function! s:put__get_splice_info(count, tail, ctx, reg, sep, flags)
         let ret.range = [[0, 1, 1, 0], [0, line('$'), col([line('$'), '$']), 0]]
         let ret.inc = [1, 1]
     elseif !adj_pos[1]
+        " TODO: Consider eliminating this and handling in the else now that BOF/EOF
+        " positions can be handled like regular positions.
         " No element or bracket in direction of put, so put to BOF or EOF.
         " Note: Empty buffer case currently handled separately in if, but could be handled
         " here if we wanted to replace only whitespace in direction of put.
-        let ret.range[a:tail] = a:tail
+        let ret.range[tail] = tail
             \ ? [0, line('$'), col([line('$'), '$']), 0]
             \ : [0, 1, 1, 0]
         " Note: The following resolves to a directed put towards BOF/EOF if no whitespace
         " separates tgt position from BOF/EOF.
-        let ret.inc = a:tail ? [0, 1] : [1, 0]
+        let ret.inc = tail ? [0, 1] : [1, 0]
     else
         " There's something adjacent to target to anchor splice at other end.
-        let ret.range[a:tail] = adj_pos
+        let ret.range[tail] = adj_pos
         if far_sep == NL
             " Determine number of newlines needed between put text and adjacent as a
             " function of the number of blank lines *currently* between target and
@@ -3125,9 +3181,9 @@ function! s:put__get_splice_info(count, tail, ctx, reg, sep, flags)
         " Logic: Always use adjacent whitespace-exclusive mode at end when adj and tgt are
         " not *currently* colinear and we're inserting at least 1 NL.
         " Rationale: Permits earlier "clean point" for re-indent; discarding the leading
-        " indent would require inclusion of one extra element at end (tgt if !a:tail, adj
-        " if a:tail).
-        if !ctx.adj_colinear && sep[a:tail ? 'far_sep' : 'near_sep'] == NL
+        " indent would require inclusion of one extra element at end (tgt if !tail, adj if
+        " tail).
+        if !ctx.adj_colinear && sep[tail ? 'far_sep' : 'near_sep'] == NL
             let exc_typ = 2
         endif
         let ret.inc = [0, exc_typ]
@@ -3135,9 +3191,8 @@ function! s:put__get_splice_info(count, tail, ctx, reg, sep, flags)
     " Build splice string.
     " TODO: Refactor this into a function somehow, since something similar is used
     " elsewhere (for cloning, I think).
-    " TODO: Do we need to consider 'collapse whitespace' option?
     let t = join(repeat([reg.text], a:count), interior_sep)
-    let ret.text = a:tail ? near_sep . t . far_sep : far_sep . t . near_sep
+    let ret.text = tail ? near_sep . t . far_sep : far_sep . t . near_sep
     return ret
 endfunction
 
@@ -3153,8 +3208,8 @@ function! sexp#put(count, tail)
         return
     endif
     let ctx = s:put__get_context(count, a:tail)
-    let sep = s:put__get_seps(a:tail, ctx, reg)
-    let spl = s:put__get_splice_info(count, a:tail, ctx, reg, sep, {})
+    let sep = s:put__get_seps(ctx, reg)
+    let spl = s:put__get_splice_info(count, ctx, reg, sep, {})
     let ps = [vs, ve]
     " TODO: Consider having put__get_context() build the position list.
     let ps = s:concat_positions(vs, ve,
@@ -3304,6 +3359,7 @@ endfunction
 "   1 = inclusive (nop)
 "   2 = exclusive of adjacent non-NL whitespace
 "       Note: Equivalent to inc==0 if no adjacent whitespace
+" Note: Handles virtual pre-BOF/post-EOF positions
 " Example:
 " foo|)   bar   ==>   foo)   |bar
 function! s:yankdel_range__preadjust_range_start(start, inc)
@@ -3312,10 +3368,12 @@ function! s:yankdel_range__preadjust_range_start(start, inc)
         " Get index of whatever (possibly NL) follows whitespace adjacent to start.
         " This match produces results identical to normal-exclusive if no adjacent ws.
         " Note: The dot in pattern must be optional to handle empty line case.
-        let eidx = match(getline(ret[1])[ret[2] - 1:], '\v^.?\s*\zs(.|$)')
-        let ret[2] = eidx + 1
+        " Note: max() prevents use of negative index for input position before BOF.
+        let eidx = match(getline(ret[1])[max([0, ret[2] - 1]):], '\v^.?\s*\zs(.|$)')
+        let ret[2] += eidx
     elseif !a:inc " normal-exclusive
         " Move to next position, including newline.
+        " Assumption: s:offset_char can handle s:bof.
         let ret = s:offset_char(ret, 1, 1)
     endif
     return ret
@@ -3332,7 +3390,6 @@ endfunction
 " Special Case: If end is BOF and adjustment is exclusive, return special
 " non-physical position [0, 1, -1, 0].
 " Caveat: Callers requiring physical positions will need to check for this.
-" TODO: Make this a script constant (like nullpos - eg, bofpos).
 function! s:yankdel_range__preadjust_range_end(end, inc)
     let ret = a:end[:]
     " Adjust input position for non-inclusive inc.
@@ -3340,15 +3397,17 @@ function! s:yankdel_range__preadjust_range_end(end, inc)
         " adjacent whitespace-exclusive
         " Caveat: Using strpart rather than [:] indexing to avoid problems with negative
         " indices.
-        let sidx = match(strpart(getline(ret[1]), 0, ret[2] - 1), '\v\S\s*$')
+        " Note: max() not actually needed, but negative length handling isn't documented.
+        let sidx = match(
+            \ strpart(getline(ret[1]), 0, max([0, ret[2] - 1])), '\v\S\s*$')
         if sidx < 0
             " Adjacent whitespace extends back to BOL.
             if ret[1] > 1
                 " Use previous line's NL.
                 let ret = [0, ret[1] - 1, col([ret[1] - 1, '$']), 0]
             else
-                " BOF sentinel
-                let ret = [0, 1, -1, 0]
+                " pre-BOF virtual pos
+                let ret = s:bof
             endif
         else
             " Use position of found non-ws.
@@ -3629,6 +3688,7 @@ function! s:yankdel_range(start, end, del_or_spl, ...)
     " cases (e.g., non-inclusive start at EOL).
     let reg_save = [@a, @"]
     try
+        " FIXME: I don't like using a:1 only for tail default!!!!
         let inc = a:0 ? type(a:1) == 3 ? a:1 : [1, a:1] : [1, 0]
         let failsafe_override = g:sexp_inhibit_failsafe || (a:0 > 2 ? a:3 : 0)
         " Canonicalize start/end/range.

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3788,7 +3788,7 @@ endfunction
 " treating the one that puts *away from* the colinear target as a request for extra
 " separation seems intuitive and gives extra flexibility.
 function! s:put__get_tgt(count, tail, ...)
-    let save_curpos = getpos('.')
+    let curpos = getpos('.')
     let ret = a:0 && !empty(a:1)
         \ ? a:1
         \ : s:regput__ctx_init('n', a:tail ? 'put_after' : 'put_before', a:count)
@@ -3854,7 +3854,7 @@ function! s:put__get_tgt(count, tail, ...)
         endif
         return ret
     finally
-        call s:setcursor(save_curpos)
+        call s:setcursor(curpos)
     endtry
 endfunction
 

--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -131,6 +131,8 @@ endfunction
 function! sexp#pre_op(mode, name)
     let s:sexp_ve_save = &ve
     set ve=onemore
+    " May be used by command handlers to figure out how to leave view.
+    let s:win_view = winsaveview()
     " Create the msg queue used by sexp#warn#msg().
     call sexp#warn#create_msg_q()
     " TODO: Consider removing or simplifying the cache, which is currently needed only for
@@ -2524,9 +2526,9 @@ function! s:nth_from(pos, n, tail)
             let ret.range[a:tail] = sexp#current_element_terminal(a:tail)
             let ret.missing = cnt
         endif
+        return ret
     finally
         call s:setcursor(cursor)
-        return ret
     endtry
 endfunction
 
@@ -2598,9 +2600,9 @@ function! s:child_range(count, tail, inner, ...)
                 let ret.range = s:terminals_with_whitespace(ret.range[0], ret.range[1])
             endif
         endif
+        return ret
     finally
         call s:setcursor(cursor)
-        return ret
     endtry
 endfunction
 
@@ -2898,8 +2900,9 @@ endfunction
 " Set visual marks around count'th inner/outer child of current (or parent) list; 0 to
 " count backwards from tail, 1 to count forwards from head. If no such child element
 " exists, selects closest one (i.e., last in the specified direction).
-function! sexp#select_child(mode, count, next, inner)
-    let [s, e] = s:child_range(a:count, a:next, a:inner, {'exact_child': 0})
+function! sexp#select_child(mode, count, tail, inner)
+    let cr = s:child_range(a:count, a:tail, a:inner, {'exact_child': 0})
+    let [s, e] = cr.range
     if s[1]
         " Note: Although we may be called from visual mode, child selection ignores
         " current selection by definition.
@@ -3038,7 +3041,7 @@ function! s:regput__get_reginfo()
         " Register contents are not valid lisp. Decide how to handle...
         " Assumption: Can't get here if g:sexp_regput_inhibit_regparse disables parsing.
         let errmsg = printf("Error encountered at or near %s%s.",
-            \ string(ret.err_loc),
+            \ "(" . string(ret.err_loc[1:2]) . ")",
             \ !empty(ret.err_hint) ? " (Hint: " . ret.err_hint . ")" : "" )
         " Enumeration defined in help doc.
         let action = g:sexp_regput_invalid_register_action
@@ -3715,9 +3718,9 @@ function! s:put__get_tgt(count, tail)
         if !ret.range[1][1]
             let ret.range[1] = [0, line('$'), col([line('$'), '$']), 0]
         endif
+        return ret
     finally
         call s:setcursor(curpos)
-        return ret
     endtry
 endfunction
 
@@ -3816,7 +3819,7 @@ function! s:replace_mode__get_tgt(put_mode, mode, count, tail, P)
                 \ {'exact_count': 1, 'inner_only': g:sexp_regput_bracket_is_child})
             if cr.missing
                 " Requested child doesn't exist!
-                throw "sexp-warning: 'replace_child': the requested child does not exist!"
+                throw "sexp-abort: 'replace_child': the requested child does not exist!"
             endif
             let ret.inner_range = cr.range
         endif
@@ -3837,9 +3840,9 @@ function! s:replace_mode__get_tgt(put_mode, mode, count, tail, P)
             endif
             let ret.range[i] = p
         endfor
+        return ret
     finally
         call s:setcursor(curpos)
-        return ret
     endtry
 endfunction
 
@@ -3939,9 +3942,9 @@ function! s:put_child__get_tgt(count, tail)
             let ret.is_bra = [1, 1]
             let ret.is_ele = [0, 0]
         endif
+        return ret
     finally
         call s:setcursor(cursor)
-        return ret
     endtry
 endfunction
 
@@ -5770,10 +5773,10 @@ function! s:list_info(tail, ...)
             let ret.terminal_range =
                 \ [sexp#current_element_terminal(0), sexp#current_element_terminal(1)]
         endif
+        return ret
     finally
         " Restore original position.
         call s:setcursor(save_cursor)
-        return ret
     endtry
 endfunction
 
@@ -5790,9 +5793,9 @@ function! s:buffer_terminal(tail)
             " Found an element. Get its extents.
             let ret = [sexp#current_element_terminal(0), sexp#current_element_terminal(1)]
         endif
+        return ret
     finally
         call s:setcursor(cursor)
-        return ret
     endtry
 endfunction
 

--- a/autoload/sexp/feat.vim
+++ b/autoload/sexp/feat.vim
@@ -26,6 +26,7 @@ let s:feat_notify = {
             \ 'regput_untrimmed_is_linewise',
             \ 'regput_linewise_forces_multiline',
             \ 'regput_ignore_list_shape',
+            \ 'regput_curpos',
         \ ],
         \ 'msg':
             \   "Vim-sexp now provides smarter, Lisp-aware versions of `register put'"

--- a/autoload/sexp/feat.vim
+++ b/autoload/sexp/feat.vim
@@ -1,108 +1,161 @@
-" This dict supports data-driven approach to notifying user of new(-ish) features he may
+" This dict supports a data-driven approach to notifying user of new(-ish) features he may
 " not be aware of.
-" The notification is triggered by use of a builtin operator more or less related to the
-" feature (e.g., `p` and friends for the "smart paste" feature), but the notification is
-" inhibited if the user has set *any* vim-sexp options related to the feature, thereby
-" indicating feature awareness
-" Important Note: The test for user awareness occurs *once only* at plugin load, not on
-" each buffer load.
-" Rationale: The plugin currently has no way to distinguish between user and default
-" assignments once the plugin has loaded.
-" TODO: Consider keeping the defaults and user settings distinct, even after plugin load.
-" This would probably entail adding s:sexp_{opt} counterparts for each global option and
-" adding a query layer between the options and the client code that checks them, but it
-" would permit certain user configuration changes to take effect later.
+" -- Keys --
+" aware:    set to 1 to indicate user awareness
+" opts:     names of options whose override by user indicates feature awareness
+" cmds:     list of plug maps provided by the feature
+" builtins: dictionary of builtins overridden by the feature:
+"             key=builtin
+"             val=modes
+"           Note: The modes are required because, in theory at least, two distinct
+"           features could override the same builtin in different modes.
+" msg:      message to display once-per-session when conditions for notification are met
+"
+" The logic for this feature exists in two distinct phases:
+" 1. Plugin Load: For each notifiable feature, look at both options and g:sexp_mappings[],
+"    setting the feature-specific 'aware' flag iff the existence of feature-specific
+"    overrides demonstrates awareness of the feature's existence.
+"    Note: The option checks *must* occur at plugin load time because default option logic
+"    sets the global options to default values, with the result that we have no way of
+"    knowing after load whether user has overridden the option. This is an implementation
+"    detail, which could change in a subsequent revision. In the current implementation,
+"    the check for user map overrides *could* be deferred till command execution time, but
+"    since g:sexp_mappings[] is processed only in sexp_create_mappings(), there's no
+"    reason to defer.
+" 2. Command Execution: If the invoked command's plug name corresponds to a feature
+"    requiring notification, present the configured notification to user unless the
+"    feature-specific 'aware' flag indicates at least one of the following conditions is
+"    met:
+"      1. User option/map override provides evidence of feature awareness ('aware' flag
+"         set).
+"      2. We've already notified user about this feature during current session.
+"    If feature has a notification and we display it, set its 'aware' flag to inhibit
+"    subsequent notifications.
 let s:feat_notify = {
     \ 'regput': {
-        \ 'builtins': {
-            \ 'nx': ['p', 'P', '[p', '[P', ']p', ']P', 'gp', 'gP'],
-        \ },
-        \ 'notify': 0,
+        \ 'aware': 0,
         \ 'opts': [
-            \ 'regput_override_builtins',
+            \ 'regput_silence_notification',
             \ 'regput_bracket_is_target',
             \ 'regput_bracket_is_child',
             \ 'regput_allow_comment_append',
             \ 'regput_untrimmed_is_linewise',
             \ 'regput_linewise_forces_multiline',
             \ 'regput_ignore_list_shape',
-            \ 'regput_curpos',
+            \ 'regput_curpos', 'regput_curpos_child', 'regput_curpos_op',
+            \ 'regput_invalid_register_action',
+            \ 'regput_inhibit_regparse',
+            \ 'regput_replace_expanded',
+            \ 'regput_tele_motion',
+            \ 'regput_use_string_parser',
         \ ],
-        \ 'msg': "vim-sexp: You could be using \"Smart Paste\" for this. (:help sexp-smart-paste)"
+        \ 'cmds': [
+            \ 'sexp_put_before', 'sexp_put_after', 'sexp_replace', 'sexp_replace_P',
+            \ 'sexp_put_before_op', 'sexp_put_after_op', 'sexp_replace_op', 'sexp_replace_op_P',
+            \ 'sexp_put_at_head', 'sexp_put_at_tail',
+        \ ],
+        \ 'builtins': { 'p': 'xn', 'P': 'xn', 'gp': 'n', 'gP': 'n' },
+        \ 'msg': "vim-sexp: You have invoked a \"Smart Paste\" command."
+            \ . " (:help sexp-smart-paste)"
     \ },
 \ }
 
-" Return 1 iff the user appears not to be aware of the specified feature.
-function! s:notification_needed(feat)
-    " Allow caller to provide either the feature name or the cfg object.
-    let cfg = type(a:feat) == type("") ? s:feat_notify[a:feat] : a:feat
-    " Has user set any options related to the feature?
-    for opt in cfg.opts
-        if exists('g:sexp_' . opt)
-            return 0
+" Return feature dict corresponding to plug name iff the feature is subject to
+" notifications, else empty dict.
+function! s:get_feat_cfg(plug)
+    for [feat_name, feat_cfg] in items(s:feat_notify)
+        " Does this feature provide this command?
+        if index(feat_cfg.cmds, a:plug) >= 0
+            return feat_cfg
         endif
     endfor
-    " User hasn't set any relevant options.
-    return 1
+    " Command doesn't belong to feature requiring notification.
+    return {}
 endfunction
 
-" Present feature notification to user, then delete the all the mappings associated with
-" this feature (not just the one that triggered this call) to ensure we don't notify about
-" this feature again this session.
-function! s:do_notification(feat)
-    call sexp#warn#msg(s:feat_notify[a:feat].msg)
-    call s:destroy_notification(a:feat)
-endfunction
-
-" Delete all the mappings installed to trigger notifications for the specified feature.
-function! s:destroy_notification(feat)
-    let cfg = s:feat_notify[a:feat]
-    if cfg.notify
-        for [modes, lhss] in items(cfg.builtins)
-            for mode in split(modes, '\zs')
-                for lhs in lhss
-                    exe mode . "unmap <buffer> " . lhs
-                endfor
-            endfor
-        endfor
+" Perform new feature notification (and set 'aware' flag to prevent future notifications)
+" iff conditions outlined in s:feat_notify[] header comment are met.
+function! sexp#feat#notify_maybe(mode, plug)
+    " Short-circuit if this command doesn't belong to a feature supporting notification or
+    " if user appears to be aware of the feature.
+    let cfg = s:get_feat_cfg(a:plug)
+    if empty(cfg) || cfg.aware
+        return
     endif
+    " User may still be unaware of the feature.
+    call sexp#warn#msg(cfg.msg)
+    " Don't notify again this session.
+    " Note: The notification is per-feature, not per command within feature.
+    let cfg.aware = 1
+endfunction
+
+" Return 1 iff user appears to be aware of the feature whose key/value pair from the
+" feature dictionary are provided as inputs.
+" Pre Condition: Called at plugin load, *BEFORE* option/map processing.
+function! s:is_user_aware(feat, cfg)
+    " Has user set any options related to the feature?
+    for opt in a:cfg.opts
+        if exists('g:sexp_' . opt)
+            return 1
+        endif
+    endfor
+    if !has_key(g:, 'sexp_mappings')
+        " User hasn't customized *any* maps.
+        return 0
+    endif
+    " Has user customized any plug maps related to the feature?
+    " Note: Modes are irrelevant since we're interested only in feature *awareness*.
+    for cmd in a:cfg.cmds
+        if has_key(g:sexp_mappings, cmd)
+            return 1
+        endif
+    endfor
+    " Has user customized any builtins?
+    for [builtin, builtin_modes] in items(a:cfg.builtins)
+        " Design Decision: Default to v:null rather than (eg) {} or ''.
+        " Rationale: User might set a builtin to {} or '' to disable backups (though this
+        " is unnecessary, since they're disabled by default).
+        " Note: There's a slight ambiguity here, since it's theoretically possible that
+        " the same builtin could be used for different plug commands in different modes
+        " and a value of {} or '' provides no mode information; however, this scenario
+        " should be vanishingly rare, and it should be safe to err on the side of *not*
+        " notifying. If we want to err on the side of notifying when in doubt, change the
+        " default to {} and the `override isnot v:null' to `!empty(override)'.
+        let override = get(g:sexp_mappings, builtin, v:null)
+        if override isnot v:null
+            " User has overridden the builtin, but we need to make sure at least one of
+            " the modes of the override corresponds to one of the feature-specific modes.
+            try
+                let [parsed_override, _] = 
+                    \ sexp#plug#parse_map_entry(builtin, override, builtin_modes)
+                for m in split(builtin_modes, '\zs')
+                    if has_key(parsed_override, m)
+                        " User provided override for builtin in at least one mode.
+                        return 1
+                    endif
+                endfor
+            catch /sexp-error/
+                " Just continue: warnings should be handled by sexp_create_mappings().
+                " Design Decision: Draw no awareness conclusions from invalid override.
+                continue
+            endtry
+        endif
+    endfor
+    " User seems to be unaware of the feature.
+    return 0
 endfunction
 
 " For all features represented in s:feat_notify{}, set flag indicating whether user
-" requires notification.
-" Logic: Notification required iff user hasn't set *any* related options.
+" requires once-per-session notification upon the first invocation of a command pertaining
+" to the feature.
+" Logic: Notification required iff user has neither set options nor customized mappings
+" related to the feature.
 " Pre-Condition: Must be invoked *before* any global options are set to default values.
 function! sexp#feat#record_user_awareness()
     for [feat, cfg] in items(s:feat_notify)
-        let cfg.notify = s:notification_needed(cfg)
-    endfor
-endfunction
-
-
-" For each feature represented in s:feat_notify{}, remap all associated builtin operators
-" to do the following:
-"   * perform requested operation
-"   * notify user of new feature
-"   * remove all mappings in the set (not just the one that triggered this call)
-function! sexp#feat#create_notifications()
-    for [feat, cfg] in items(s:feat_notify)
-        " Assumption: 'notify' flag was set by record_user_awareness() prior to startup
-        " option processing.
-        if cfg.notify
-            " Create a mapping for each relevant builtin...
-            for [modes, lhss] in items(cfg.builtins)
-                " ...and for each mode.
-                for mode in split(modes, '\zs')
-                    " ...and for each lhs
-                    for lhs in lhss
-                        " Note: We're still supporting Vim versions that don't provide
-                        " <Cmd>, so use `:<C-U>', which should be safe for all
-                        " versions/modes.
-                        exe mode . "noremap <buffer> " . lhs . " " . lhs
-                            \ . " :<C-U>call <SID>do_notification('" . feat . "')<cr>"
-                    endfor
-                endfor
-            endfor
+        if s:is_user_aware(feat, cfg)
+            " Nothing more to be done for this feature.
+            let cfg.aware = 1
         endif
     endfor
 endfunction

--- a/autoload/sexp/feat.vim
+++ b/autoload/sexp/feat.vim
@@ -1,0 +1,115 @@
+" This dict supports data-driven approach to notifying user of new(-ish) features he may
+" not be aware of.
+" The notification is triggered by use of a builtin operator more or less related to the
+" feature (e.g., `p` and friends for the "smart paste" feature), but the notification is
+" inhibited if the user has set *any* vim-sexp options related to the feature, thereby
+" indicating feature awareness
+" Important Note: The test for user awareness occurs *once only* at plugin load, not on
+" each buffer load.
+" Rationale: The plugin currently has no way to distinguish between user and default
+" assignments once the plugin has loaded.
+" TODO: Consider keeping the defaults and user settings distinct, even after plugin load.
+" This would probably entail adding s:sexp_{opt} counterparts for each global option and
+" adding a query layer between the options and the client code that checks them, but it
+" would permit certain user configuration changes to take effect later.
+let s:feat_notify = {
+    \ 'regput': {
+        \ 'builtins': {
+            \ 'nx': ['p', 'P', '[p', '[P', ']p', ']P', 'gp', 'gP'],
+        \ },
+        \ 'notify': 0,
+        \ 'opts': [
+            \ 'regput_override_builtins',
+            \ 'regput_bracket_is_target',
+            \ 'regput_bracket_is_child',
+            \ 'regput_allow_comment_append',
+            \ 'regput_untrimmed_is_linewise',
+            \ 'regput_linewise_forces_multiline',
+            \ 'regput_ignore_list_shape',
+        \ ],
+        \ 'msg':
+            \   "Vim-sexp now provides smarter, Lisp-aware versions of `register put'"
+            \ . " commands. You may wish to remap the builtin put operators to use them."
+            \ . " For more information, :help sexp-smart-paste. To silence this warning in"
+            \ . " future sessions, set any of the options pertaining to this feature"
+            \ . " (even to its default value): e.g.,"
+            \ . " let g:sexp_regput_bracket_is_target = 1"
+    \ },
+\ }
+
+" Return 1 iff the user appears not to be aware of the specified feature.
+function! s:notification_needed(feat)
+    " Allow caller to provide either the feature name or the cfg object.
+    let cfg = type(a:feat) == type("") ? s:feat_notify[a:feat] : a:feat
+    " Has user set any options related to the feature?
+    for opt in cfg.opts
+        if exists('g:sexp_' . opt)
+            return 0
+        endif
+    endfor
+    " User hasn't set any relevant options.
+    return 1
+endfunction
+
+" Present feature notification to user, then delete the all the mappings associated with
+" this feature (not just the one that triggered this call) to ensure we don't notify about
+" this feature again this session.
+function! s:do_notification(feat)
+    call sexp#warn#msg(s:feat_notify[a:feat].msg)
+    call s:destroy_notification(a:feat)
+endfunction
+
+" Delete all the mappings installed to trigger notifications for the specified feature.
+function! s:destroy_notification(feat)
+    let cfg = s:feat_notify[a:feat]
+    if cfg.notify
+        for [modes, lhss] in items(cfg.builtins)
+            for mode in split(modes, '\zs')
+                for lhs in lhss
+                    exe mode . "unmap <buffer> " . lhs
+                endfor
+            endfor
+        endfor
+    endif
+endfunction
+
+" For all features represented in s:feat_notify{}, set flag indicating whether user
+" requires notification.
+" Logic: Notification required iff user hasn't set *any* related options.
+" Pre-Condition: Must be invoked *before* any global options are set to default values.
+function! sexp#feat#record_user_awareness()
+    for [feat, cfg] in items(s:feat_notify)
+        let cfg.notify = s:notification_needed(cfg)
+    endfor
+endfunction
+
+
+" For each feature represented in s:feat_notify{}, remap all associated builtin operators
+" to do the following:
+"   * perform requested operation
+"   * notify user of new feature
+"   * remove all mappings in the set (not just the one that triggered this call)
+function! sexp#feat#create_notifications()
+    for [feat, cfg] in items(s:feat_notify)
+        " Assumption: 'notify' flag was set by record_user_awareness() prior to startup
+        " option processing.
+        if cfg.notify
+            " Create a mapping for each relevant builtin...
+            for [modes, lhss] in items(cfg.builtins)
+                " ...and for each mode.
+                for mode in split(modes, '\zs')
+                    " ...and for each lhs
+                    for lhs in lhss
+                        " Note: We're still supporting Vim versions that don't provide
+                        " <Cmd>, so use `:<C-U>', which should be safe for all
+                        " versions/modes.
+                        exe mode . "noremap <buffer> " . lhs . " " . lhs
+                            \ . " :<C-U>call <SID>do_notification('" . feat . "')<cr>"
+                    endfor
+                endfor
+            endfor
+        endif
+    endfor
+endfunction
+
+" vim:ts=4:sw=4:et:tw=90

--- a/autoload/sexp/feat.vim
+++ b/autoload/sexp/feat.vim
@@ -28,13 +28,7 @@ let s:feat_notify = {
             \ 'regput_ignore_list_shape',
             \ 'regput_curpos',
         \ ],
-        \ 'msg':
-            \   "Vim-sexp now provides smarter, Lisp-aware versions of `register put'"
-            \ . " commands. You may wish to remap the builtin put operators to use them."
-            \ . " For more information, :help sexp-smart-paste. To silence this warning in"
-            \ . " future sessions, set any of the options pertaining to this feature"
-            \ . " (even to its default value): e.g.,"
-            \ . " let g:sexp_regput_bracket_is_target = 1"
+        \ 'msg': "vim-sexp: You could be using \"Smart Paste\" for this. (:help sexp-smart-paste)"
     \ },
 \ }
 

--- a/autoload/sexp/parse.vim
+++ b/autoload/sexp/parse.vim
@@ -1,0 +1,168 @@
+" This autoload module contains functions for parsing arbitrary lisp using the
+" legacy syntax engine. It is the legacy Vim counterpart to ts.lua.
+
+" Script-local vars facilitating reuse of a vim-sexp parse buffer.
+let s:bufnr = -1
+let s:parsebuf_name = "vim-sexp-parser-playground"
+
+" Symbolic constants
+let s:nullpos = [0,0,0,0]
+
+" Return 1 iff we're pretty certain the specified buffer is ours.
+function! s:is_valid_parse_buffer(bufnr)
+    return a:bufnr > 0 && bufexists(a:bufnr) && bufname(a:bufnr) == s:parsebuf_name
+        \ && getbufvar(a:bufnr, '&buftype') == 'nofile'
+        \ && getbufvar(a:bufnr, '&bufhidden') == 'hide'
+        \ && !getbufvar(a:bufnr, '&swapfile')
+endfunction
+
+function! s:enter_parse_buffer()
+    " Save and invalidate s:bufnr, re-assigning only after we know we're in a valid target
+    " buffer.
+    let [bufnr, s:bufnr] = [s:bufnr, -1]
+    " Do we have an old buffer we can *safely* reuse (i.e, hasn't been repurposed by user
+    " since we last used it)?
+    if s:is_valid_parse_buffer(bufnr)
+        try
+            " Although parse buffer will most likely never be displayed, we can't
+            " guarantee a curious user won't open it in a window. If he does, we need to
+            " leave it open to keep the parsing implementation completely invisible to the
+            " user. The simplest way to accomplish this is to use 'switchbuf' to ensure we
+            " always open the parse buffer in a new window (even if it's already
+            " displayed), thereby permitting an unconditional close after parsing.
+            let switchbuf_save = &switchbuf
+            set switchbuf=
+            silent exe bufnr . "sb"
+            " Design Decision: Require buffer to be empty.
+            " Vim Idiosyncrasy: line2byte should never return -1, but sometimes does. This
+            " logic accounts for that.
+            if line2byte(line('$') + 1) - 1 <= 0
+                let s:bufnr = bufnr()
+            else
+                " Buffer not empty! Silently refuse to use it (by closing and leaving
+                " s:bufnr invalid).
+                hide
+            endif
+        finally
+            let &switchbuf = switchbuf_save
+        endtry
+    endif
+    if s:bufnr < 0
+        " Create parse buffer.
+        silent exe "new" s:parsebuf_name
+        setlocal buftype=nofile bufhidden=hide noswapfile
+        let s:bufnr = bufnr()
+    endif
+endfunction
+
+function! s:exit_parse_buffer()
+    " Note: This is being overly cautious; we should always be in the parse buffer at this
+    " point.
+    if s:is_valid_parse_buffer(s:bufnr)
+        " No need to keep the parsed text in memory.
+        " TODO: Consider a simple undo...
+        "%d _
+        silent undo
+        hide
+    else
+        call sexp#warn#msg("vim-sexp: Refusing to unload parse buffer " . s:bufnr
+            \ . " because it's in an unexpected state."
+            \ . " If warning persists, please open an issue.")
+    endif
+endfunction
+
+function! s:analyze_codestr(ret)
+    " Cache ref to the dict we're responsible for tweaking/filling in.
+    let ret = a:ret
+    " Start parsing on first char, which is guaranteed to be non-ws.
+    normal! gg0
+    let p = getpos('.')
+    while p[1]
+        " We're on the start of an element. Find its end.
+        let ps = p
+        let pe = sexp#move_to_current_element_terminal(1)
+        if !pe[1]
+            " Hint: Probably unbalanced open
+            "echomsg printf("Hint: Unbalanced open at %s", string(ps))
+            let ret.err_loc = ps
+            let ret.err_hint = "Unbalanced open"
+            break
+        endif
+        " Accumulate valid top-level node.
+        call add(ret.node_ranges, [ps, pe])
+        let ret.elem_count += 1
+        if !ret.has_com
+            let ret.has_com = sexp#is_comment(ps[1], ps[2])
+            if ret.has_com && ret.elem_count == 0
+                let ret.s_is_com = 1
+            endif
+        endif
+        " Attempt to find near side of next element.
+        let p = sexp#move_to_adjacent_element_terminal(1, 0, 1, 1)
+        if !p[1]
+            " Are we at the end? If not, we've likely encountered unbalanced close.
+            let [curpos, epos] = [getpos('.'), [0, line('$'), col([line('$'), '$']), 0]]
+            if sexp#compare_pos(curpos, epos) < 0
+                \ && sexp#range_has_non_ws(sexp#offset_char(curpos, 1), epos, 1)
+                " Hint: Unbalanced open at curpos.
+                "echomsg printf("Hint: Unbalanced close after %s", string(curpos))
+                let ret.err_loc = curpos
+                let ret.err_hint = "Unbalanced close"
+                break
+            endif
+        endif
+    endwhile
+    if ret.elem_count > 0 && !ret.err_loc[1]
+        let ret.e_is_com =
+            \ sexp#is_comment(ret.node_ranges[-1][0][1], ret.node_ranges[-1][0][2])
+    endif
+    let ret.is_ml = ret.elem_count > 0
+        \ && ret.node_ranges[0][0][1] < ret.node_ranges[-1][1][1]
+    return ret
+endfunction
+
+function! sexp#parse#analyze_codestr(codestr, filetype)
+    " Note: Several fields are initialized to final values here; the ones requiring a
+    " parse are filled in by s:analyze_codestr().
+    let ret = {
+        \ 'elem_count': 0,
+        \ 'is_ml': 0,
+        \ 'has_com': 0, 's_is_com': 0, 'e_is_com': 0,
+        \ 'node_ranges': [],
+        \ 'err_loc': s:nullpos, 'err_hint': '',
+        \ 'text': substitute(a:codestr, '^\s*\|\s*$', '', 'g'),
+        \ 'linewise': g:sexp_regput_untrimmed_is_linewise
+            \ ? a:codestr =~ '^\s\|\s$'
+            \ : a:codestr =~ '\n$'
+    \ }
+    " Be sure we end up in starting window, with original window layout.
+    let [winnr, wrc] = [winnr(), winrestcmd()]
+    " 'lz' should already be set, but just in case...
+    let lz_save = &lazyredraw
+    try
+        set lz
+        " Make sure we're in a scratch buffer we can use for parsing.
+        call s:enter_parse_buffer()
+        " Note: Inserting with P ensures we won't insert leading blank line if ret.text
+        " ends in newline (thereby triggering a linewise put); however, we currently trim
+        " the surrounding whitespace to simplify logic in s:analyze_codestr(), so either
+        " type of of put would work.
+        silent exe "normal! \"=ret.text\<cr>P"
+        " Make sure we have syntax regions for parsing.
+        let &l:ft = a:filetype
+        " Parse the buffer and fill in the return dict.
+        call s:analyze_codestr(ret)
+    finally
+        " Hide the parse buffer and return to the original window.
+        call s:exit_parse_buffer()
+        exe winnr . 'wincmd w'
+        " Restore window sizes.
+        " Assumption: Open window set is identical to what it was when wrc was captured.
+        exe wrc
+        let &lz = lz_save
+    endtry
+    " Note: Empty dict will be returned on error.
+    return ret
+endfunction
+
+" vim:ts=4:sw=4:et:tw=90

--- a/autoload/sexp/parse.vim
+++ b/autoload/sexp/parse.vim
@@ -10,6 +10,7 @@
 " Script-local vars facilitating reuse of a vim-sexp parse buffer.
 let s:bufnr = -1
 let s:parsebuf_name = "vim-sexp-parser-playground"
+let s:in_parse_buf = 0
 
 " Symbolic constants
 let s:nullpos = [0,0,0,0]
@@ -58,10 +59,12 @@ function! s:enter_parse_buffer()
         silent exe "new" s:parsebuf_name
         setlocal buftype=nofile bufhidden=hide noswapfile
         let s:bufnr = bufnr()
+        let s:in_parse_buf = 1
     endif
 endfunction
 
 function! s:exit_parse_buffer()
+    let s:in_parse_buf = 0
     " Note: This is being overly cautious; we should always be in the parse buffer at this
     " point.
     if s:is_valid_parse_buffer(s:bufnr)
@@ -75,6 +78,11 @@ function! s:exit_parse_buffer()
             \ . " because it's in an unexpected state."
             \ . " If warning persists, please open an issue.")
     endif
+endfunction
+
+" Return 1 iff we're in the parse buffer.
+function! sexp#parse#in_buf()
+    return s:in_parse_buf
 endfunction
 
 " This function is a "Context Manager" (in the Python sense), which ensures the provided

--- a/autoload/sexp/parse.vim
+++ b/autoload/sexp/parse.vim
@@ -1,5 +1,11 @@
 " This autoload module contains functions for parsing arbitrary lisp using the
 " legacy syntax engine. It is the legacy Vim counterpart to ts.lua.
+" It also contains sexp#parse#do_in_buf(), which is something like a Python Context
+" Manager for managing the temporary parse buffer as an RAII resource. Because all
+" non-buffer-related logic is confined to a callback, do_in_buf() can be used for a
+" Treesitter-based parse that doesn't require this module's parsing function(s).
+" TODO: Consider moving the buffer-related stuff to its own module (or moving the parse
+" logic back to sexp#autoload).
 
 " Script-local vars facilitating reuse of a vim-sexp parse buffer.
 let s:bufnr = -1
@@ -71,9 +77,57 @@ function! s:exit_parse_buffer()
     endif
 endfunction
 
-function! s:analyze_codestr(ret)
-    " Cache ref to the dict we're responsible for tweaking/filling in.
-    let ret = a:ret
+" This function is a "Context Manager" (in the Python sense), which ensures the provided
+" function is invoked with args '...' within a temporary buffer of type 'filetype'
+" containing text 'buftext'. Care is taken to ensure buffer reuse.
+function! sexp#parse#do_in_buf(fn, buftext, filetype, ...)
+    " Be sure we end up in starting window, with original window layout.
+    let [winnr, wrc] = [winnr(), winrestcmd()]
+    " 'lz' should already be set, but just in case...
+    let lz_save = &lazyredraw
+    try
+        set lz
+        " Make sure we're in a scratch buffer we can use for parsing.
+        call s:enter_parse_buffer()
+        " Note: Inserting with P ensures we won't insert leading blank line if ret.text
+        " ends in newline (thereby triggering a linewise put); however, we currently trim
+        " the surrounding whitespace to simplify logic in s:analyze_codestr(), so either
+        " type of of put would work.
+        if !empty(a:buftext)
+            silent exe "normal! \"=a:buftext\<cr>P"
+        endif
+        " Make sure we have syntax regions for parsing.
+        let &l:ft = a:filetype
+        " Call the wrapped function now that we're in the new buffer.
+        return call(a:fn, a:000)
+    finally
+        " Hide the parse buffer and return to the original window.
+        call s:exit_parse_buffer()
+        exe winnr . 'wincmd w'
+        " Restore window sizes.
+        " Assumption: Open window set is identical to what it was when wrc was captured.
+        exe wrc
+        let &lz = lz_save
+    endtry
+    " Note: Empty dict will be returned on error.
+    return ret
+endfunction
+
+" Parse the *current* buffer and return a dictionary characterizing it.
+" Preconditions: We're in a temporary buffer with provided 'filetype' and contents given
+" by 'codestr'. (This is guaranteed by sexp#parse#do_in_buf().)
+function! sexp#parse#analyze_codestr(codestr, filetype)
+    let ret = {
+        \ 'elem_count': 0,
+        \ 'is_ml': 0,
+        \ 'has_com': 0, 's_is_com': 0, 'e_is_com': 0,
+        \ 'node_ranges': [],
+        \ 'err_loc': s:nullpos, 'err_hint': '',
+        \ 'text': substitute(a:codestr, '^\s*\|\s*$', '', 'g'),
+        \ 'linewise': g:sexp_regput_untrimmed_is_linewise
+            \ ? a:codestr =~ '^\s\|\s$'
+            \ : a:codestr =~ '\n$'
+    \ }
     " Start parsing on first char, which is guaranteed to be non-ws.
     normal! gg0
     let p = getpos('.')
@@ -118,50 +172,6 @@ function! s:analyze_codestr(ret)
     endif
     let ret.is_ml = ret.elem_count > 0
         \ && ret.node_ranges[0][0][1] < ret.node_ranges[-1][1][1]
-    return ret
-endfunction
-
-function! sexp#parse#analyze_codestr(codestr, filetype)
-    " Note: Several fields are initialized to final values here; the ones requiring a
-    " parse are filled in by s:analyze_codestr().
-    let ret = {
-        \ 'elem_count': 0,
-        \ 'is_ml': 0,
-        \ 'has_com': 0, 's_is_com': 0, 'e_is_com': 0,
-        \ 'node_ranges': [],
-        \ 'err_loc': s:nullpos, 'err_hint': '',
-        \ 'text': substitute(a:codestr, '^\s*\|\s*$', '', 'g'),
-        \ 'linewise': g:sexp_regput_untrimmed_is_linewise
-            \ ? a:codestr =~ '^\s\|\s$'
-            \ : a:codestr =~ '\n$'
-    \ }
-    " Be sure we end up in starting window, with original window layout.
-    let [winnr, wrc] = [winnr(), winrestcmd()]
-    " 'lz' should already be set, but just in case...
-    let lz_save = &lazyredraw
-    try
-        set lz
-        " Make sure we're in a scratch buffer we can use for parsing.
-        call s:enter_parse_buffer()
-        " Note: Inserting with P ensures we won't insert leading blank line if ret.text
-        " ends in newline (thereby triggering a linewise put); however, we currently trim
-        " the surrounding whitespace to simplify logic in s:analyze_codestr(), so either
-        " type of of put would work.
-        silent exe "normal! \"=ret.text\<cr>P"
-        " Make sure we have syntax regions for parsing.
-        let &l:ft = a:filetype
-        " Parse the buffer and fill in the return dict.
-        call s:analyze_codestr(ret)
-    finally
-        " Hide the parse buffer and return to the original window.
-        call s:exit_parse_buffer()
-        exe winnr . 'wincmd w'
-        " Restore window sizes.
-        " Assumption: Open window set is identical to what it was when wrc was captured.
-        exe wrc
-        let &lz = lz_save
-    endtry
-    " Note: Empty dict will be returned on error.
     return ret
 endfunction
 

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -204,6 +204,7 @@ endfunction
 " addition to carrying information explicitly, it serves as an indication to the wrapper
 " mechanism that a sexp operator is in progress.
 function! s:OP_cleanup()
+    let &report = s:OP.report_save
     let s:OP = {}
     call sexp#warn#dbg("OP_cleanup: mode=%s", mode(1))
     au! SexpTextYankPost
@@ -232,7 +233,11 @@ function! s:OP_setup(Fn, name, cnt)
         \ 'range': [[0,0,0,0],[0,0,0,0]],
         \ 'inclusive': -1,
         \ 'motion': '',
+        \ 'report_save': &report,
     \}
+    " Temporarily set 'report' to something very large to prevent "yanked N lines" msgs.
+    " Caveat: Must ensure original value (saved in s:OP) is restored by cleanup.
+    set report=1000000
     call sexp#warn#dbg("Configuring TYP callback OP=%s", string(s:OP))
     augroup SexpTextYankPost
         au! TextYankPost <buffer> ++once call <SID>OP_TextYankPost()

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -234,14 +234,20 @@ function! s:OP_setup(Fn, name, cnt)
         \ 'plug_cmd': a:name,
         \ 'cnt': a:cnt,
         \ 'reg': v:register,
-        \ 'unnamed_reg': @",
-        \ 'z_reg': @z,
+        \ 'unnamed_reg': getreg('"', 1, 1),
+        \ 'z_reg': getreg('z', 1, 1),
         \ 'fn': a:Fn,
         \ 'range': [[0,0,0,0],[0,0,0,0]],
         \ 'inclusive': -1,
         \ 'motion': '',
         \ 'report_save': &report,
     \}
+    if exists('*getreginfo')
+        " Save/restore more complete information if reginfo() available.
+        " Note: setreg() accepts values in various formats.
+        let s:OP.unnamed_reg = getreginfo('"')
+        let s:OP.z_reg = getreginfo('z')
+    endif
     " Temporarily set 'report' to something very large to prevent "yanked N lines" msgs.
     " Caveat: Must ensure original value (saved in s:OP) is restored by cleanup.
     set report=1000000
@@ -267,7 +273,13 @@ endfunction
 " Note: The SafeState autocmd may fire many times (e.g., in command mode) before the yank
 " completes.
 function! s:OP_SafeState()
-    call sexp#warn#dbg("OP_SafeState: mode=%s", mode(1))
+    " Now that the yank is complete, restore all potentially impacted registers to their
+    " pre-yank values.
+    " Note: The unnamed register is clobbered in legacy Vim only, but since this behavior
+    " is undocumented, safest approach is to restore unconditionally for both.
+    call setreg('"', s:OP.unnamed_reg)
+    call setreg('z', s:OP.z_reg)
+    "call sexp#warn#dbg("OP_SafeState: mode=%s", mode(1))
     if mode() == 'n'
         " Yank is either complete or canceled; s:OP_handle() can tell the difference.
         call s:OP_handle()
@@ -279,7 +291,7 @@ function! s:OP_handle()
         " If we get here without a valid range having been set in OP_TextYankPost(), something
         " unexpected happened...
         if !empty(s:OP) && s:OP.range[0][1]
-            call sexp#warn#dbg("OP_handle: Handling op with cached TYP!")
+            "call sexp#warn#dbg("OP_handle: Handling op with cached TYP!")
             " Perform callback.
             let Fn = s:OP.fn
             call Fn('char', s:OP.inclusive)
@@ -290,15 +302,20 @@ function! s:OP_handle()
     endtry
 endfunction
 
-" Cache the yank information and restore the registers clobbered by the yank, letting the
-" operation be performed in the SafeState handler.
+" Cache yank information that will be needed by the operation, which is deferred to the
+" SafeState handler.
 " Rationale: TextYankPost autocmd prohibits buffer modifications.
+" Caveat: Must defer restoration of @" and @z to the SafeState handler.
+" Rationale: Legacy Vim overwrites the @" register with yanked text *after* TextYankPost
+" handler returns; Neovim seems not to update @" at all when another register is the
+" target of the yank, though neither behavior is documented explicitly. To ensure we
+" restore @" to the value it had *before* the yank used to simulate g@, we defer the
+" restore till SafeState fires.
 function! s:OP_TextYankPost()
-    let [@", @z] = [s:OP.unnamed_reg, s:OP.z_reg]
     let s:OP.range = [getpos("'["), getpos("']")]
     let s:OP.inclusive = v:event.inclusive
-    call sexp#warn#dbg("OP_TextYankPost: Cached TYP %s", string(s:OP))
-    call sexp#warn#dbg("OP_TextYankPost: v:event: %s", string(v:event))
+    "call sexp#warn#dbg("OP_TextYankPost: Cached TYP %s", string(s:OP))
+    "call sexp#warn#dbg("OP_TextYankPost: v:event: %s", string(v:event))
 endfunction
 
 " Calls repeat#set() and registers a one-time CursorMoved handler to correctly

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -44,6 +44,9 @@ function! s:configure_repeat(plug_name, opmode, count)
         call sexp#warn#dbg(
             \ "Setting op_ipg.RepFn for %s with seq=%s reg=%s", a:plug_name, seq, reg)
         let op_info.RepFn = RepFn
+        " Record the fact that the operator motion/object is provided by sexp, as this
+        " has implications for range handling.
+        let op_info.motion = a:plug_name
     else
         " No need to defer setting repeat.
         call sexp#warn#dbg(
@@ -60,6 +63,7 @@ function! s:opfunc(mode, name, cnt, expr, ...)
         " a:expr string, we can't really access them, but we don't really need to, so long
         " as the initial invocation packages up the required args with function().
         let [op, SexpFn] = eval(a:expr)
+        " Note: Both 'opfunc' and TextYankPost handler will use this function as callback.
         let Fn = function('s:opfunc', [a:mode, a:name, a:cnt, a:expr, op, SexpFn])
         if op[0] == 'g'
             let &opfunc = Fn
@@ -73,18 +77,21 @@ function! s:opfunc(mode, name, cnt, expr, ...)
         endif
         return op
     endif
+    call sexp#warn#dbg("!!!getpos(\"']\")=%s", string(getpos("']")))
     call sexp#pre_op(a:mode, a:name)
+    let op_info = s:OP_get()
     " The callback function that completes the operation was packaged as the first
     " variadic arg in the rhs of the assignment to &opfunc above. The type flag is
     " provided by Vim's opfunc engine.
-    " Caveat: Only when called by opfunc mechanism will we receive 3rd vararg ('type').
+    " Caveat: Only when called by opfunc mechanism will we receive 3rd vararg
+    " ('type').
     let [op, Fn, type] = a:000[0:2]
     let inclusive = op[0] == 'g' ? -1 : a:000[3]
     try
         " Note: The Fn callback contains everything it needs but type.
         call sexp#warn#dbg("Invoking the sexp op callback... %s ']=%s '>=%s",
             \ string(s:OP), string(getpos("']")), string(getpos("'>")))
-        call Fn(type, inclusive)
+        call Fn(type, inclusive, op_info.motion)
         let RepFn = get(s:OP, 'RepFn', v:null)
         if type(RepFn) == v:t_func
             call sexp#warn#dbg("Invoking RepFn()")
@@ -185,14 +192,17 @@ endfunction
 
 " Cache the information needed to support repeat for a sexp operator.
 " Pre-condition: Called when the operator is first triggered and only when the
-" TextYankPost mechanism isn't in use.
+" TextYankPost mechanism *isn't* in use.
+" Note: If a sexp motion/object is used as operand, 'motion' key will be added.
 function! s:OP_cache(name, cnt)
-    let s:OP = {'plug_cmd': a:name, 'cnt': a:cnt, 'reg': v:register}
+    let s:OP = {'plug_cmd': a:name, 'cnt': a:cnt, 'reg': v:register, 'motion': ''}
 endfunction
 
 " Configure use of TextYankPost (and other autocmds) to handle sexp operators in a way
 " that permits detection of object/motion inclusivity.
 function! s:OP_setup(Fn, name, cnt)
+    " Note: If a sexp command provides the object/motion, 'motion' will be set to the plug
+    " cmd.
     let s:OP = {
         \ 'plug_cmd': a:name,
         \ 'cnt': a:cnt,
@@ -202,6 +212,7 @@ function! s:OP_setup(Fn, name, cnt)
         \ 'fn': a:Fn,
         \ 'range': [[0,0,0,0],[0,0,0,0]],
         \ 'inclusive': -1,
+        \ 'motion': '',
     \}
     call sexp#warn#dbg("Configuring TYP callback OP=%s", string(s:OP))
     augroup SexpTextYankPost
@@ -233,15 +244,19 @@ function! s:OP_SafeState()
 endfunction
 
 function! s:OP_handle()
-    " If we get here without a valid range having been set in OP_TextYankPost(), something
-    " unexpected happened...
-    if !empty(s:OP) && s:OP.range[0][1]
-        call sexp#warn#dbg("OP_handle: Handling op with cached TYP!")
-        " Perform callback.
-        let Fn = s:OP.fn
-        call Fn('char', s:OP.inclusive)
-    endif
-    call s:OP_cleanup()
+    try
+        " If we get here without a valid range having been set in OP_TextYankPost(), something
+        " unexpected happened...
+        if !empty(s:OP) && s:OP.range[0][1]
+            call sexp#warn#dbg("OP_handle: Handling op with cached TYP!")
+            " Perform callback.
+            let Fn = s:OP.fn
+            call Fn('char', s:OP.inclusive)
+        endif
+    finally
+        " Kill the autocmd unconditionally to eliminate possibility of endless error loops.
+        call s:OP_cleanup()
+    endtry
 endfunction
 
 " Cache the yank information and restore the registers clobbered by the yank, letting the

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -26,6 +26,23 @@ function! s:configure_repeat(plug_name, opmode, count)
     let seq = a:opmode && v:operator ==? "c"
         \ ? opstr . "\<Plug>(" . a:plug_name . ")\<C-r>.\<C-Bslash>\<C-n>"
         \ : opstr . "\<Plug>(" . a:plug_name . ")"
+    " Have separate counts have been supplied to operator and operand? 
+    " Assumption: When separate counts are provided, both will be > 1 and the operand
+    " count will be greater than the operator count (due to Vim's multiplication).
+    if op_ipg && op_info.cnt > 1 && a:count > op_info.cnt
+        " This is unlikely to do what the user expects.
+        " Note that the test is designed to permit a non-unity count to be used on the
+        " operator alone. If we didn't permit this, there would be no way to provide a
+        " count to the sexp object in a custom mapping whose rhs looked like this:
+        " <sexp_op> <sexp_object>.
+        call sexp#warn#msg_once('operator counts',
+            \ "Warning: Separate counts have been provided to a sexp operator and"
+            \ . " its operand. This is unlikely to work the way you expect: vim-sexp's"
+            \ . " operators do not support counts and Vim multiplies the motion/object"
+            \ . " count by the operator count. It's best to provide counts only to"
+            \ . " motion/object commands.")
+        call sexp#warn#dbg("Counts mismatch: operator: %d operand: %d", op_info.cnt, a:count)
+    endif
     " If sexp operator in progress, use cached v:register.
     " Design Decision: Always pass register, even if unnamed.
     " Rationale: Failure to set register explicitly inhibits the repeat plugin's register
@@ -133,7 +150,7 @@ function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
         " Caveat: Can't set marks in an <expr> mapping. If it's necessary, the opfunc
         " should save the old '` and restore it at completion of operation.
         if !a:flags.nojump && !a:flags.asexpr
-            " TODO: This may need special handling with g:sexp_regput{_into}_curpos == 2.
+            " TODO: This may need special handling with g:sexp_regput_curpos* == 2.
             exe "normal! " . (opmode ? 'vv' : '') . "m`"
         endif
         " Don't set repeat if this is a sexp operator, but if it's an operator-pending
@@ -151,12 +168,6 @@ function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
         " TODO: Remove 'prev' from the pattern now that it's been removed from cmd defs.
         let rhs = substitute(a:rhs, '\<v:\%(prev\)\?count\>', a:count, 'g')
         if a:flags.asexpr
-            if a:count > 1
-                call sexp#warn#msg_once('operator counts',
-                    \ "Warning: Counts provided to sexp operators are ignored"
-                    \ . " but will multiply any count provided to the motion/object."
-                    \ . " It's best to provide counts only to motion/object commands.")
-            endif
             " Let opfunc decide what the mapping looks like (i.e., g@ or *yv).
             return call('s:opfunc', [a:mapmode[0], a:name, a:count, rhs])
         else

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -133,13 +133,20 @@ endfunction
 "   mode before completing an operator-pending command so that the cursor
 "   returns to its original position after an = command.
 " RE: v:count
-"   Currently, the count arg is captured before this function escapes to normal mode (if
-"   it does). In particular, neither <cmd> nor :<c-u> (even from visual mode) reset
-"   v:count, so we should never need to use v:prevcount.
-function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
+"   This function needs to determine command count from either v:count or v:prevcount.
+"   Since neither <cmd> nor :<c-u> (even from visual mode) reset v:count, I was originally
+"   taking a snapshot of it before the call to sexp#ensure_normal_mode(). However, this
+"   approach breaks when the popular which-key plugin is in use; the reason, apparently,
+"   is that which-key's mapping exits and restores visual mode before this wrapper gets a
+"   chance to run, with the result that v:count has already been zeroed and its count
+"   transferred to v:prevcount.
+"   Solution: If we defer the snapshot till *after* ensuring exit to normal mode, we can use
+"   v:prevcount for visual maps and v:count otherwise.
+function! sexp#plug#wrapper(flags, mapmode, name, rhs)
     let opmode = a:mapmode[0] ==# 'o'
-    " Assumption: v:count does not change before this call.
     call sexp#ensure_normal_mode()
+    " Note: See note in header on v:count logic.
+    let cnt = a:mapmode[0] ==# 'x' ? v:prevcount : v:count
     " Note: This commented block was added to fix a regression that occurred when we
     " started using <cmd> in lieu of :<c-u> for visual maps, but a refactor of
     " set_marks_around_current_list() has obviated the need for it. For details, see
@@ -169,15 +176,15 @@ function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
         " (since Vim doesn't provide it), and will simply discard the repeat information
         " without ever calling repeat#set().
         if !a:flags.asexpr && a:flags.repeat && s:have_repeat_set
-            call s:configure_repeat(a:name, opmode, a:count)
+            call s:configure_repeat(a:name, opmode, cnt)
         endif
         " Note: v:count may already have been reset (and transferred to v:prevcount), but
-        " we snapshotted it in the call to this function, so use that.
+        " cnt contains the value we want to use.
         " TODO: Remove 'prev' from the pattern now that it's been removed from cmd defs.
-        let rhs = substitute(a:rhs, '\<v:\%(prev\)\?count\>', a:count, 'g')
+        let rhs = substitute(a:rhs, '\<v:\%(prev\)\?count\>', cnt, 'g')
         if a:flags.asexpr
             " Let opfunc decide what the mapping looks like (i.e., g@ or *yv).
-            return call('s:opfunc', [a:mapmode[0], a:name, a:count, rhs])
+            return call('s:opfunc', [a:mapmode[0], a:name, cnt, rhs])
         else
             " Not an operator: no need for deferred execution
             exe 'call' rhs

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -27,8 +27,10 @@ let s:have_repeat_set = exists('*repeat#set')
 " TODO: Consider making this an autoload function like s:opfunc().
 function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
     let opmode = a:mapmode[0] ==# 'o'
+    "echomsg "before:" v:count v:prevcount a:count
     " Assumption: v:count does not change before this call.
     call sexp#ensure_normal_mode()
+    "echomsg "after:" v:count v:prevcount a:count
     " Caveat: For a sexp operator (e.g., replace_op), the {pre,post}_op wrapper
     " invocations are deferred till operation completion.
     if !a:flags.asexpr
@@ -66,7 +68,7 @@ function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
         endif
         " Note: v:count may already have been reset (and transferred to v:prevcount);
         " fortunately, we snapshotted it in the call to this function, so use that.
-        let rhs = substitute(a:rhs, '\<v:\%(prev\)count\>', a:count, 'g')
+        let rhs = substitute(a:rhs, '\<v:\%(prev\)\?count\>', a:count, 'g')
         if a:flags.asexpr
             return call('s:opfunc', [a:mapmode[0], a:name, rhs])
         else

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -140,6 +140,14 @@ function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
     let opmode = a:mapmode[0] ==# 'o'
     " Assumption: v:count does not change before this call.
     call sexp#ensure_normal_mode()
+    " Note: This commented block was added to fix a regression that occurred when we
+    " started using <cmd> in lieu of :<c-u> for visual maps, but a refactor of
+    " set_marks_around_current_list() has obviated the need for it. For details, see
+    " 'Important Note' in that function's header.
+    "if a:mapmode[0] =~? '[xv]'
+    "    let p = getpos("'<")
+    "    keepjumps call cursor(p[1], p[2])
+    "endif
     " Caveat: For a sexp operator (e.g., replace_op), the {pre,post}_op wrapper
     " invocations are deferred till operation completion.
     if !a:flags.asexpr

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -7,6 +7,51 @@
 silent! call repeat#set('')
 let s:have_repeat_set = exists('*repeat#set')
 
+" Configure dot repeat for the specified command.
+function! s:configure_repeat(plug_name, opmode, count)
+    let [op_ipg, op_info] = [s:OP_ipg(), s:OP_get()]
+    " Determine the sequence to pass to repeat#set.
+    " Note: The identical sequence must be used for both setreg() and set().
+    " Special Case: If the operator was c (change), the dot register should contain the
+    " text we wish to insert over the sexp motion/object; however, the dot repeat will
+    " simply do `c<Plug>(some_sexp_object)', leaving us in insert mode with nothing
+    " inserted. To complete the desired operation, we must then use `<C-R>' to insert the
+    " dot register, then use `<C-\><C-n>' to ensure our return to normal mode doesn't
+    " trigger a beep.
+    let opstr = a:opmode
+        \ ? op_ipg
+            \ ? "\<Plug>(" . op_info.plug_cmd . ")"
+            \ : v:operator
+        \ : ""
+    let seq = a:opmode && v:operator ==? "c"
+        \ ? opstr . "\<Plug>(" . a:plug_name . ")\<C-r>.\<C-Bslash>\<C-n>"
+        \ : opstr . "\<Plug>(" . a:plug_name . ")"
+    " If sexp operator in progress, use cached v:register.
+    " Design Decision: Always pass register, even if unnamed.
+    " Rationale: Failure to set register explicitly inhibits the repeat plugin's register
+    " logic, with the result that a register specification for the "." command would be
+    " ignored.
+    " Note: Use a lambda with a closure to simplify the operator callback.
+    let reg = op_ipg ? op_info.reg : v:register
+    let RepFn = {->
+        \ repeat#set(seq, a:count) && repeat#setreg(seq, reg)
+    \ }
+    if op_ipg
+        " A sexp op is in progress! Allow repeat to be set *after* it completes.
+        " Note: If the motion/object for a sexp operator is not a sexp motion/object, we
+        " won't get here, so RepFn won't be set and repeat won't be configured. This is an
+        " inherent limitation.
+        call sexp#warn#dbg(
+            \ "Setting op_ipg.RepFn for %s with seq=%s reg=%s", a:plug_name, seq, reg)
+        let op_info.RepFn = RepFn
+    else
+        " No need to defer setting repeat.
+        call sexp#warn#dbg(
+            \ "non-deferred repeat#set on %s with seq=%s reg=%s", a:plug_name, seq, reg)
+        call RepFn()
+    endif
+endfunction
+
 function! s:opfunc(mode, name, cnt, expr, ...)
     if !a:0
         " Let the operator function provide a stateful callback to be invoked to complete
@@ -66,7 +111,6 @@ endfunction
 "   Currently, the count arg is captured before this function escapes to normal mode (if
 "   it does). In particular, neither <cmd> nor :<c-u> (even from visual mode) reset
 "   v:count, so we should never need to use v:prevcount.
-" TODO: Consider making this an autoload function like s:opfunc().
 function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
     let opmode = a:mapmode[0] ==# 'o'
     " Assumption: v:count does not change before this call.
@@ -84,68 +128,31 @@ function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
             " TODO: This may need special handling with g:sexp_regput{_into}_curpos == 2.
             exe "normal! " . (opmode ? 'vv' : '') . "m`"
         endif
-        let op_ipg = get(s:, 'OP', {})
-        "let cnt = max([1, a:count])
-        let cnt = a:count
         " Don't set repeat if this is a sexp operator, but if it's an operator-pending
         " sexp command, set it in a way that takes any *active* operator (including a sexp
-        " operator) into account. Note that for this to work, we have to save both the
-        " plug cmd and any count associated with the sexp operator when it's first
-        " invoked. If the object/motion belongs to sexp, we'll concatenate the following
-        " for repeat:
-        "   {op count} {sexp operator} {object/motion count} {sexp object/motion}
-        " If the object/motion is non-sexp, we'll have no way of knowing what it was, and
-        " will simply discard the repeat information without ever calling repeat#set().
+        " operator) into account. If the object/motion belongs to sexp, we'll concatenate
+        " the following for repeat: {sexp operator} {sexp object/motion}
+        " If the object/motion is non-sexp, we'll have no way of knowing what it was
+        " (since Vim doesn't provide it), and will simply discard the repeat information
+        " without ever calling repeat#set().
         if !a:flags.asexpr && a:flags.repeat && s:have_repeat_set
-            " Note: The identical sequence must be used for both setreg() and set().
-            " Special Case: If the operator was c (change), the dot register should
-            " contain the text we wish to insert over the sexp motion/object. The
-            " repeat effectively does `c<Plug>(some_sexp_object)', leaving us in
-            " insert mode; thus, we use `<C-R>' to insert the dot register, then use
-            " `<C-\><C-n>' to ensure our return to normal mode doesn't trigger a beep.
-            let opstr = opmode
-                \ ? !empty(get(s:, 'OP', {}))
-                    \ ? (s:OP.cnt > 1 ? s:OP.cnt : '') . "\<Plug>(" . s:OP.plug_cmd . ")"
-                    \ : v:operator
-                \ : ""
-            " TODO: Decide on best way to handle the 2 relevant counts.
-            let cntstr = !empty(op_ipg) ? (cnt > 1 ? cnt : '') : ''
-            let seq = opmode && v:operator ==? "c"
-                \ ? opstr . cntstr . "\<Plug>(" . a:name . ")\<C-r>.\<C-Bslash>\<C-n>"
-                \ : opstr . cntstr . "\<Plug>(" . a:name . ")"
-            " The repeat plugin defaults to the unnamed register, so don't bother setting
-            " reg unless current register is named.
-            let reg = v:register != '"' ? v:register : ''
-            " Design Decision: Always pass repeat#set() a count of 1.
-            " Rationale: Allows us to embed distinct counts for operator and motion/object
-            " in the actual repeat sequence.
-            " Note: Use a lambda with a closure to simplify the operator callback.
-            let RepFn = {->
-                \ repeat#set(seq, cnt) && !empty(reg)
-                \ ? repeat#setreg(seq, reg) : 0
-            \ }
-            if !empty(op_ipg)
-                " A sexp op is in progress! Allow repeat to be set *after* it completes.
-                " Note: If the motion/object for a sexp operator is not a sexp
-                " motion/object, RepFn won't be set and repeat won't be configured.
-                call sexp#warn#dbg(
-                    \ "Setting op_ipg.RepFn for %s with seq=%s reg=%s", a:name, seq, reg)
-                let op_ipg.RepFn = RepFn
-            else
-                " No need to defer setting repeat.
-                call sexp#warn#dbg(
-                    \ "non-deferred repeat#set on %s with seq=%s reg=%s", a:name, seq, reg)
-                call RepFn()
-            endif
+            call s:configure_repeat(a:name, opmode, a:count)
         endif
         " Note: v:count may already have been reset (and transferred to v:prevcount), but
         " we snapshotted it in the call to this function, so use that.
-        let rhs = substitute(a:rhs, '\<v:\%(prev\)\?count\>', cnt, 'g')
+        " TODO: Remove 'prev' from the pattern now that it's been removed from cmd defs.
+        let rhs = substitute(a:rhs, '\<v:\%(prev\)\?count\>', a:count, 'g')
         if a:flags.asexpr
+            if a:count > 1
+                call sexp#warn#msg_once('operator counts',
+                    \ "Warning: Counts provided to sexp operators are ignored"
+                    \ . " but will multiply any count provided to the motion/object."
+                    \ . " It's best to provide counts only to motion/object commands.")
+            endif
             " Let opfunc decide what the mapping looks like (i.e., g@ or *yv).
-            return call('s:opfunc', [a:mapmode[0], a:name, cnt, rhs])
+            return call('s:opfunc', [a:mapmode[0], a:name, a:count, rhs])
         else
-            " No need for deferred execution
+            " Not an operator: no need for deferred execution
             exe 'call' rhs
         endif
     finally
@@ -153,6 +160,16 @@ function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
             call sexp#post_op(a:mapmode[0], a:name)
         endif
     endtry
+endfunction
+
+" Return dict for a sexp operator in progress, else {}.
+function! s:OP_get()
+    return get(s:, 'OP', {})
+endfunction
+
+" Return true iff sexp operator is in progress.
+function! s:OP_ipg()
+    return !empty(get(s:, 'OP', {}))
 endfunction
 
 " Remove all autocmds used as part of the TextYankPost-based mechanism for handling
@@ -169,7 +186,7 @@ endfunction
 " Pre-condition: Called when the operator is first triggered and only when the
 " TextYankPost mechanism isn't in use.
 function! s:OP_cache(name, cnt)
-    let s:OP = {'plug_cmd': a:name, 'cnt': a:cnt}
+    let s:OP = {'plug_cmd': a:name, 'cnt': a:cnt, 'reg': v:register}
 endfunction
 
 " Configure use of TextYankPost (and other autocmds) to handle sexp operators in a way
@@ -178,6 +195,7 @@ function! s:OP_setup(Fn, name, cnt)
     let s:OP = {
         \ 'plug_cmd': a:name,
         \ 'cnt': a:cnt,
+        \ 'reg': v:register,
         \ 'unnamed_reg': @",
         \ 'z_reg': @z,
         \ 'fn': a:Fn,

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -82,7 +82,8 @@ function! s:opfunc(mode, name, cnt, expr, ...)
     let inclusive = op[0] == 'g' ? -1 : a:000[3]
     try
         " Note: The Fn callback contains everything it needs but type.
-        call sexp#warn#dbg("Invoking the sexp op callback... %s", string(s:OP))
+        call sexp#warn#dbg("Invoking the sexp op callback... %s ']=%s '>=%s",
+            \ string(s:OP), string(getpos("']")), string(getpos("'>")))
         call Fn(type, inclusive)
         let RepFn = get(s:OP, 'RepFn', v:null)
         if type(RepFn) == v:t_func
@@ -251,6 +252,7 @@ function! s:OP_TextYankPost()
     let s:OP.range = [getpos("'["), getpos("']")]
     let s:OP.inclusive = v:event.inclusive
     call sexp#warn#dbg("OP_TextYankPost: Cached TYP %s", string(s:OP))
+    call sexp#warn#dbg("OP_TextYankPost: v:event: %s", string(v:event))
 endfunction
 
 " Calls repeat#set() and registers a one-time CursorMoved handler to correctly

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -7,6 +7,48 @@
 silent! call repeat#set('')
 let s:have_repeat_set = exists('*repeat#set')
 
+function! s:opfunc(mode, name, cnt, expr, ...)
+    if !a:0
+        " Let the operator function provide a stateful callback to be invoked to complete
+        " the operation.
+        " Note: Since the arguments required by the callback function are embedded in the
+        " a:expr string, we can't really access them, but we don't really need to, so long
+        " as the initial invocation packages up the required args with function().
+        let [op, SexpFn] = eval(a:expr)
+        let Fn = function('s:opfunc', [a:mode, a:name, a:cnt, a:expr, op, SexpFn])
+        if op[0] == 'g'
+            let &opfunc = Fn
+            " Cache the operator for repeat mechanism.
+            call sexp#warn#dbg("Caching OP")
+            call s:OP_cache(a:name, a:cnt)
+        else
+            " Cache operator and configure TextYankPost autocmd.
+            call sexp#warn#dbg("Calling OP_setup()")
+            call s:OP_setup(Fn, a:name, a:cnt)
+        endif
+        return op
+    endif
+    call sexp#pre_op(a:mode, a:name)
+    " The callback function that completes the operation was packaged as the first
+    " variadic arg in the rhs of the assignment to &opfunc above. The type flag is
+    " provided by Vim's opfunc engine.
+    " Caveat: Only when called by opfunc mechanism will we receive 3rd vararg ('type').
+    let [op, Fn, type] = a:000[0:2]
+    let inclusive = op[0] == 'g' ? -1 : a:000[3]
+    try
+        " Note: The Fn callback contains everything it needs but type.
+        call sexp#warn#dbg("Invoking the sexp op callback... %s", string(s:OP))
+        call Fn(type, inclusive)
+        let RepFn = get(s:OP, 'RepFn', v:null)
+        if type(RepFn) == v:t_func
+            call sexp#warn#dbg("Invoking RepFn()")
+            call RepFn()
+        endif
+    finally
+        call sexp#post_op(a:mode, a:name)
+    endtry
+endfunction
+
 " This function is a wrapper for sexp <Plug> commands used to ensure common boilerplate
 " runs at the appropriate time. It is invoked by the <Plug> mappings defined by
 " s:defplug() in the plugin script; thus, it will not force load of this autoload file
@@ -27,15 +69,14 @@ let s:have_repeat_set = exists('*repeat#set')
 " TODO: Consider making this an autoload function like s:opfunc().
 function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
     let opmode = a:mapmode[0] ==# 'o'
-    "echomsg "before:" v:count v:prevcount a:count
     " Assumption: v:count does not change before this call.
     call sexp#ensure_normal_mode()
-    "echomsg "after:" v:count v:prevcount a:count
     " Caveat: For a sexp operator (e.g., replace_op), the {pre,post}_op wrapper
     " invocations are deferred till operation completion.
     if !a:flags.asexpr
         call sexp#pre_op(a:mapmode[0], a:name)
     endif
+    call sexp#warn#dbg("sexp#plug#wrapper: %s: OP=%s", a:name, string(get(s:, 'OP', {})))
     try
         " Caveat: Can't set marks in an <expr> mapping. If it's necessary, the opfunc
         " should save the old '` and restore it at completion of operation.
@@ -43,40 +84,69 @@ function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
             " TODO: This may need special handling with g:sexp_regput{_into}_curpos == 2.
             exe "normal! " . (opmode ? 'vv' : '') . "m`"
         endif
-        " repeat (register) setup (prolog)
-        " Note: Only sexp motions/objects (not sexp operators such as replace) should be repeated.
-        " Rationale: The repeat sequence concatenates the operator and motion/object; an
-        " operator by itself is nothing until combined with a target.
+        let op_ipg = get(s:, 'OP', {})
+        "let cnt = max([1, a:count])
+        let cnt = a:count
+        " Don't set repeat if this is a sexp operator, but if it's an operator-pending
+        " sexp command, set it in a way that takes any *active* operator (including a sexp
+        " operator) into account. Note that for this to work, we have to save both the
+        " plug cmd and any count associated with the sexp operator when it's first
+        " invoked. If the object/motion belongs to sexp, we'll concatenate the following
+        " for repeat:
+        "   {op count} {sexp operator} {object/motion count} {sexp object/motion}
+        " If the object/motion is non-sexp, we'll have no way of knowing what it was, and
+        " will simply discard the repeat information without ever calling repeat#set().
         if !a:flags.asexpr && a:flags.repeat && s:have_repeat_set
-            " Note: The identical sequence should be used for both setreg() and set().
-            " FIXME: Reevaluate the assumptions made wrt repeat: e.g., should we simply
-            " assume this is operator-pending map? Also, need to configure repeat for sexp
-            " operators in opfunc once the motion/object is known.
+            " Note: The identical sequence must be used for both setreg() and set().
             " Special Case: If the operator was c (change), the dot register should
             " contain the text we wish to insert over the sexp motion/object. The
             " repeat effectively does `c<Plug>(some_sexp_object)', leaving us in
             " insert mode; thus, we use `<C-R>' to insert the dot register, then use
             " `<C-\><C-n>' to ensure our return to normal mode doesn't trigger a beep.
-            let repseq = opmode && v:operator ==? "c"
-                \ ? v:operator . "\<Plug>(" . a:name . ")\<C-r>.\<C-Bslash>\<C-n>"
-                \ : v:operator . "\<Plug>(" . a:name . ")"
-            " The repeat plugin defaults to unnamed register, so don't bother setting
-            " unless current register is named.
-            if v:register != '"'
-                call repeat#setreg(repseq, v:register)
+            let opstr = opmode
+                \ ? !empty(get(s:, 'OP', {}))
+                    \ ? (s:OP.cnt > 1 ? s:OP.cnt : '') . "\<Plug>(" . s:OP.plug_cmd . ")"
+                    \ : v:operator
+                \ : ""
+            " TODO: Decide on best way to handle the 2 relevant counts.
+            let cntstr = !empty(op_ipg) ? (cnt > 1 ? cnt : '') : ''
+            let seq = opmode && v:operator ==? "c"
+                \ ? opstr . cntstr . "\<Plug>(" . a:name . ")\<C-r>.\<C-Bslash>\<C-n>"
+                \ : opstr . cntstr . "\<Plug>(" . a:name . ")"
+            " The repeat plugin defaults to the unnamed register, so don't bother setting
+            " reg unless current register is named.
+            let reg = v:register != '"' ? v:register : ''
+            " Design Decision: Always pass repeat#set() a count of 1.
+            " Rationale: Allows us to embed distinct counts for operator and motion/object
+            " in the actual repeat sequence.
+            " Note: Use a lambda with a closure to simplify the operator callback.
+            let RepFn = {->
+                \ repeat#set(seq, cnt) && !empty(reg)
+                \ ? repeat#setreg(seq, reg) : 0
+            \ }
+            if !empty(op_ipg)
+                " A sexp op is in progress! Allow repeat to be set *after* it completes.
+                " Note: If the motion/object for a sexp operator is not a sexp
+                " motion/object, RepFn won't be set and repeat won't be configured.
+                call sexp#warn#dbg(
+                    \ "Setting op_ipg.RepFn for %s with seq=%s reg=%s", a:name, seq, reg)
+                let op_ipg.RepFn = RepFn
+            else
+                " No need to defer setting repeat.
+                call sexp#warn#dbg(
+                    \ "non-deferred repeat#set on %s with seq=%s reg=%s", a:name, seq, reg)
+                call RepFn()
             endif
         endif
-        " Note: v:count may already have been reset (and transferred to v:prevcount);
-        " fortunately, we snapshotted it in the call to this function, so use that.
-        let rhs = substitute(a:rhs, '\<v:\%(prev\)\?count\>', a:count, 'g')
+        " Note: v:count may already have been reset (and transferred to v:prevcount), but
+        " we snapshotted it in the call to this function, so use that.
+        let rhs = substitute(a:rhs, '\<v:\%(prev\)\?count\>', cnt, 'g')
         if a:flags.asexpr
-            return call('s:opfunc', [a:mapmode[0], a:name, rhs])
+            " Let opfunc decide what the mapping looks like (i.e., g@ or *yv).
+            return call('s:opfunc', [a:mapmode[0], a:name, cnt, rhs])
         else
+            " No need for deferred execution
             exe 'call' rhs
-        endif
-        " repeat setup (epilog)
-        if !a:flags.asexpr && a:flags.repeat && s:have_repeat_set
-            call repeat#set(repseq, a:count)
         endif
     finally
         if !a:flags.asexpr
@@ -85,29 +155,84 @@ function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
     endtry
 endfunction
 
-function! s:opfunc(mode, name, expr, ...)
-    if !a:0
-        " Let the operator function provide a stateful callback to be invoked to complete
-        " the operation.
-        " Note: Since the arguments required by the callback function are embedded in the
-        " a:expr string, we can't really access them, but we don't really need to, so long
-        " as the initial invocation packages up the required args with function().
-        let Fn = eval(a:expr)
-        " FIXME: This will get the extra type arg, which we need to pass to replace_op.
-        let &opfunc = function('s:opfunc', [a:mode, a:name, a:expr, Fn])
-        return 'g@'
+" Remove all autocmds used as part of the TextYankPost-based mechanism for handling
+" operators and make the associated state dict empty; this is necessary because in
+" addition to carrying information explicitly, it serves as an indication to the wrapper
+" mechanism that a sexp operator is in progress.
+function! s:OP_cleanup()
+    let s:OP = {}
+    call sexp#warn#dbg("OP_cleanup: mode=%s", mode(1))
+    au! SexpTextYankPost
+endfunction
+
+" Cache the information needed to support repeat for a sexp operator.
+" Pre-condition: Called when the operator is first triggered and only when the
+" TextYankPost mechanism isn't in use.
+function! s:OP_cache(name, cnt)
+    let s:OP = {'plug_cmd': a:name, 'cnt': a:cnt}
+endfunction
+
+" Configure use of TextYankPost (and other autocmds) to handle sexp operators in a way
+" that permits detection of object/motion inclusivity.
+function! s:OP_setup(Fn, name, cnt)
+    let s:OP = {
+        \ 'plug_cmd': a:name,
+        \ 'cnt': a:cnt,
+        \ 'unnamed_reg': @",
+        \ 'z_reg': @z,
+        \ 'fn': a:Fn,
+        \ 'range': [[0,0,0,0],[0,0,0,0]],
+        \ 'inclusive': -1,
+    \}
+    call sexp#warn#dbg("Configuring TYP callback OP=%s", string(s:OP))
+    augroup SexpTextYankPost
+        au! TextYankPost <buffer> ++once call <SID>OP_TextYankPost()
+        " This one may fire before TYP, but if it fires when we're in normal mode, the
+        " yank has probably been canceled.
+        au! SafeState <buffer> call s:OP_SafeState()
+        " Note: ModeChanged is problematic because we can go from nov->n *before*
+        " TextYankPost fires: e.g., this happens when a sexp object is used to specify the
+        " yank region. Better to rely on SafeState, which shouldn't fire in Normal mode
+        " until the yank completes or is canceled; note, however, that it can fire in (eg)
+        " command-line mode if user hits / to perform the search.
+        "au! ModeChanged nov:n call <SID>TYP_mode_changed()
+    augroup END
+endfunction
+
+" Monitor SafeState autocmd, invoking our operator callback upon return to Normal mode.
+" Explanation: Ideally, we would simply invoke our operator callback from the TextYankPost
+" autocmd, but since that autocmd prohibits buffer changes, we wait until we're back in
+" Normal mode after the yank has completed.
+" Note: The SafeState autocmd may fire many times (e.g., in command mode) before the yank
+" completes.
+function! s:OP_SafeState()
+    call sexp#warn#dbg("OP_SafeState: mode=%s", mode(1))
+    if mode() == 'n'
+        " Yank is either complete or canceled; s:OP_handle() can tell the difference.
+        call s:OP_handle()
     endif
-    call sexp#pre_op(a:mode, a:name)
-    " The callback function that completes the operation was packaged as the first
-    " variadic arg in the rhs of the assignment to &opfunc above. The type flag is
-    " provided by Vim's opfunc engine.
-    let [Fn, type] = a:000
-    try
-        " Note: The Fn callback contains everything it needs but type.
-        call Fn(type)
-    finally
-        call sexp#post_op(a:mode, a:name)
-    endtry
+endfunction
+
+function! s:OP_handle()
+    " If we get here without a valid range having been set in OP_TextYankPost(), something
+    " unexpected happened...
+    if !empty(s:OP) && s:OP.range[0][1]
+        call sexp#warn#dbg("OP_handle: Handling op with cached TYP!")
+        " Perform callback.
+        let Fn = s:OP.fn
+        call Fn('char', s:OP.inclusive)
+    endif
+    call s:OP_cleanup()
+endfunction
+
+" Cache the yank information and restore the registers clobbered by the yank, letting the
+" operation be performed in the SafeState handler.
+" Rationale: TextYankPost autocmd prohibits buffer modifications.
+function! s:OP_TextYankPost()
+    let [@", @z] = [s:OP.unnamed_reg, s:OP.z_reg]
+    let s:OP.range = [getpos("'["), getpos("']")]
+    let s:OP.inclusive = v:event.inclusive
+    call sexp#warn#dbg("OP_TextYankPost: Cached TYP %s", string(s:OP))
 endfunction
 
 " Calls repeat#set() and registers a one-time CursorMoved handler to correctly

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -35,12 +35,12 @@ function! s:configure_repeat(plug_name, opmode, count)
         " operator alone. If we didn't permit this, there would be no way to provide a
         " count to the sexp object in a custom mapping whose rhs looked like this:
         " <sexp_op> <sexp_object>.
-        call sexp#warn#msg_once('operator counts',
+        call sexp#warn#msg(
             \ "Warning: Separate counts have been provided to a sexp operator and"
             \ . " its operand. This is unlikely to work the way you expect: vim-sexp's"
             \ . " operators do not support counts and Vim multiplies the motion/object"
             \ . " count by the operator count. It's best to provide counts only to"
-            \ . " motion/object commands.")
+            \ . " motion/object commands.", {'once': 'operator counts'})
         call sexp#warn#dbg("Counts mismatch: operator: %d operand: %d", op_info.cnt, a:count)
     endif
     " If sexp operator in progress, use cached v:register.
@@ -325,6 +325,78 @@ function! s:repeat_set(buf, count)
                     \ endif |
                     \ let g:repeat_tick = b:changedtick | autocmd! sexp_repeat
     augroup END
+endfunction
+
+" Validate and convert a single value in the sexp_mappings dict to a denormalized form
+" conducive to use in map creation.
+" Args:
+"   plug:         command name (i.e., the ... in <Plug>(...))
+"   entry:        lhs specification in one of the following forms:
+"                 '<lhs>'
+"                 | {'<modes1>': '<lhs1>', ..., '<modesN>': '<lhsN>'}
+"   valid_modes:  string of chars in [nxo] constraining the modes for this command
+"                 default: 'nox'
+" Return: A pair representing the denormalized map and a string of ignored modes: e.g.,
+"   [{'x': <lhs>, 'n': <lhs>, ...}, 'o']
+" Exception: throw 'sexp-error' with appropriate message if entry format is irremediably
+" invalid. If, OTOH, the problem is merely valid Vim modes that aren't in a:valid_modes,
+" don't throw exception, but add the ignored modes to the string returned as second
+" element of pair.
+" Examples:
+"   entry:         {'xn': 'lhs'}
+"   valid_modes:   'x'
+"   => [{'x': 'lhs'}, 'n']
+"   entry:         {'xn': 'lhs1', 'o': 'lhs2'}
+"   valid_modes:   'xo'
+"   => [{'x': 'lhs1', 'o': 'lhs2'}, 'n'}
+" TODO: Consider returning 2 denormalized maps: i.e., [valid_map, ignored_map].
+function! sexp#plug#parse_map_entry(plug, entry, valid_modes)
+    " Initialize return values.
+    let [maps, ignored_modes] = [{}, '']
+    let valid_modes = empty(a:valid_modes) ? 'novx' : a:valid_modes
+    let entry = type(a:entry) == type({})
+        \ ? a:entry
+        \ : type(a:entry) == type('')
+        \ ? {valid_modes: a:entry}
+        \ : v:null
+    if entry is v:null
+        throw "sexp-error: Invalid user map entry: must be string or dict"
+    endif
+    " At this point, we have a dict, which may or may not be usable as a map override.
+    for [modes, lhs] in items(entry)
+        if type(modes) != type('')
+            throw "sexp-error: Invalid mode string: " . string(modes)
+        endif
+        " Convert v to x: e.g., 'nvo' => 'nxo'
+        let modes = substitute(modes, 'v', 'x', 'g')
+        " Collapse multiple occurrences of same mode: e.g., {'x': ..., 'xo': ...}.
+        let modes = substitute(
+            \ join(sort(split(modes, '\zs')), ''), '\v(.)\1+', '\1', 'g')
+        " Loop over sorted/uniquified mode chars.
+        for mode in split(modes, '\zs')
+            if mode !~ '[' . valid_modes . ']'
+                " Differentiate between weird mode and one that's simply not valid for
+                " this command: e.g., 'w' is not a valid mode for *any* sexp commands, but
+                " 'x' may or may not be valid for this particular command.
+                if mode !~ '[xno]'
+                    throw printf("sexp-error: Invalid mode `%s'", mode)
+                endif
+                if stridx(ignored_modes, mode) < 0
+                    let ignored_modes .= mode
+                endif
+            endif
+            " We have a valid mode, but has it already been specified for this plug?
+            " Design Decision: Treat only a conflicting specification (i.e., different
+            " LHS's) as error.
+            if has_key(maps, mode) && lhs != maps[mode]
+                throw printf("sexp-error: Conflicting LHSs for mode %s: old=%s new=%s",
+                    \ mode, maps[mode], lhs)
+            endif
+            " We have a valid, non-conflicting mode spec.
+            let maps[mode] = lhs
+        endfor
+    endfor
+    return [maps, ignored_modes]
 endfunction
 
 " vim:ts=4:sw=4:et:tw=90

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -41,7 +41,7 @@ function! s:configure_repeat(plug_name, opmode, count)
             \ . " operators do not support counts and Vim multiplies the motion/object"
             \ . " count by the operator count. It's best to provide counts only to"
             \ . " motion/object commands.", {'once': 'operator counts'})
-        call sexp#warn#dbg("Counts mismatch: operator: %d operand: %d", op_info.cnt, a:count)
+        "call sexp#warn#dbg("Counts mismatch: operator: %d operand: %d", op_info.cnt, a:count)
     endif
     " If sexp operator in progress, use cached v:register.
     " Design Decision: Always pass register, even if unnamed.
@@ -58,16 +58,16 @@ function! s:configure_repeat(plug_name, opmode, count)
         " Note: If the motion/object for a sexp operator is not a sexp motion/object, we
         " won't get here, so RepFn won't be set and repeat won't be configured. This is an
         " inherent limitation.
-        call sexp#warn#dbg(
-            \ "Setting op_ipg.RepFn for %s with seq=%s reg=%s", a:plug_name, seq, reg)
+        "call sexp#warn#dbg(
+        "    \ "Setting op_ipg.RepFn for %s with seq=%s reg=%s", a:plug_name, seq, reg)
         let op_info.RepFn = RepFn
         " Record the fact that the operator motion/object is provided by sexp, as this
         " has implications for range handling.
         let op_info.motion = a:plug_name
     else
         " No need to defer setting repeat.
-        call sexp#warn#dbg(
-            \ "non-deferred repeat#set on %s with seq=%s reg=%s", a:plug_name, seq, reg)
+        "call sexp#warn#dbg(
+        "    \ "non-deferred repeat#set on %s with seq=%s reg=%s", a:plug_name, seq, reg)
         call RepFn()
     endif
 endfunction
@@ -85,16 +85,15 @@ function! s:opfunc(mode, name, cnt, expr, ...)
         if op[0] == 'g'
             let &opfunc = Fn
             " Cache the operator for repeat mechanism.
-            call sexp#warn#dbg("Caching OP")
+            "call sexp#warn#dbg("Caching OP")
             call s:OP_cache(a:name, a:cnt)
         else
             " Cache operator and configure TextYankPost autocmd.
-            call sexp#warn#dbg("Calling OP_setup()")
+            "call sexp#warn#dbg("Calling OP_setup()")
             call s:OP_setup(Fn, a:name, a:cnt)
         endif
         return op
     endif
-    call sexp#warn#dbg("!!!getpos(\"']\")=%s", string(getpos("']")))
     call sexp#pre_op(a:mode, a:name)
     let op_info = s:OP_get()
     " The callback function that completes the operation was packaged as the first
@@ -106,12 +105,12 @@ function! s:opfunc(mode, name, cnt, expr, ...)
     let inclusive = op[0] == 'g' ? -1 : a:000[3]
     try
         " Note: The Fn callback contains everything it needs but type.
-        call sexp#warn#dbg("Invoking the sexp op callback... %s ']=%s '>=%s",
-            \ string(s:OP), string(getpos("']")), string(getpos("'>")))
+        "call sexp#warn#dbg("Invoking the sexp op callback... %s ']=%s '>=%s",
+        "    \ string(s:OP), string(getpos("']")), string(getpos("'>")))
         call Fn(type, inclusive, op_info.motion)
         let RepFn = get(s:OP, 'RepFn', v:null)
         if type(RepFn) == v:t_func
-            call sexp#warn#dbg("Invoking RepFn()")
+            "call sexp#warn#dbg("Invoking RepFn()")
             call RepFn()
         endif
     finally
@@ -160,7 +159,7 @@ function! sexp#plug#wrapper(flags, mapmode, name, rhs)
     if !a:flags.asexpr
         call sexp#pre_op(a:mapmode[0], a:name)
     endif
-    call sexp#warn#dbg("sexp#plug#wrapper: %s: OP=%s", a:name, string(get(s:, 'OP', {})))
+    "call sexp#warn#dbg("sexp#plug#wrapper: %s: OP=%s", a:name, string(get(s:, 'OP', {})))
     try
         " Caveat: Can't set marks in an <expr> mapping. If it's necessary, the opfunc
         " should save the old '` and restore it at completion of operation.
@@ -213,7 +212,7 @@ endfunction
 function! s:OP_cleanup()
     let &report = s:OP.report_save
     let s:OP = {}
-    call sexp#warn#dbg("OP_cleanup: mode=%s", mode(1))
+    "call sexp#warn#dbg("OP_cleanup: mode=%s", mode(1))
     au! SexpTextYankPost
 endfunction
 
@@ -251,7 +250,7 @@ function! s:OP_setup(Fn, name, cnt)
     " Temporarily set 'report' to something very large to prevent "yanked N lines" msgs.
     " Caveat: Must ensure original value (saved in s:OP) is restored by cleanup.
     set report=1000000
-    call sexp#warn#dbg("Configuring TYP callback OP=%s", string(s:OP))
+    "call sexp#warn#dbg("Configuring TYP callback OP=%s", string(s:OP))
     augroup SexpTextYankPost
         au! TextYankPost <buffer> ++once call <SID>OP_TextYankPost()
         " This one may fire before TYP, but if it fires when we're in normal mode, the

--- a/autoload/sexp/plug.vim
+++ b/autoload/sexp/plug.vim
@@ -1,0 +1,137 @@
+" This autoload module contains infrastructure/boilerplate that facilitates the execution
+" of plug mappings in a consistent manner.
+
+" Autoload and detect repeat.vim
+" Note: Keeping this in an autoload module avoids loading repeat module before it's
+" needed.
+silent! call repeat#set('')
+let s:have_repeat_set = exists('*repeat#set')
+
+" This function is a wrapper for sexp <Plug> commands used to ensure common boilerplate
+" runs at the appropriate time. It is invoked by the <Plug> mappings defined by
+" s:defplug() in the plugin script; thus, it will not force load of this autoload file
+" until a mapping is invoked.
+" Note: If we eventually split the functions in this file across more autoload scripts, it
+" might make sense to move this into a dedicated autoload module to avoid loading
+" functionality unnecessarily.
+" Several points to note...
+" RE: vv
+"   Due to a ?bug? in vim, we need to set curwin->w_curswant to the
+"   current cursor position by entering and exiting character-wise visual
+"   mode before completing an operator-pending command so that the cursor
+"   returns to its original position after an = command.
+" RE: v:count
+"   Currently, the count arg is captured before this function escapes to normal mode (if
+"   it does). In particular, neither <cmd> nor :<c-u> (even from visual mode) reset
+"   v:count, so we should never need to use v:prevcount.
+" TODO: Consider making this an autoload function like s:opfunc().
+function! sexp#plug#wrapper(flags, mapmode, name, count, rhs)
+    let opmode = a:mapmode[0] ==# 'o'
+    " Assumption: v:count does not change before this call.
+    call sexp#ensure_normal_mode()
+    " Caveat: For a sexp operator (e.g., replace_op), the {pre,post}_op wrapper
+    " invocations are deferred till operation completion.
+    if !a:flags.asexpr
+        call sexp#pre_op(a:mapmode[0], a:name)
+    endif
+    try
+        " Caveat: Can't set marks in an <expr> mapping. If it's necessary, the opfunc
+        " should save the old '` and restore it at completion of operation.
+        if !a:flags.nojump && !a:flags.asexpr
+            " TODO: This may need special handling with g:sexp_regput{_into}_curpos == 2.
+            exe "normal! " . (opmode ? 'vv' : '') . "m`"
+        endif
+        " repeat (register) setup (prolog)
+        " Note: Only sexp motions/objects (not sexp operators such as replace) should be repeated.
+        " Rationale: The repeat sequence concatenates the operator and motion/object; an
+        " operator by itself is nothing until combined with a target.
+        if !a:flags.asexpr && a:flags.repeat && s:have_repeat_set
+            " Note: The identical sequence should be used for both setreg() and set().
+            " FIXME: Reevaluate the assumptions made wrt repeat: e.g., should we simply
+            " assume this is operator-pending map? Also, need to configure repeat for sexp
+            " operators in opfunc once the motion/object is known.
+            " Special Case: If the operator was c (change), the dot register should
+            " contain the text we wish to insert over the sexp motion/object. The
+            " repeat effectively does `c<Plug>(some_sexp_object)', leaving us in
+            " insert mode; thus, we use `<C-R>' to insert the dot register, then use
+            " `<C-\><C-n>' to ensure our return to normal mode doesn't trigger a beep.
+            let repseq = opmode && v:operator ==? "c"
+                \ ? v:operator . "\<Plug>(" . a:name . ")\<C-r>.\<C-Bslash>\<C-n>"
+                \ : v:operator . "\<Plug>(" . a:name . ")"
+            " The repeat plugin defaults to unnamed register, so don't bother setting
+            " unless current register is named.
+            if v:register != '"'
+                call repeat#setreg(repseq, v:register)
+            endif
+        endif
+        " Note: v:count may already have been reset (and transferred to v:prevcount);
+        " fortunately, we snapshotted it in the call to this function, so use that.
+        let rhs = substitute(a:rhs, '\<v:\%(prev\)count\>', a:count, 'g')
+        if a:flags.asexpr
+            return call('s:opfunc', [a:mapmode[0], a:name, rhs])
+        else
+            exe 'call' rhs
+        endif
+        " repeat setup (epilog)
+        if !a:flags.asexpr && a:flags.repeat && s:have_repeat_set
+            call repeat#set(repseq, a:count)
+        endif
+    finally
+        if !a:flags.asexpr
+            call sexp#post_op(a:mapmode[0], a:name)
+        endif
+    endtry
+endfunction
+
+function! s:opfunc(mode, name, expr, ...)
+    if !a:0
+        " Let the operator function provide a stateful callback to be invoked to complete
+        " the operation.
+        " Note: Since the arguments required by the callback function are embedded in the
+        " a:expr string, we can't really access them, but we don't really need to, so long
+        " as the initial invocation packages up the required args with function().
+        let Fn = eval(a:expr)
+        " FIXME: This will get the extra type arg, which we need to pass to replace_op.
+        let &opfunc = function('s:opfunc', [a:mode, a:name, a:expr, Fn])
+        return 'g@'
+    endif
+    call sexp#pre_op(a:mode, a:name)
+    " The callback function that completes the operation was packaged as the first
+    " variadic arg in the rhs of the assignment to &opfunc above. The type flag is
+    " provided by Vim's opfunc engine.
+    let [Fn, type] = a:000
+    try
+        " Note: The Fn callback contains everything it needs but type.
+        call Fn(type)
+    finally
+        call sexp#post_op(a:mode, a:name)
+    endtry
+endfunction
+
+" Calls repeat#set() and registers a one-time CursorMoved handler to correctly
+" set the value of g:repeat_tick.
+"
+" cf. https://github.com/tpope/vim-repeat/issues/8#issuecomment-13951082
+function! s:repeat_set(buf, count)
+    call repeat#set(a:buf, a:count)
+    " TODO: Should probably remove this autocmd after validating the new
+    " sexp#plug#wrapper().
+    " Rationale: The purpose of the autocmd is to set g:repeat_tick *after* the sexp
+    " command has completed, but sexp#plug#wrapper() already does this. Previously, the
+    " autocmd was needed because repeat#set was called *before* the sexp command ran.
+    " Note: Another problem with using the CursorMoved autocmd this way is that the Vim
+    " help says "Not always triggered... while executing commands in a script file", which
+    " doesn't sound like a firm guarantee, and we definitely don't want g:repeat_tick set
+    " before the sexp command completes.
+    augroup sexp_repeat
+        autocmd!
+        " FIXME: Remove the debug stuff after testing.
+        autocmd CursorMoved <buffer>
+                    \ if b:changedtick != g:repeat_tick |
+                    \ echomsg "Oops!" b:changedtick "!=" g:repeat_tick |
+                    \ endif |
+                    \ let g:repeat_tick = b:changedtick | autocmd! sexp_repeat
+    augroup END
+endfunction
+
+" vim:ts=4:sw=4:et:tw=90

--- a/autoload/sexp/warn.vim
+++ b/autoload/sexp/warn.vim
@@ -1,0 +1,88 @@
+" This autoload module contains shared functions that might be needed by the plugin script
+" (e.g., for presenting warnings to user), but which needn't trigger load of the much
+" larger autoload/sexp.
+" TODO: Consider renaming this autoload module to ui or some such.
+
+" UTILITIES
+" Return a composite string that contains all the inputs and preserves the boundaries
+" between them: e.g., H("foo", "bar") is different from H("fo", "obar"), etc...
+function! sexp#warn#join_hashable(...)
+    " Separate elements with *untranslated* Ctrl-A.
+    return join(map(a:000[:], "strtrans(v:val)"), "\x01")
+endfunction
+
+""" USER INTERFACE {{{1
+
+" Display warning with requested highlighting.
+function! s:warnmsg_impl(s, hl)
+    try
+        exe 'echohl' a:hl
+        echomsg a:s
+    finally
+        echohl None
+    endtry
+endfunction
+
+" Called by client to display warning to user via echomsg with appropriate highlighting
+" (WarningMsg unless optional error flag is provided, in which case, use ErrorMsg).
+" If we're inside {pre,post}_op() calls, there will be an active message queue, and we
+" simply add the msg to it; otherwise (e.g., called from insert-mode command, which
+" currently doesn't use the {pre,post}_op() mechanism), we echo the msg immediately.
+" Rationale: Deferring the echomsg call is preferable because it greatly increases the
+" probability it will be seen by the user before being overwritten (e.g., by an already
+" pending redraw).
+" TODO: Support printf-style formatting.
+function! sexp#warn#msg(s, ...)
+    let hl = a:0 && a:1 ? 'ErrorMsg' : 'WarningMsg'
+    if exists('s:msg_q')
+        " Add to queue.
+        call add(s:msg_q, {'hl': hl, 'msg': a:s})
+    else
+        " Don't defer: display now.
+        call s:warnmsg_impl(a:s, hl)
+    endif
+endfunction
+
+" Wrapper for sexp#warn#msg(), which takes an arbitrary key representing the warning and
+" ensures the warning is displayed only once per buffer.
+" -- Optional Arg(s) --
+" a:1  1 if warning should be displayed with error highlighting
+fu! sexp#warn#msg_once(key, msg, ...)
+    let b:sexp_did_warn = get(b:, 'sexp_did_warn', {})
+    if get(b:sexp_did_warn, a:key, 0)
+        " Already warned! Do nothing.
+        return
+    endif
+    call sexp#warn#msg(a:msg, a:0 && !!a:1)
+    " Make sure we don't display this one again for this buffer.
+    let b:sexp_did_warn[a:key] = 1
+endfu
+
+" Display to user any messages queued during command execution.
+function! sexp#warn#echo_queued_msgs()
+    if empty(get(s:, 'msg_q', []))
+        return
+    endif
+    " Perform any pending redraws now, to ensure they won't overwrite our message(s).
+    redraw
+    " Send all queued msgs.
+    for m in s:msg_q
+        " Get msg and highlight, noting that queue entry can be either a string (defaults
+        " to warning) or a dict.
+        let [msg, hl] = type(m) == type("") ? [m, 'WarningMsg'] : [m.msg, m.hl]
+        call s:warnmsg_impl(msg, hl)
+    endfor
+    " Remove the processed msgs, but don't delete the queue, as only the creator knows
+    " whether more messages may be queued.
+    let s:msg_q = []
+endfunction
+
+function! sexp#warn#create_msg_q()
+    let s:msg_q = []
+endfunction
+
+function! sexp#warn#destroy_msg_q()
+    unlet! s:msg_q
+endfunction
+
+" vim:ts=4:sw=4:et:tw=90

--- a/autoload/sexp/warn.vim
+++ b/autoload/sexp/warn.vim
@@ -3,8 +3,8 @@
 " larger autoload/sexp.
 " TODO: Consider renaming this autoload module to ui or some such.
 
-" Note: Do not uncomment the luaeval in this function, as it requires a logging module
-" that's not currently part of the plugin.
+" Caveat: Do not set g:sexp_enable_debug_output in release contexts, as the luaeval
+" requires a logging module that's not currently part of the plugin.
 " TODO: Eventually, remove it and all commented calls to it.
 fu! sexp#warn#dbg(...)
     if get(g:, 'sexp_enable_debug_output', 0)
@@ -12,15 +12,13 @@ fu! sexp#warn#dbg(...)
     endif
 endfu
 
-" UTILITIES
 " Return a composite string that contains all the inputs and preserves the boundaries
 " between them: e.g., H("foo", "bar") is different from H("fo", "obar"), etc...
+" TODO: Refactor of sexp#warn#msg() obviates need for this. Remove...
 function! sexp#warn#join_hashable(...)
     " Separate elements with *untranslated* Ctrl-A.
     return join(map(a:000[:], "strtrans(v:val)"), "\x01")
 endfunction
-
-""" USER INTERFACE {{{1
 
 " Display warning with requested highlighting.
 function! s:warnmsg_impl(s, hl)
@@ -32,16 +30,17 @@ function! s:warnmsg_impl(s, hl)
     endtry
 endfunction
 
-" Called by client to display warning to user via echomsg with appropriate highlighting
-" (WarningMsg unless optional error flag is provided, in which case, use ErrorMsg).
-" If we're inside {pre,post}_op() calls, there will be an active message queue, and we
-" simply add the msg to it; otherwise (e.g., called from insert-mode command, which
-" currently doesn't use the {pre,post}_op() mechanism), we echo the msg immediately.
+" Display warning to user via echomsg (using message queue if active) with appropriate
+" highlighting (ErrorMsg if optional error flag is provided, else WarningMsg).
+" Message Queue Logic: If we're inside {pre,post}_op() calls, there will be an active
+" message queue, and we simply add the msg to it, thereby deferring its display till
+" command has completed; otherwise (e.g., called from insert-mode command, which currently
+" doesn't use the {pre,post}_op() mechanism), we echo the msg immediately.
 " Rationale: Deferring the echomsg call is preferable because it greatly increases the
 " probability it will be seen by the user before being overwritten (e.g., by an already
 " pending redraw).
 " TODO: Support printf-style formatting.
-function! sexp#warn#msg(s, ...)
+function! s:display_msg(s, ...)
     let hl = a:0 && a:1 ? 'ErrorMsg' : 'WarningMsg'
     if exists('s:msg_q')
         " Add to queue.
@@ -52,20 +51,43 @@ function! sexp#warn#msg(s, ...)
     endif
 endfunction
 
-" Wrapper for sexp#warn#msg(), which takes an arbitrary key representing the warning and
-" ensures the warning is displayed only once per buffer.
-" TODO: Consider making the key optional, defaulting to msg itself.
-" -- Optional Arg(s) --
-" a:1  1 if warning should be displayed with error highlighting
-fu! sexp#warn#msg_once(key, msg, ...)
-    let b:sexp_did_warn = get(b:, 'sexp_did_warn', {})
-    if get(b:sexp_did_warn, a:key, 0)
-        " Already warned! Do nothing.
-        return
+" Display provided message with :echomsg, taking flags in options dict into account.
+" -- Option Dict Keys --
+" once:    either explicit enable/disable requesting "once-only" msg display (in which
+"          case, the msg itself is used as uniqueness key) or an object used to generate
+"          uniqueness key.
+"          Logic: Treat things that look like explicit enable/disable flags (e.g.,
+"          boolean/null/0/1) specially. Also, since empty things aren't effective
+"          uniqueness keys, treat them as false.
+"          Design Decision: 0 and 1 are the only numbers treated as boolean.
+"          Rationale: Legacy (pre v:{true,false}) usage
+" session: (applies only in "once-only" mode) true for once-per-session, false (or
+"          omitted) for once-per-buffer
+" err:     true requests ErrorMsg highlighting
+fu! sexp#warn#msg(msg, ...)
+    let opts = extend(
+        \ {'once': v:null, 'session': 0, 'err': 0},
+        \ a:0 ? a:1 : {}, "force")
+    let key =
+        \ empty(opts.once) || opts.once is v:null || opts.once is v:false
+        \ ? v:null
+        \ : opts.once is v:true || opts.once is 1
+        \ ? msg
+        \ : string(opts.once)
+    " Assumption: A non-empty key implies once-only.
+    if !empty(key)
+        let scope = opts.session ? s: : b:
+        " Auto-vivify if necessary.
+        let scope.sexp_did_warn = get(scope, 'sexp_did_warn', {})
+        if get(scope.sexp_did_warn, key, 0)
+            " Already warned! Do nothing.
+            return
+        endif
+        " Make sure we don't display this one again for this buffer.
+        let scope.sexp_did_warn[key] = 1
     endif
-    call sexp#warn#msg(a:msg, a:0 && !!a:1)
-    " Make sure we don't display this one again for this buffer.
-    let b:sexp_did_warn[a:key] = 1
+    " Arrival here means we're not skipping output due to "once-only" mechanism.
+    call s:display_msg(a:msg, opts.err)
 endfu
 
 " Display to user any messages queued during command execution.

--- a/autoload/sexp/warn.vim
+++ b/autoload/sexp/warn.vim
@@ -7,7 +7,9 @@
 " that's not currently part of the plugin.
 " TODO: Eventually, remove it and all commented calls to it.
 fu! sexp#warn#dbg(...)
-    call luaeval("require'dp':get'sexp':logf(unpack(_A))", a:000)
+    if get(g:, 'sexp_enable_debug_output', 0)
+        call luaeval("require'dp':get'sexp':logf(unpack(_A))", a:000)
+    endif
 endfu
 
 " UTILITIES
@@ -52,6 +54,7 @@ endfunction
 
 " Wrapper for sexp#warn#msg(), which takes an arbitrary key representing the warning and
 " ensures the warning is displayed only once per buffer.
+" TODO: Consider making the key optional, defaulting to msg itself.
 " -- Optional Arg(s) --
 " a:1  1 if warning should be displayed with error highlighting
 fu! sexp#warn#msg_once(key, msg, ...)

--- a/autoload/sexp/warn.vim
+++ b/autoload/sexp/warn.vim
@@ -3,6 +3,13 @@
 " larger autoload/sexp.
 " TODO: Consider renaming this autoload module to ui or some such.
 
+" Note: Do not uncomment the luaeval in this function, as it requires a logging module
+" that's not currently part of the plugin.
+" TODO: Eventually, remove it and all commented calls to it.
+fu! sexp#warn#dbg(...)
+    call luaeval("require'dp':get'sexp':logf(unpack(_A))", a:000)
+endfu
+
 " UTILITIES
 " Return a composite string that contains all the inputs and preserves the boundaries
 " between them: e.g., H("foo", "bar") is different from H("fo", "obar"), etc...

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -892,39 +892,49 @@ LIST MANIPULATION (normal, visual) ~
 <
 REGISTER PUT (PASTE) COMMANDS (normal, visual) ~
 
-TODO  ~
-Finish adding smart register paste section...
+All of the register put (paste) commands accept an optional register name via
+the standard Vim mechanism (e.g., `"ap` to put from the `"a` register), as
+well as an optional [count] whose usage is documented with the corresponding
+command. Commands that replace existing elements have distinct `p` and `P`
+variants: by analogy with builtin `p` and `P`, the former updates the unnamed
+register (`@"`); the latter does not. Finally, all put (paste) commands
+automatically reindent the affected region.
 
 Put register before/after (normal)  ~
 
-P                                                    *<Plug>(sexp_put_before)*
-p                                                     *<Plug>(sexp_put_after)*
+["x]P                                                *<Plug>(sexp_put_before)*
+["x]p                                                 *<Plug>(sexp_put_after)*
+        Put [count] copies of register x before (`P`) or after (`p`) the
+        current element.
 
 Replace element with register (normal)  ~
 
-Design Decision Needed: Should we suport support distinct p and P versions by
-analogy with builtin visual-mode P (which doesn't update the unnamed
-register).
-
-Design Decision Needed: Ok to commandeer ]p and/or [p for defaults?
-
-gP                                                      *<Plug>(sexp_replace)*
-gp                                                      *<Plug>(sexp_replace)*
+["x]gP                                                *<Plug>(sexp_replace_P)*
+["x]gp                                                  *<Plug>(sexp_replace)*
+        Replace the current element with [count] copies of register x. With
+        `gP`, the unnamed register (`@"`) is not updated.
 
 Replace selection with register (visual)  ~
 
-Design Decision: Should be safe to commandeer builtins for this.
-Rationale: Plugin behavior is closer to builtin than for the other put
-commands.
+["x]P                                                 *<Plug>(sexp_replace_P)*
+["x]p                                                   *<Plug>(sexp_replace)*
+        Replace the current visual selection with [count] copies of register
+        x. With `P`, the unnamed register (`@"`) is not updated.
 
-P                                                       *<Plug>(sexp_replace)*
-p                                                       *<Plug>(sexp_replace)*
+Put register into list (normal)  ~
 
-Replace selection with register (visual)  ~
+["x]<M-p>                                           *<Plug>(sexp_put_at_head)*
+["x]<M-P>                                           *<Plug>(sexp_put_at_tail)*
+        Put register x into the current list, making it the [count]th child
+        from head (`<M-p>`) or tail (`<M-P>`).
 
-<LocalLeader>P                                      *<Plug>(sexp_put_at_head)*
-<LocalLeader>p                                      *<Plug>(sexp_put_at_tail)*
+Replace child with register (normal)  ~
 
+["x]<LocalLeader>p                               *<Plug>(sexp_replace_at_head)*
+["x]<LocalLeader>P                               *<Plug>(sexp_replace_at_tail)*
+        Replace the [count]th child from head (`<LocalLeader>p`) or tail
+        (`<LocalLeader>P>`) with register x. With `<LocalLeader>P`, the
+        unnamed register (`@"`) is not updated.
 
 INSERT MODE MAPPINGS (insert, optional) ~
 
@@ -1410,7 +1420,7 @@ Note: To unbind a command, simply set its <lhs> to an empty string.
             \ 'sexp_move_to_next_top_element':  ']]',
             \ 'sexp_select_prev_element':       '[e',
             \ 'sexp_select_next_element':       ']e',
-            \ 'sexp_indent':                    '==',
+            \ 'sexp_indent':                    {'n': '==', 'x': '='},
             \ 'sexp_indent_top':                '=-',
             \ 'sexp_indent_and_clean':          '<M-=>',
             \ 'sexp_indent_and_clean_top':      '<M-->',
@@ -1448,6 +1458,14 @@ Note: To unbind a command, simply set its <lhs> to an empty string.
             \ 'sexp_emit_tail_element':         '<M-S-k>',
             \ 'sexp_capture_prev_element':      '<M-S-h>',
             \ 'sexp_capture_next_element':      '<M-S-l>',
+            \ 'sexp_put_before':                {'n': 'P'},
+            \ 'sexp_put_after':                 {'n': 'p'},
+            \ 'sexp_replace':                   {'n': 'gp', 'x': 'p'},
+            \ 'sexp_replace_P':                 {'n': 'gP', 'x': 'P'},
+            \ 'sexp_put_at_head':               {'n': '<M-p>'},
+            \ 'sexp_put_at_tail':               {'n': '<M-P>'},
+            \ 'sexp_replace_at_head':           {'n': '<LocalLeader>p'},
+            \ 'sexp_replace_at_tail':           {'n': '<LocalLeader>P'},
             \ }
 <
 Override Example: ~
@@ -1502,6 +1520,7 @@ empty string:
 Next, write a function that will create your desired |:map-local| bindings.
 The following example includes every default mapping in vim-sexp. You can
 copy, paste, and edit this example to taste.
+FIXME: Add new commands to the list!
 >
         function! s:vim_sexp_mappings()
             xmap <silent><buffer> af              <Plug>(sexp_outer_list)

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -897,8 +897,8 @@ Finish adding smart register paste section...
 
 Put register before/after (normal)  ~
 
-<LocalLeader>P                          *<Plug>(sexp_put_before)*
-<LocalLeader>p                          *<Plug>(sexp_put_after)*
+P                                                    *<Plug>(sexp_put_before)*
+p                                                     *<Plug>(sexp_put_after)*
 
 Replace element with register (normal)  ~
 
@@ -908,8 +908,8 @@ register).
 
 Design Decision Needed: Ok to commandeer ]p and/or [p for defaults?
 
-<M-P>                                   *<Plug>(sexp_replace)*
-<M-p>                                   *<Plug>(sexp_replace)*
+gP                                                      *<Plug>(sexp_replace)*
+gp                                                      *<Plug>(sexp_replace)*
 
 Replace selection with register (visual)  ~
 
@@ -917,13 +917,13 @@ Design Decision: Should be safe to commandeer builtins for this.
 Rationale: Plugin behavior is closer to builtin than for the other put
 commands.
 
-P                                       *<Plug>(sexp_replace)*
-p                                       *<Plug>(sexp_replace)*
+P                                                       *<Plug>(sexp_replace)*
+p                                                       *<Plug>(sexp_replace)*
 
 Replace selection with register (visual)  ~
 
-P                                                   *<Plug>(sexp_put_at_head)*
-p                                                   *<Plug>(sexp_put_at_tail)*
+<LocalLeader>P                                      *<Plug>(sexp_put_at_head)*
+<LocalLeader>p                                      *<Plug>(sexp_put_at_tail)*
 
 
 INSERT MODE MAPPINGS (insert, optional) ~

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -893,10 +893,38 @@ LIST MANIPULATION (normal, visual) ~
 REGISTER PUT (PASTE) COMMANDS (normal, visual) ~
 
 TODO  ~
-Add smart register paste section...
+Finish adding smart register paste section...
+
+Put register before/after (normal)  ~
 
 <LocalLeader>P                          *<Plug>(sexp_put_before)*
 <LocalLeader>p                          *<Plug>(sexp_put_after)*
+
+Replace element with register (normal)  ~
+
+Design Decision Needed: Should we suport support distinct p and P versions by
+analogy with builtin visual-mode P (which doesn't update the unnamed
+register).
+
+Design Decision Needed: Ok to commandeer ]p and/or [p for defaults?
+
+<M-P>                                   *<Plug>(sexp_replace)*
+<M-p>                                   *<Plug>(sexp_replace)*
+
+Replace selection with register (visual)  ~
+
+Design Decision: Should be safe to commandeer builtins for this.
+Rationale: Plugin behavior is closer to builtin than for the other put
+commands.
+
+P                                       *<Plug>(sexp_replace)*
+p                                       *<Plug>(sexp_replace)*
+
+Replace selection with register (visual)  ~
+
+P                                                   *<Plug>(sexp_put_at_head)*
+p                                                   *<Plug>(sexp_put_at_tail)*
+
 
 INSERT MODE MAPPINGS (insert, optional) ~
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -805,6 +805,12 @@ LIST MANIPULATION (normal, visual) ~
         automatic re-indent. If you dislike this behavior, see
         |sexp-auto-indent|.
 
+REGISTER PUT (PASTE) COMMANDS (normal, visual) ~
+
+<LocalLeader>W                          *<Plug>(sexp_round_head_wrap_element)*
+<LocalLeader>w                          *<Plug>(sexp_round_tail_wrap_element)*
+<LocalLeader>e[                        *<Plug>(sexp_square_head_wrap_element)*
+
 INSERT MODE MAPPINGS (insert, optional) ~
 
 (                                          *<Plug>(sexp_insert_opening_round)*
@@ -854,6 +860,7 @@ INSERT MODE MAPPINGS (insert, optional) ~
         regular expression, comment, or character atom.
 
         Normal backspace otherwise.
+
 
 AUTO INDENT                                                 *sexp-auto-indent*
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -903,11 +903,9 @@ disctinct command and operator variants: the commands operate on a target
 determined by the cursor location; the operators give you "cybernetic arms",
 which can put or replace forms at a distance. The feature is highly
 customizable, with option names bearing the "sexp_regput" prefix. Even if you
-normally stick with plugin defaults, you should definitely look at the
-following sections if you wish to get the most out of this feature:
-
-        |sexp-regput-telescopic-motion|       replace-at-a-distance
-        |sexp-regput-overriding-builtins|     more convenient mappings
+normally stick with plugin defaults, you should definitely read the section
+|sexp-regput-telescopic-motion| to ensure you get the most out of this
+feature.
 
 Overview  ~
 All of the register put (paste) commands and operators accept an optional
@@ -930,10 +928,10 @@ with the "." command. Smart-paste operators can be repeated if and only if
 their operand is a sexp object/motion. (This is an inherent limitation, due to
 the fact that Vim's API does not expose the object/motion to the 'opfunc'.)
 
-Note: Although most users will probably wish to remap the builtin put
-commands to vim-sexp's smarter, Lisp-aware counterparts, the builtins will not
-be overridden without an explicit request via one of the methods discussed in
-|sexp-regput-overriding-builtins|.
+Note: The default vim-sexp configuration assigns smart-paste functionality to
+builtin commands `p`, `P`, `gp` and `gP`, but this is customizable. For
+details, see |sexp-regput-builtin-overrides|.
+
 
 Put register before/after (normal)  ~
                                                                     *sexp-put*
@@ -1809,14 +1807,6 @@ full (level 2) optimization.
 >
         " Default
         let g:sexp_aligncom_density_weight = 5
-<
-                                             *g:sexp_regput_override_builtins*
-When this is set, several of Vim's builtin put operators are remapped to
-vim-sexp's "smart paste" commands.
-For details, see |sexp-regput-overriding-builtins|.
->
-        " Default
-        let g:sexp_regput_override_builtins = 1
 <
                                                         *g:sexp_regput_curpos*
 Determines where cursor is placed after a smart-paste command that targets the

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -997,11 +997,11 @@ Normal  ~
 
 Put register into current list (normal)  ~
 
-["x] <LocalLeader>[p                                *<Plug>(sexp_put_at_head)*
-["x] <LocalLeader>]p                                *<Plug>(sexp_put_at_tail)*
+["x] <LocalLeader><p                                *<Plug>(sexp_put_at_head)*
+["x] <LocalLeader>>p                                *<Plug>(sexp_put_at_tail)*
         Put register `x` into the current list, just before the `[count]`th
-        child from head (`<LocalLeader>[p`) or after the `[count]`th child
-        from tail (`<LocalLeader>]p`).
+        child from head (`<LocalLeader><p`) or after the `[count]`th child
+        from tail (`<LocalLeader>>p`).
 
         Note: The mapping for this command is intentionally long (and
         inconvenient) since you can get the same behavior with the
@@ -1065,7 +1065,7 @@ Put operator (normal)  ~
 
         Examples:  ~
         1. `<piC`  Put before final element of current list
-                 Note: Equivalent to `2<LocalLeader>]p` (i.e., put into second
+                 Note: Equivalent to `2<LocalLeader>>p` (i.e., put into second
                  slot from tail of list)
         2. `>p3E`  Put after the second element beyond the current element
                  Note: `3E` is used instead of `2W` because the `W` motion is
@@ -2059,8 +2059,8 @@ Note: To unbind a command, simply set its <lhs> to an empty string.
             \                                    'n': '<LocalLeader><LocalLeader>P'},
             \ 'sexp_put_at_head':               '<p',
             \ 'sexp_put_at_tail':               '>p',
-            \ 'sexp_put_at_head':               '<LocalLeader>[p',
-            \ 'sexp_put_at_tail':               '<LocalLeader>]p',
+            \ 'sexp_put_at_head':               '<LocalLeader><p',
+            \ 'sexp_put_at_tail':               '<LocalLeader>>p',
             \ }
 <
 Override Example: ~

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -43,6 +43,7 @@ Note: Treesitter support has been tested by a handful of users, but if you
 notice any issues, please open an issue on Github.
 
 Installation ~
+                                                           *sexp-installation*
 
 Vim-sexp requires no installation beyond downloading the plugin into your
 'runtimepath', which can be done manually or with the aid of a plugin manager.

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -891,6 +891,7 @@ LIST MANIPULATION (normal, visual) ~
         (|) () () foo bar
 <
 REGISTER PUT ("SMART PASTE") COMMANDS (normal, visual) ~
+                                        *sexp-smart-paste* *sexp-register-put*
 
 All of the register put (paste) commands accept an optional register name via
 the standard Vim mechanism (e.g., `"ap` to put from the `"a` register), as
@@ -904,65 +905,64 @@ perform an automatic re-indent on a range whose size is determined by
 Put register before/after (normal)  ~
                                                                     *sexp_put*
 
-["x]P                                                *<Plug>(sexp_put_before)*
-["x]p                                                 *<Plug>(sexp_put_after)*
-        Put [count] copies of register x before (`P`) or after (`p`) the
-        current element; alternatively, works like "put register into list"
-        when the conditions in the following paragraph are met.
+["x]<LocalLeader>P                                   *<Plug>(sexp_put_before)*
+["x]<LocalLeader>p                                    *<Plug>(sexp_put_after)*
+        Put [count] copies of register x before (`<LocalLeader>P`) or after
+        (`<LocalLeader>p`) the current element; alternatively, works like "put
+        register into list" when the conditions in the following paragraph are
+        met.
 
         Special Behavior on List Brackets  ~
         By default, if this command is executed with the cursor on a list
         bracket (or the macro chars preceding an open), and the put direction
         is towards the list interior, it will be handled as the corresponding
         "put register into list" command:
-                p ==> |<Plug>(sexp_put_at_head)|
-                P ==> |<Plug>(sexp_put_at_tail)|
+                <LocalLeader>p ==> |<Plug>(sexp_put_at_head)|
+                <LocalLeader>P ==> |<Plug>(sexp_put_at_tail)|
         I.e., the register text will be inserted into the head or tail of the
-        list at an offset determined by [count]. If you do not like this
-        behavior, and want this command to treat lists just like regular
-        elements, simply set option *g:sexp_regput_bracket_is_target* to 0.
+        list at an offset determined by [count]. If you would prefer that this
+        command treat lists just like regular elements, simply set option
+        *g:sexp_regput_bracket_is_target* to 0.
 
         Note: If there is no current element, the register contents are put
         before or after the cursor position; moreover, there is a subtle
-        difference between `p` and `P` in this case: in particular, putting
-        _away from_ an adjacent element on the same line as the cursor forces
-        a line break between the put text and the adjacent element.
+        difference between `<LocalLeader>p` and `<LocalLeader>P` in this case:
+        in particular, putting _away from_ an adjacent element on the same
+        line as the cursor forces a line break between the put text and the
+        adjacent element.
 
-Replace element with register (normal)  ~
+Replace element/selection with register (normal, visual)  ~
 
-["x]gP                                                *<Plug>(sexp_replace_P)*
-["x]gp                                                  *<Plug>(sexp_replace)*
-        Replace the current element with [count] copies of register x. With
-        `gP`, the unnamed register (`@"`) is not updated.
-
-Replace selection with register (visual)  ~
-
-["x]P                                                 *<Plug>(sexp_replace_P)*
-["x]p                                                   *<Plug>(sexp_replace)*
-        Replace the current visual selection with [count] copies of register
-        x. With `P`, the unnamed register (`@"`) is not updated.
+["x]<M-P>                                             *<Plug>(sexp_replace_P)*
+["x]<M-p>                                               *<Plug>(sexp_replace)*
+        Replace the current element or visual selection with [count] copies of
+        register x, first expanding the visual selection to include all of any
+        partially selected elements. With `<M-P>`, the unnamed register (`@"`)
+        is not updated.
 
 Put register into list (normal)  ~
 
-["x]<M-p>                                           *<Plug>(sexp_put_at_head)*
-["x]<M-P>                                           *<Plug>(sexp_put_at_tail)*
+["x]<LocalLeader><p                                 *<Plug>(sexp_put_at_head)*
+["x]<LocalLeader>>p                                 *<Plug>(sexp_put_at_tail)*
         Put register x into the current list, making it the [count]th child
-        from head (`<M-p>`) or tail (`<M-P>`).
+        from head (`<LocalLeader><p`) or tail (`<LocalLeader>>p`).
 
         See also |sexp-regput-definition-of-current-list|.
 
 Replace child with register (normal)  ~
 
-["x]<LocalLeader>p                               *<Plug>(sexp_replace_at_head)*
-["x]<LocalLeader>P                               *<Plug>(sexp_replace_at_tail)*
-        Replace the [count]th child from head (`<LocalLeader>p`) or tail
-        (`<LocalLeader>P>`) with register x. With `<LocalLeader>P`, the
-        unnamed register (`@"`) is not updated.
+["x]<LocalLeader>[p                              *<Plug>(sexp_replace_at_head)*
+["x]<LocalLeader>]p                              *<Plug>(sexp_replace_at_tail)*
+["x]<LocalLeader>[P                            *<Plug>(sexp_replace_at_head_P)*
+["x]<LocalLeader>]P                            *<Plug>(sexp_replace_at_tail_P)*
+        Replace the [count]th child from head (`<LocalLeader>[p`) or tail
+        (`<LocalLeader>]p`) with register x. With the versions ending in `P`,
+        the unnamed register (`@"`) is not updated.
 
         See also |sexp-regput-definition-of-current-list|.
 
                                        *sexp-regput-definition-of-current-list*
-Definition of "current list"  ~
+Definition of "Current List"  ~
 By default, the preceding two commands treat a list whose bracket or macro
 char is under the cursor as the current list. Some users may prefer that a
 list be treated as a simple child element when the cursor is positioned on one
@@ -973,6 +973,33 @@ containing list is the target of the put. If you wish to enable this approach,
 set |g:sexp_regput_bracket_is_child| to 1.
 Note: Since a toplevel list has no parent, this option does not apply when the
 cursor is on the terminals of a toplevel list.
+
+IMPORTANT NOTE: |g:sexp_regput_bracket_is_child| is not yet supported.
+
+                                                *sexp-regput-builtin-overrides*
+Overriding Builtin Put Commands  ~
+You may not have much need for Vim's builtin put operators once you become
+comfortable with vim-sexp's "smart paste" commands. Since the default mappings
+are not as convenient as builtins, you may wish to remap Vim's builtin put
+operators to vim-sexp smart paste commands. The following snippet is provided
+to facilitate this. Either copy it into your |g:sexp_mappings| list to serve
+as a basis for further customization or set |g:sexp_regput_override_builtins|
+to use it as-is.
+>
+    \ 'sexp_put_before':                   {'n': 'P'},
+    \ 'sexp_put_after':                    {'n': 'p'},
+    \ 'sexp_replace':                      {'n': '<M-p>', 'x': 'p'},
+    \ 'sexp_replace_P':                    {'n': '<M-P>', 'x': 'P'},
+    \ 'sexp_put_at_head':                  {'n': '<p'},
+    \ 'sexp_put_at_tail':                  {'n': '>p'},
+    \ 'sexp_replace_at_head':              {'n': '[p'},
+    \ 'sexp_replace_at_tail':              {'n': ']p'},
+    \ 'sexp_replace_at_head_P':            {'n': '[P'},
+    \ 'sexp_replace_at_tail_P':            {'n': ']P'},
+<
+Note: Because the put before/after commands are unavailable in visual mode,
+`p` and `P` are also used for visual mode `sexp_replace`, making `vp` and `vP`
+effectively aliases to `<M-p>` and `<M-P>`.
 
                                              *sexp-regput-single-vs-multiline*
 Single vs Multi-line  ~
@@ -1057,7 +1084,6 @@ surrounding the put text in an effort to preserve the shape.
 
 If you don't like this behavior, you can disable it by setting option
 |sexp_regput_ignore_list_shape| to 1.
-
 
                                                    *sexp-regput-comment-logic*
 Constraints on Comments  ~
@@ -1534,6 +1560,14 @@ full (level 2) optimization.
 >
         " Default
         let g:sexp_aligncom_density_weight = 5
+<
+                                             *g:sexp_regput_override_builtins*
+When this is set, several of Vim's builtin put operators are remapped to
+vim-sexp's "smart paste" commands.
+For details, see |sexp-regput-builtin-overrides|.
+>
+        " Default
+        let g:sexp_regput_override_builtins = 1
 <
                                              *g:sexp_regput_bracket_is_target*
 When this is set, |<Plug>(sexp_put_before)| and |<Plug>(sexp_put_after)| are

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -895,19 +895,20 @@ REGISTER PUT ("SMART PASTE") COMMANDS (normal, visual) ~
 
 All of the register put (paste) commands (and operators) accept an optional
 register name via the standard Vim mechanism (e.g., `"ap` to put from the `"a`
-register), as well as an optional `[count]` whose usage is documented with the
-corresponding command. Commands that replace existing elements have distinct
-`p` and `P` variants: by analogy with builtin `p` and `P`, the former updates
-the unnamed register (|@"|); the latter does not. By default, the cursor will
-be left at the head of the put text, but this can be changed with option
-|g:sexp_regput_curpos| and its several variants. All put (paste) commands
-perform an automatic re-indent on a range whose size is determined by
-|g:sexp_auto_indent_range|. By default, vim-sexp attempts to validate register
-contents before pasting them. To learn more about this behavior, including how
-to disable/customize it, see |sexp-regput-register-parsing|.
+register). The non-operator commands also accept an optional `[count]` , whose
+usage is documented with the corresponding command. Commands that replace
+existing elements have distinct `p` and `P` variants: by analogy with builtin
+`p` and `P`, the former updates the unnamed register (|@"|); the latter does
+not. By default, the cursor is left at the head of the put text, but this
+can be changed with option |g:sexp_regput_curpos| and its several variants.
+All put (paste) commands and operators perform an automatic re-indent on a
+range whose size is determined by |g:sexp_auto_indent_range|. By default,
+vim-sexp attempts to validate register contents before pasting them. To learn
+more about this behavior, including how to disable/customize it, see
+|sexp-regput-register-parsing|.
 
-Note: If vim-repeat is installed, the non-operator smart-paste commands can be
-repeated with the |.| command.
+Note: If vim-repeat is installed, the all smart-paste commands and operators
+can be repeated with the |.| command.
 
 Note: Although most users will probably wish to remap the builtin put
 commands to vim-sexp's smarter, Lisp-aware counterparts, the builtins will not
@@ -949,24 +950,59 @@ Replace operator (normal)  ~
 
 ["x] <M-p>                                           *<Plug>(sexp_replace_op)*
 ["x] <M-P>                                         *<Plug>(sexp_replace_op_P)*
-        Replace a target determined by one of the following with `[count]`
-        copies of register x:
-
-                * a motion
-                * a builtin text object
-                * a vim-sexp object (e.g., inner/outer element/list/child)
+        Replace a target determined by a motion or text/sexp object with the
+        contents of register x. For motions/objects whose endpoints are both
+        within a single level of the sexp tree, the selection or moved-over
+        region determines the replacement target.
 
                                              *sexp-replace-target-constraints*
-        Note: The target may contain multiple S-expressions, but may not cross
-        list boundaries, and must not contain partial S-expressions, unless
-        |g:sexp_regput_replace_expanded| is set, in which case, the target
-        will be expanded to include all of any partially selected
-        S-expressions.
+        The target may contain multiple S-expressions, and must not contain
+        partial S-expressions, unless |g:sexp_regput_replace_expanded| is set,
+        in which case, the target will be expanded to include all of any
+        partially selected S-expressions.
 
-        Note: The `[count]` mentioned above is the count for the replace
-        operator itself; the motion/object that determines the target may have
-        its own count: e.g., `3<M-p>2ic` would replace the 2nd inner child
-        of the current list with 3 copies of the unnamed register.
+**Experimental**  ~
+                                                *sexp-replace-telescopic-mode*
+        Unless you set |g:sexp_regput_op_tele|, vim-sexp will refuse to
+        operate on a region whose defining motion's endpoints are at different
+        levels of the sexp tree. This is done to minimize the risk of creating
+        unbalanced forms. There is, however, another way of looking at
+        operator motions, which gives them meaning when they span multiple
+        levels: rather than selecting the forms "moved over", a motion can
+        select the form "reached" by the motion search. Here's an illustrative
+        example, which assumes the following option settings:
+
+          `g:sexp_regput_op_tele == 1`
+          `g:sexp_regput_curpos == 2`
+>
+          (foo (bar)
+               (|baz))
+<
+        To swap "foo" and "baz" without moving the cursor (indicated by `|`),
+        execute the following sequence...
+>
+          yie
+          <M-p>?foo<CR>
+          <M-p>ie
+<
+        Because this mode permits "action at a distance", it is known as
+        "telescopic" mode. It may also be referred to as "endpoint" mode. This
+        feature is still considered experimental because some additional work
+        is needed to ensure it works properly with all vim-sexp motions, but
+        it already works well with non-sexp search operators (e.g., `/` and
+        `?`) and even works with motion plugins like vim-easymotion. The issue
+        with vim-sexp motions is that they sometimes exclude brackets from the
+        motion in a way that is generally helpful to the user, but which
+        breaks the telescopic selection logic. Fortunately, there's a
+        workaround, which should be implemented in a subsequent version...
+
+        Note: Unlike the non-operator smart paste commands, the replace
+        operator does not use a `[count]`. If you supply one, Vim's operator
+        mechanism will use it as a multiplier for any count used with the
+        motion/object (probably not what you intended).
+        **Warning**: Use counts only with the motion/operator and do not
+        use a count with the "." (repeat) operator when using it to repeat a
+        replace operation.
 
         The commands ending in `P` do not update the unnamed register.
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -175,6 +175,28 @@ ie                                                *<Plug>(sexp_inner_element)*
 
         An element always includes leading macro characters.
 
+aC                                             *<Plug>(sexp_outer_child_tail)*
+ac                                             *<Plug>(sexp_outer_child_head)*
+iC                                             *<Plug>(sexp_inner_child_tail)*
+ic                                             *<Plug>(sexp_inner_child_head)*
+        Select the [count]th "child" element from the head (lowercase c) or
+        tail (uppercase C) of the current compound form. If cursor is not on
+        the macro chars or paired bracket of a compound form, the containing
+        form is used. If there is no containing form (cursor at toplevel), it
+        is as though a virtual form encloses the file itself (i.e., [count]th
+        toplevel element from beginning or end of file).
+
+        The meaning of the terms "inner" and "outer" are as defined for the ie
+        and ae text objects. 
+
+                                             *sexp-child-objects-vs-[e-and-]e*
+        There is overlap between the use cases for child objects and the
+        select prev/next element commands ([e and ]e). The chief difference is
+        that a child object's offset is always specified relative to the start
+        or end of a compound form, whereas [e and ]e always search relative to
+        the cursor position. Depending on the use case, one set of commands
+        may be significantly more convenient than the other.
+
 Outer Element whitespace selection logic ~
                                           *sexp-outer-element-selection-logic*
                                            *sexp-surrounding-whitespace-rules*
@@ -234,28 +256,6 @@ Outer Element whitespace selection logic ~
           Note: By moving the cursor to the start of the selection, `o'
           changes the direction of the expansion.
 <
-
-aC                                             *<Plug>(sexp_outer_child_tail)*
-ac                                             *<Plug>(sexp_outer_child_head)*
-iC                                             *<Plug>(sexp_inner_child_tail)*
-ic                                             *<Plug>(sexp_inner_child_head)*
-        Select the [count]th "child" element from the head (lowercase c) or
-        tail (uppercase C) of the current compound form. If cursor is not on
-        the macro chars or paired bracket of a compound form, the containing
-        form is used. If there is no containing form (cursor at toplevel), it
-        is as though a virtual form encloses the file itself (i.e., [count]th
-        toplevel element from beginning or end of file).
-
-        The meaning of the terms "inner" and "outer" are as defined for the ie
-        and ae text objects. 
-
-                                             *sexp-child-objects-vs-[e-and-]e*
-        There is overlap between the use cases for child objects and the
-        select prev/next element commands ([e and ]e). The chief difference is
-        that a child object's offset is always specified relative to the start
-        or end of a compound form, whereas [e and ]e always search relative to
-        the cursor position. Depending on the use case, one set of commands
-        may be significantly more convenient than the other.
 
 TEXT OBJECT MOTIONS (normal, visual, operator-pending) ~
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -902,11 +902,14 @@ register (`@"`); the latter does not. By default, the cursor will be left at
 the head of the put text, but this can be changed with option
 |g:sexp_regput_curpos|. All put (paste) commands perform an automatic
 re-indent on a range whose size is determined by |g:sexp_auto_indent_range|.
+By default, vim-sexp attempts to validate register contents before pasting
+them. To learn more about this behavior, including how to disable/customize
+it, see |sexp-regput-register-parsing|.
 
 Note: Although most users will probably wish to remap the builtin put
 operators to vim-sexp's smarter, Lisp-aware counterparts, the builtin put
 operators will not be overridden without an explicit request via one of the
-methods discussed in |sexp-overriding-builtins|.
+methods discussed in |sexp-regput-overriding-builtins|.
 
 Put register before/after (normal)  ~
                                                                     *sexp_put*
@@ -1012,6 +1015,26 @@ if you prefer that the cursor be left at the end (as it is for Vim's builtin
 `p` operator), simply set |g:sexp_regput_curpos| to 1. Alternatively, for a
 more "telescopic" (put at-a-distance) feel, set the option to 2 to preserve
 the original (pre-paste) cursor position.
+
+                                                *sexp-regput-register-parsing*
+Register Parsing  ~
+Before putting a register into the buffer, vim-sexp attempts to parse its
+contents as lisp code of a dialect corresponding to 'filetype'. The primary
+goal of this parsing is to detect problems such as unbalanced parentheses,
+which could render the code in the buffer malformed. A secondary goal is to
+characterize the register contents in a way that can inform decisions about
+how to separate the put text from the surrounding buffer text: e.g., Does the
+text begin or end with a comment? Does it contain multiple toplevel forms?
+The parsing is straightforward when Treesitter is available; when only the
+legacy syntax engine is available, vim-sexp must put the register contents
+into a hidden buffer where its own syntax-aware functions can be used to
+perform the parsing. In either case, the parsing should be completely
+invisible. With the default configuration, you will be prompted to decide
+whether to proceed with a put of invalid register contents. If you don't like
+this behavior, you can customize it with option
+|g:sexp_regput_invalid_register_action|.
+Note: Although it is possible to disable parsing altogether, it is not
+recommended. For details, see |g:sexp_regput_inhibit_regparse|.
 
                                              *sexp-regput-single-vs-multiline*
 Single vs Multi-line  ~
@@ -1662,6 +1685,32 @@ For additional details, see |sexp-regput-list-shape-preservation|.
 >
         " Default
         let g:sexp_regput_ignore_list_shape = 0
+<
+
+                                       *g:sexp_regput_invalid_register_action*
+Enumerated value that determines how to handle an attempt to put text that
+fails to parse as valid lisp (of a dialect determined by buffer 'filetype').
+  -1  Present continue/abort prompt to user
+   0  Abort paste with warning
+   1  Paste with warning
+   2  Paste silently
+
+>
+        " Default
+        let g:sexp_regput_invalid_register_action = -1
+<
+                                              *g:sexp_regput_inhibit_regparse*
+Set to 1 to inhibit the parsing of register contents described in
+|sexp-regput-register-parsing|. With parsing disabled, vim-sexp uses only
+simplistic, regex-based matching to determine the most critical information
+about the register: e.g., whether it contains comments. However, this approach
+is not able to fully and correctly characterize the register contents and
+makes no attempt to detect errors; thus, unless you're having issues with the
+parser, it's best not to disable it. (And if you do experience issues, please
+create an issue report.)
+>
+        " Default
+        let g:sexp_regput_inhibit_regparse = 0
 <
 
 Expert options ~

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -1468,24 +1468,24 @@ For details, see |sexp-auto-indent|.
         let g:sexp_auto_indent = -1
 <
                                                     *g:sexp_auto_indent_range*
-One of the following characters indicating how the line range for an
-auto-indent should be calculated:
+Integer determining how the range for an auto-indent is calculated.
 
-  'm'  use algorithm to find the minimal region required to guarantee
+  -1   re-indent top-level form
+   0   use algorithm to find the minimal region required to guarantee
        correctness. (Assumes the indentation was correct before the operation
        that triggered the re-indent.)
-  'p'  re-indent the parent list
-  't'  re-indent the toplevel list
+  >0   re-indent N containing lists
 
-There is an inherent tradeoff between performance and speed, with 'm' yielding
-the best performance and 't' most likely to produce correct indentation. If
-neither |g:sexp_indent_aligns_comments| nor |g:sexp_indent_does_clean| is
-enabled, there's probably little advantage to re-indenting the parent or
-toplevel list. However, since comment alignment works best on non-trivial line
-ranges, some users may wish to accept the performance hit of 't' in order to
-ensure optimal comment alignment. Others may prefer keeping the re-indent
-small (and fast) with 'm', using `sexp_align_comments_top` (`<M-\>`) to
-re-align comments manually only after they've become unacceptably "ragged".
+There is an inherent tradeoff between performance and speed, with 0 yielding
+the best performance and larger values (or -1) least likely to produce
+incorrect indentation. If neither |g:sexp_indent_aligns_comments| nor
+|g:sexp_indent_does_clean| is enabled, there's probably little advantage to
+changing the default of 0. However, since comment alignment works best on
+non-trivial line ranges, some users may wish to accept the performance hit of
+larger values of N in order to ensure optimal comment alignment. Others may
+prefer keeping the re-indent small (and fast) with 0, using
+`sexp_align_comments_top` (`<M-\>`) to re-align comments manually only after
+they've become unacceptably "ragged".
 
                                                     *g:sexp_clone_does_indent*
 Automatically re-indent the target(s) of a multi-line clone operation.

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -1052,6 +1052,23 @@ For details, see section |sexp-auto-indent|.
         " Default
         let g:sexp_auto_indent = -1
 <
+                                                    *g:sexp_auto_indent_range*
+Determines how the range for an auto-indent is calculated. Smaller numbers
+prioritize performance; larger numbers prioritize correctness. The algorithm
+used for level 0 assumes the indentation was correct before the command that
+triggered the auto-indent, and may produce incorrect results if this
+pre-condition is not met.
+  0  re-indent only subset of elements determined by conservative algorithm
+  1  re-indent containing form if indent currently configured to align
+     comments or clean whitespace, else fall back to 0
+  2  re-indent containing form unconditionally
+  3  re-indent containing top-level form if indent currently configured to
+     align comments or clean whitespace, else fall back to 2
+  4  re-indent containing top-level form unconditionally
+>
+        " Default
+        let g:sexp_auto_indent_range = 1
+<
                                                     *g:sexp_clone_does_indent*
 Automatically re-indent the target(s) of a multi-line clone operation.
 See also |sexp-auto-indent|.
@@ -1198,7 +1215,6 @@ Align end-of-line comments automatically after performing an indent.
         " Default
         let g:sexp_indent_aligns_comments = 0
 <
-
                                                     *g:sexp_aligncom_maxshift*
 Maximum number of screen columns an end-of-line comment is allowed to shift
 rightward to align with other columns in an end-of-line comment block.

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -893,16 +893,33 @@ LIST MANIPULATION (normal, visual) ~
 REGISTER PUT ("SMART PASTE") COMMANDS (normal, visual) ~
                                         *sexp-smart-paste* *sexp-register-put*
 
+Motivation  ~
+Vim's builtin register put commands (e.g., `p`, `P`, etc.) are useful for
+plain text, but decidedly suboptimal for working with S-expressions. If you've
+ever been annoyed by the need to fix incorrect surrounding whitespace, broken
+alignment, or even unbalanced forms after pasting text into a lisp buffer,
+vim-sexp's "smart paste" commands are for you! The commands are broken into
+disctinct command and operator variants: the commands operate on a target
+determined by the cursor location, whereas the operators give you "cybernetic
+arms", allowing you to put or replace forms at a distance. The feature is
+highly customizable, with options whose names bear the "sexp_regput" prefix.
+Even if you normally stick with plugin defaults, you should definitely look at
+the following sections if you wish to get the most out of this feature:
+
+        |sexp-regput-telescopic-motion|       replace-at-a-distance
+        |sexp-regput-overriding-builtins|     more convenient mappings
+
+Overview  ~
 All of the register put (paste) commands and operators accept an optional
 register name via the standard Vim mechanism (e.g., `"ap` to put from the `"a`
 register). The non-operator commands also accept an optional `[count]`, whose
 usage is documented with the corresponding command. Commands that replace
 existing elements have distinct `p` and `P` variants: by analogy with builtin
-`p` and `P`, the former updates the unnamed register (|@"|); the latter does
-not. By default, the cursor is left at the head of the put text, but this can
-be changed with option |g:sexp_regput_curpos| and its several variants. All
-put (paste) commands and operators perform an automatic re-indent on a range
-whose size is determined by |g:sexp_auto_indent_range|. By default, vim-sexp
+`p` and `P`, only the former updates the unnamed register (|@"|). By default,
+the cursor is left at the head of the put text, but this can be changed with
+option |g:sexp_regput_curpos| and its command-specific variants. All put
+(paste) commands and operators perform an automatic re-indent on a range whose
+size is determined by |g:sexp_auto_indent_range|. By default, vim-sexp
 attempts to validate register contents before pasting them. To learn more
 about this behavior, including how to disable or customize it, see
 |sexp-regput-register-parsing|.
@@ -920,8 +937,8 @@ be overridden without an explicit request via one of the methods discussed in
 Put register before/after (normal)  ~
                                                                     *sexp-put*
 
-["x]<LocalLeader>p                                    *<Plug>(sexp_put_after)*
-["x]<LocalLeader>P                                   *<Plug>(sexp_put_before)*
+["x] <LocalLeader>p                                   *<Plug>(sexp_put_after)*
+["x] <LocalLeader>P                                  *<Plug>(sexp_put_before)*
         Put `[count]` copies of register x before (`<LocalLeader>P`) or after
         (`<LocalLeader>p`) the current element; alternatively, works like "put
         register into list" when the conditions in the following paragraph are
@@ -971,9 +988,10 @@ Replace current element with register (normal)  ~
 
         Note: The mapping for this command is intentionally long (and
         inconvenient) since you can get the same behavior with the
-        corresponding replace operator: i.e., `<M-p>ie`
+        corresponding replace operator: e.g., `<M-p>ie`
 
-        Feel free to unmap in |g:sexp_mappings|.
+        Feel free to unmap (or provide a more convenient mapping) in
+        |g:sexp_mappings|.
 
 Put register into current list (normal)  ~
 
@@ -987,9 +1005,11 @@ Put register into current list (normal)  ~
         inconvenient) since you can get the same behavior with the
         corresponding put operator followed by an inner/outer "child object"
         with a `[count]`: e.g.,
-                `>p2ic` to put after the second child.
+                `>p2ic`   to put after the second child
+                `<piC`    to put before the tail element 
 
-        Feel free to unmap in |g:sexp_mappings|.
+        Feel free to unmap (or provide a more convenient mapping) in
+        |g:sexp_mappings|.
 
         See also |sexp-regput-definition-of-current-list|.
 
@@ -1000,7 +1020,7 @@ Replace operator (normal)  ~
 ["x] <M-P>                                         *<Plug>(sexp_replace_op_P)*
         Works just like the corresponding non-operator replace commands, but
         instead of the element at the cursor, replaces the S-expression(s)
-        selected by the operator motion/object range.
+        selected by the operator's motion/object.
 
                                              *sexp-replace-target-constraints*
         The target range may contain multiple S-expressions, but must not
@@ -1008,129 +1028,134 @@ Replace operator (normal)  ~
         is set, in which case, the target will be expanded to include all of
         any partially selected S-expressions. As with the visual replace
         commands, the motion endpoints must lie within the same node of the
-        sexp tree unless you've set |g:sexp_regput_enable_teleop| to enable
-        "telescopic mode", as described in |sexp-operator-telescopic-mode|.
+        sexp tree unless you've set |g:sexp_regput_tele_motion| to enable
+        "telescopic mode", as described in |sexp-operator-telescopic-motion|.
 
         The commands ending in `P` do not update the unnamed register.
 
         Examples:  ~
-        1. Replace current list:  `<M-p>af`
-        2. Replace current element without updating @":  `<M-P>ie`
-        3. Replace second child of current list:  `<M-p>2ic`
-        4. Replace current and next two elements: `<M-p>3E`
+        1. `<M-p>af`  Replace current list
+        2. `<M-P>ie`  Replace current element without updating `@"`
+        3. `<M-p>2ic` Replace second child of current list
+        4. `<M-p>3E`  Replace current and next two elements
 
+        ** Important Note **  ~
         For a powerful approach to replacing elements in distant branches of
         the sexp tree, (optionally) without even moving the cursor, see
-        |sexp-operator-telescopic-mode|.
-
+        |sexp-operator-telescopic-motion|.
 
 Put operator (normal)  ~
-                                                       *sexp-put-operator*
+                                                           *sexp-put-operator*
 
-["x] `>p`                                          *<Plug>(sexp_put_after_op)*
-["x] `<p`                                         *<Plug>(sexp_put_before_op)*
-        Works just like the corresponding non-operator put before/after
-        commands, but instead of the element at the cursor, puts before/after
-        the first/last element selected by the motion/object range.
+["x] `>p`                                            *<Plug>(sexp_put_after_op)*
+["x] `<p`                                           *<Plug>(sexp_put_before_op)*
+        Works just like the corresponding non-operator put commands, but
+        instead of the element at the cursor, puts before or after the first
+        or last element selected by the operator's motion/object.
 
                                                  *sexp-put-target-constraints*
         The target may contain multiple elements, but only the element at the
-        edge of the range determined by the put direction matters. As with the
-        replace operator, both motion endpoints must lie within the same node
-        of the sexp tree, unless you've set |g:sexp_regput_enable_teleop| to
-        enable "telescopic mode", as described in
-        |sexp-operator-telescopic-mode|.
+        edge of the range corresponding to the put direction matters. As with
+        the replace operator, both motion endpoints must lie within the same
+        node of the sexp tree, unless you've set |g:sexp_regput_tele_motion|
+        to enable "telescopic mode", as described in
+        |sexp-operator-telescopic-motion|.
 
         Examples:  ~
-        1. Put before final element of current list:  `<piC`
-           Note: Equivalent to `2<LocalLeader>]p` (put into second slot from
-           tail of list)
-        2. Put after the second element beyond the current element: `>p3E`
-           Note: `3E` is used instead of `2W` because the `W` motion is
-           exclusive, and thus, would not include any part of the desired
-           target element.
+        1. `<piC`  Put before final element of current list
+                 Note: Equivalent to `2<LocalLeader>]p` (i.e., put into second
+                 slot from tail of list)
+        2. `>p3E`  Put after the second element beyond the current element
+                 Note: `3E` is used instead of `2W` because the `W` motion is
+                 exclusive, and thus, would not include the desired target
+                 element.
 
+        ** Important Note **  ~
         For a powerful approach to putting before/after elements in distant
         branches of the sexp tree, (optionally) without moving the cursor, see
-        |sexp-operator-telescopic-mode|.
+        |sexp-operator-telescopic-motion|.
 
 "Telescopic" Mode (***Experimental*** - Requires Vim Version >= 8.1) ~
-                                               *sexp-operator-telescopic-mode*
+                                             *sexp-operator-telescopic-motion*
+
         By default, vim-sexp's put/replace operators will refuse to operate on
         an "unbalanced" region whose endpoints are not both contained within
         the same node of the sexp tree. While this is necessary to minimize
         the risk of creating unbalanced forms, setting option
-        |g:sexp_regput_enable_teleop| enables an alternative interpretation of
+        |g:sexp_regput_tele_motion| enables an alternative interpretation of
         operator motions, which gives them meaning even when they reach across
-        tree levels: rather than selecting the forms "moved over", a motion
-        can select the form "reached" by the motion search. Because this mode
-        permits "action at a distance", it is known as "telescopic mode". The
-        concept is best illustrated with an example, for which the following
-        option settings are assumed:
+        tree levels: rather than selecting the forms "moved over", a
+        "telescopic" motion selects the form "reached" by the motion search.
+        The concept is best illustrated with an example, for which the
+        following option settings are assumed:
 
-          `g:sexp_regput_enable_teleop == 1`
-          `g:sexp_regput_curpos == 2`
+          |g:sexp_regput_tele_motion| >= 1
+          |g:sexp_regput_curpos| == 2
 >
           (foo (bar)
                (|baz))
 <
         To swap "foo" and "baz" without moving the cursor (indicated by `|`),
-        execute the following sequence...
+        execute the following sequence of commands...
 >
-          yie
-          <M-p>?foo<CR>
-          <M-p>ie
+          yie                copy current element into unnamed register
+          <M-p>?foo<CR>      replace target of backwards search, updating @"
+          <M-p>ie            replace current element with @"
 <
-        Note that |g:sexp_regput_enable_teleop| is not a simple flag but an
-        enumerated value. Setting it to 1 enables "telescopic mode" only for
-        jumps to other levels of the sexp tree. To enable telescopic mode
-        unconditionally, even within the same sexp tree node, set to 2 or 3: 3
-        if you want this behavior for all operators, 2 if you want it only for
-        the put operator (for which the traditional motion interpretation
-        tends to be less useful). The following example illustrates the
-        difference between conditionally and unconditionally enabled
-        "telescopic mode".
+        Although use of the unnamed register to swap words is idiomatic Vim,
+        telescopic motions streamline the pattern by obviating the need to
+        move the cursor back and forth between the elements being swapped and
+        by handling any required re-indentation.
 
-        Unnamed:      `blammo`
-        Options:      `g:sexp_regput_enable_teleop == 1`
-                      `g:sexp_regput_curpos_op == 2`
-        Initial Form: `(|foo bar baz)`
-        Command:      `<M-p>fz`
-        
-        `g:sexp_regput_enable_teleop == 1`
-        Final:       `(|blammo)`
+        Option Format  ~
+                                              *sexp-tele-motion-option-format*
+        Note that |g:sexp_regput_tele_motion| is not a simple flag but an
+        enumerated value. Setting it to 1 enables "telescopic mode" only for
+        jumps to other parts of the sexp tree. To enable telescopic mode
+        unconditionally (even within the same sexp tree node), set to 2 or 3:
+        3 if you want telescopic behavior for both put and replace operators,
+        2 if you want it only for the put operator (for which the traditional
+        motion interpretation tends to be less useful than it is for the
+        replace operator). The following example illustrates the difference
+        between conditionally and unconditionally enabled "telescopic mode".
+
+        With cursor position indicated by `|` in the following form, and
+        "blammo" in the unnamed register...
+>
+        (|foo bar baz)
+<
+        ...executing `<M-p>fz` produces option-dependent results, as shown
+        below:
+
+        g:sexp_regput_tele_motion == 1  ~
+>
+        (|blammo)
+<
         Explanation: Under the traditional motion interpretation, `fz` selects
         all 3 elements in the list, and thus all 3 elements are replaced by
         the contents of the unnamed register.
 
-        `g:sexp_regput_enable_teleop == 3`
-        Final:       `(|foo bar blammo)`
+        g:sexp_regput_tele_motion == 3  ~
+>
+        (|foo bar blammo)
+<
         Explanation: In "telescopic mode", `fz` targets only the final element
         of the list ("baz"), and thus, only that element is replaced.
 <
-        Note: Regardless of the setting of |g:sexp_regput_enable_teleop|,
+        Note: Regardless of the setting of |g:sexp_regput_tele_motion|,
         telescopic mode is inhibited when vim-sexp can tell that a text object
         (or vim-sexp object) was used as the target of the operator.
 
-        **CAVEAT**: This feature is still considered experimental because
-        additional work is needed to ensure it works properly with all
-        vim-sexp motions, but it already works well with non-sexp search
-        operators (e.g., `/` and `?`) and even works with motion plugins like
-        vim-easymotion. The issue with vim-sexp motions is that they sometimes
-        exclude brackets from the motion in a way that is generally helpful to
-        the user, but breaks the telescopic selection logic. Fortunately,
-        there's a workaround, which should be implemented in a subsequent
-        version...
-
 
 Overriding Builtin Put Commands  ~
+                                             *sexp-regput-overriding-builtins*
 You may not have much need for Vim's builtin put commands once you become
 comfortable with vim-sexp's "smart paste" commands and operators. Since the
 default mappings are not as convenient as builtins, you may wish to remap
-Vim's builtin put operators to vim-sexp smart paste commands. The following
-snippet is provided to facilitate this. Either copy it into your
-|g:sexp_mappings| list to serve as a basis for further customization or simply
-set |g:sexp_regput_override_builtins| to use it as-is.
+Vim's builtin put operators to vim-sexp smart paste commands. If so, either
+copy the following snippet into your |g:sexp_mappings| list to serve as a
+basis for further customization or simply set
+|g:sexp_regput_override_builtins| to use it as-is.
 >
     \ 'sexp_put_before':                   'P',
     \ 'sexp_put_after':                    'p',
@@ -1139,6 +1164,9 @@ set |g:sexp_regput_override_builtins| to use it as-is.
     \ 'sexp_put_at_head':                  '[p',
     \ 'sexp_put_at_tail':                  ']p',
 <
+Note: The put/replace operators are omitted from the override because their
+default mappings are fairly convenient; however, feel free to customize them
+as well.
 
 REGISTER PUT (SMART-PASTE) (ADDITIONAL DETAILS...)
 
@@ -1173,16 +1201,19 @@ operators targeted the parent list and not the yanked child.
 
                                               *sexp-regput-cursor-positioning*
 Cursor Positioning  ~
-By default, the cursor is positioned at the start of the pasted form(s), but
-if you prefer that the cursor be left at the end (as with Vim's builtin `p`
-operator), set |g:sexp_regput_curpos| and/or |g:sexp_regput_into_curpos| to 1.
-Alternatively, for a more "telescopic" (put at-a-distance) feel, set the
-option to 2 to preserve the original (pre-paste) cursor position.
-Note: The following variants of |g:sexp_regput_curpos| are provided to permit
-command-specific tailoring of cursor placement:
-        |g:sexp_regput_into_curpos|
-        |g:sexp_regput_op_curpos|
-        |g:sexp_regput_op_tele_curpos|
+By default, non-operator put/replace commands position the cursor at the start
+of the pasted form(s), whereas put/replace operators preserve the original
+cursor position. You can configure this behavior using the following,
+command-specific options:
+        |g:sexp_regput_curpos|
+        |g:sexp_regput_curpos_child|
+        |g:sexp_regput_curpos_op|
+
+For instance, if you prefer that a normal paste leave the cursor at the
+**end** of the pasted text (like Vim's builtin `p` operator), but would like
+the put **operators** to preserve the original cursor position (for a
+telescopic, "put-at-a-distance" feel), set `g:sexp_regput_curpos = 1` and
+`g:sexp_regput_curpos_op = 2`.
 
                                                 *sexp-regput-register-parsing*
 Register Parsing  ~
@@ -1431,7 +1462,7 @@ Auto-indent options  ~
                                                           *g:sexp_auto_indent*
 The default value of -1 has no effect, but setting this variable to 0 or 1
 overrides **all** of the command-specific |g:sexp_{command}_does_indent| flags.
-For details, see section |sexp-auto-indent|.
+For details, see |sexp-auto-indent|.
 >
         " Default
         let g:sexp_auto_indent = -1
@@ -1452,30 +1483,10 @@ neither |g:sexp_indent_aligns_comments| nor |g:sexp_indent_does_clean| is
 enabled, there's probably little advantage to re-indenting the parent or
 toplevel list. However, since comment alignment works best on non-trivial line
 ranges, some users may wish to accept the performance hit of 't' in order to
-keep comments aligned. Others may prefer keeping the re-indent small (and
-fast) with 'm', using `sexp_align_comments_top` (`<M-\>`) to re-align comments
-manually only after they've become unacceptably "ragged".
+ensure optimal comment alignment. Others may prefer keeping the re-indent
+small (and fast) with 'm', using `sexp_align_comments_top` (`<M-\>`) to
+re-align comments manually only after they've become unacceptably "ragged".
 
-2-character format (DEPRECATED):  ~
-So that you needn't remember to change this option every time you enable or
-disable comment alignment, this option also recognizes a 2-character format,
-in which the second character specifies the range to use when comment
-alignment is enabled.
-**Note:** The 2-character format will probably be deleted in the near future
-(before initial feature release), so it's best not to rely on it.
-
-Examples:  ~
->
-        " Re-indent parent list always.
-        let g:sexp_auto_indent_range = 'p'
-        " Re-indent toplevel if comment alignment enabled, else minimal
-        " region.
-        let g:sexp_auto_indent_range = 'mt'
-
-        " Default
-        " Re-indent parent if comment alignment enabled, else minimal region
-        let g:sexp_auto_indent_range = 'mp'
-<
                                                     *g:sexp_clone_does_indent*
 Automatically re-indent the target(s) of a multi-line clone operation.
 See also |sexp-auto-indent|.
@@ -1789,33 +1800,33 @@ For details, see |sexp-regput-overriding-builtins|.
         let g:sexp_regput_override_builtins = 1
 <
                                                         *g:sexp_regput_curpos*
-                                                   *g:sexp_regput_into_curpos*
-                                                     *g:sexp_regput_op_curpos*
-                                                *g:sexp_regput_op_tele_curpos*
-Determines where cursor is placed after the corresponding register put or
-replace ("smart paste") command.
+Determines where cursor is placed after a smart-paste command that targets the
+current element.
   0  head of put form(s)
   1  tail of put form(s)
   2  preserve original cursor position (as closely as possible)
   
-To make cursor positioning work the same for all commands/operators, simply
-set |g:sexp_regput_curpos| to the desired value.
-
-For users who desire different behavior for different command/operator
-classes, additional option variants are provided, organized hierarchically
-into the following tree, in which child elements inherit their values from
-their parents, recursively:
-
-        sexp_regput_curpos
-                sexp_regput_into_curpos
-                sexp_regput_op_curpos
-                        sexp_regput_op_tele_curpos
-
 For details, see |sexp-regput-cursor-positioning|.
 >
-        " Default (all other variants default to -1)
+        " Default
         let g:sexp_regput_curpos = 0
 <
+                                                  *g:sexp_regput_curpos_child*
+Like |g:sexp_regput_curpos|, but applies only to the smart-paste commands that
+put into the current list: i.e.,
+        |<Plug>(sexp_put_at_head)|
+        |<Plug>(sexp_put_at_tail)|
+>
+        " Default
+        let g:sexp_regput_curpos = 0
+<
+                                                     *g:sexp_regput_curpos_op*
+Like |g:sexp_regput_curpos|, but applies only to the put/replace operators.
+>
+        " Default
+        let g:sexp_regput_curpos = 2
+<
+
                                              *g:sexp_regput_bracket_is_target*
 When this is set, |<Plug>(sexp_put_before)| and |<Plug>(sexp_put_after)| are
 silently converted to |<Plug>(sexp_put_at_head)| and |<Plug>(sexp_put_at_tail)|,
@@ -1919,7 +1930,7 @@ Set to 1 to make the replace operator use partial element selections.
         let g:sexp_regput_replace_expanded = 0
 <
 
-                                                 *g:sexp_regput_enable_teleop*
+                                                   *g:sexp_regput_tele_motion*
 Enumerated value that determines the conditions under which put/replace
 operators use "telescopic mode" rather than traditional Vim motions/objects.
   0  Never use "telescopic mode".
@@ -1932,7 +1943,7 @@ operators use "telescopic mode" rather than traditional Vim motions/objects.
 
 >
         " Default
-        let g:sexp_regput_enable_teleop = 0
+        let g:sexp_regput_tele_motion = 0
 <
 Expert options ~
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -938,12 +938,11 @@ be overridden without an explicit request via one of the methods discussed in
 Put register before/after (normal)  ~
                                                                     *sexp-put*
 
-["x] <LocalLeader>p                                   *<Plug>(sexp_put_after)*
-["x] <LocalLeader>P                                  *<Plug>(sexp_put_before)*
-        Put `[count]` copies of register x before (`<LocalLeader>P`) or after
-        (`<LocalLeader>p`) the current element; alternatively, works like "put
-        register into list" when the conditions in the following paragraph are
-        met.
+["x] p                                                *<Plug>(sexp_put_after)*
+["x] P                                                *<Plug>(sexp_put_before)*
+        Put `[count]` copies of register x before (`P`) or after (`p`) the
+        current element; alternatively, works like "put register into list"
+        when the conditions in the following paragraph are met.
 
                                             *sexp-regput-behavior-on-bracket*
         Special Behavior on List Brackets  ~
@@ -951,8 +950,8 @@ Put register before/after (normal)  ~
         bracket (or the macro chars preceding an open), and the put direction
         is towards the list interior, it will be handled as the corresponding
         "put register into list" command:
-                <LocalLeader>p ==> |<Plug>(sexp_put_at_head)|
-                <LocalLeader>P ==> |<Plug>(sexp_put_at_tail)|
+                p ==> |<Plug>(sexp_put_at_head)|
+                P ==> |<Plug>(sexp_put_at_tail)|
         I.e., the register text will be inserted into the head or tail of the
         list at an offset determined by `[count]`. If you prefer that this
         command treat lists just like regular elements, simply set option
@@ -960,10 +959,9 @@ Put register before/after (normal)  ~
 
         Note: If there is no current element, the register contents are put
         before or after the cursor position; moreover, there is a subtle
-        difference between `<LocalLeader>p` and `<LocalLeader>P` in this case:
-        in particular, putting *away from* an adjacent element on the same
-        line as the cursor forces a line break between the put text and the
-        adjacent element.
+        difference between `p` and `P` in this case: in particular, putting
+        *away from* an adjacent element on the same line as the cursor forces
+        a line break between the put text and the adjacent element.
 
 
 Replace with register (normal and visual)  ~
@@ -971,29 +969,28 @@ Replace with register (normal and visual)  ~
                                  *<Plug>(sexp_replace)* *<Plug>(sexp_replace_P)*
 Visual  ~
                                                          *sexp-replace-visual*
-["x] <LocalLeader>p
-["x] <LocalLeader>P
+["x] p
+["x] P
         Replace the visually selected element(s) with `[count]` copies of
         register `x`.
 
         To prevent unbalanced forms, the command aborts with a warning if the
         selection endpoints do not lie within the same node of the sexp tree.
 
-        `<LocalLeader>P` does not update the unnamed register.
+        `P` does not update the unnamed register.
 
 Normal  ~
                                                          *sexp-replace-normal*
-["x] <LocalLeader><LocalLeader>p
-["x] <LocalLeader><LocalLeader>P
+["x] gp
+["x] gP
         Replace element at cursor with `[count]` copies of register `x`.
 
-        `<M-P>` does not update the unnamed register.
+        `gP` does not update the unnamed register.
 
-        Note: The mapping for this command is intentionally long (and
-        inconvenient) since you can get the same behavior with the
-        corresponding replace operator: e.g., `<M-p>ie`
+        Note: This command is syntactic sugar for the corresponding replace
+        operator: e.g., `<M-p>ie`
 
-        Feel free to unmap (or provide a more convenient mapping) in
+        Feel free to unmap (or provide a different mapping) in
         |g:sexp_mappings|.
 
 Put register into current list (normal)  ~
@@ -1152,28 +1149,45 @@ Put operator (normal)  ~
         (or vim-sexp object) was used as the target of the operator.
 
 
-Overriding Builtin Put Commands  ~
-                                             *sexp-regput-overriding-builtins*
-You may not have much need for Vim's builtin put commands once you become
-comfortable with vim-sexp's "smart paste" commands and operators. Since the
-default mappings are not as convenient as builtins, you may wish to remap
-Vim's builtin put operators to vim-sexp smart paste commands. If so, either
-copy the following snippet into your |g:sexp_mappings| list to serve as a
-basis for further customization or simply set
-|g:sexp_regput_override_builtins| to use it as-is.
->
-    \ 'sexp_put_before':                   'P',
-    \ 'sexp_put_after':                    'p',
-    \ 'sexp_replace':                      {'x': 'p', 'n': '<LocalLeader>p'},
-    \ 'sexp_replace_P':                    {'x': 'P', 'n': '<LocalLeader>P'},
-    \ 'sexp_put_at_head':                  '[p',
-    \ 'sexp_put_at_tail':                  ']p',
-<
-Note: The put/replace operators are omitted from the override because their
-default mappings are fairly convenient; however, feel free to customize them
-as well.
-
 REGISTER PUT (SMART-PASTE) (ADDITIONAL DETAILS...)
+
+Override of Builtin Operators  ~
+                                               *sexp-regput-builtin-overrides*
+
+By default, this feature assigns the following builtin commands to
+"smart-paste" functions:
+        `p` and `P`      (normal and visual mode)
+        `gp` and `gP`    (normal mode only)
+
+If you wish to be able to use the builtin versions of these commands in Lisp
+buffers, you have two options:
+
+1. Specify custom mappings for the "smart-paste" commands to avoid overriding
+   the builtins: e.g.,
+>
+    let g:sexp_mappings = {
+        \ 'sexp_put_before': '<LocalLeader>P',
+        \ 'sexp_put_after':  '<LocalLeader>p',
+        \ 'sexp_replace':    {'x': '<LocalLeader>p',
+        \                     'n': '<LocalLeader><LocalLeader>p'},
+        \ 'sexp_replace_P':  {'x': '<LocalLeader>P',
+        \                     'n': '<LocalLeader><LocalLeader>P'},
+    \ }
+<
+    Recommendation: Use this approach if you plan to use builtin paste more
+    than vim-sexp "smart-paste" (not recommended).
+
+2. Add "aliases" for the overridden builtins to your map customizations: e.g.,
+>
+    let g:sexp_mappings = {
+        \ 'p':   '<LocalLeader>p',
+        \ 'P':   '<LocalLeader>p',
+        \ 'gp':  '<LocalLeader>gp',
+        \ 'gP':  '<LocalLeader>gP',
+    \ }
+<
+    Recommendation: Use this approach if you will mostly use "smart-paste",
+    but may occasionally still require builtin paste.
 
                                                  *sexp-regput-operator-counts*
 Put/Replace Operator Counts  ~
@@ -2078,16 +2092,14 @@ Note: To unbind a command, simply set its <lhs> to an empty string.
             \ 'sexp_emit_tail_element':         '<M-S-k>',
             \ 'sexp_capture_prev_element':      '<M-S-h>',
             \ 'sexp_capture_next_element':      '<M-S-l>',
-            \ 'sexp_put_before':                '<LocalLeader>P',
-            \ 'sexp_put_after':                 '<LocalLeader>p',
+            \ 'sexp_put_before':                'P',
+            \ 'sexp_put_after':                 'p',
+            \ 'sexp_put_before_op':             '<p',
+            \ 'sexp_put_after_op':              '>p',
+            \ 'sexp_replace':                   {'x': 'p', 'n': 'gp'},
+            \ 'sexp_replace_P':                 {'x': 'P', 'n': 'gP'},
             \ 'sexp_replace_op':                '<M-p>',
             \ 'sexp_replace_op_P':              '<M-P>',
-            \ 'sexp_replace':                   {'x': '<LocalLeader>p',
-            \                                    'n': '<LocalLeader><LocalLeader>p'},
-            \ 'sexp_replace_P':                 {'x': '<LocalLeader>P',
-            \                                    'n': '<LocalLeader><LocalLeader>P'},
-            \ 'sexp_put_at_head':               '<p',
-            \ 'sexp_put_at_tail':               '>p',
             \ 'sexp_put_at_head':               '<LocalLeader><p',
             \ 'sexp_put_at_tail':               '<LocalLeader>>p',
             \ }

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -955,7 +955,7 @@ Put register before/after (normal)  ~
         I.e., the register text will be inserted into the head or tail of the
         list at an offset determined by `[count]`. If you prefer that this
         command treat lists just like regular elements, simply set option
-        *g:sexp_regput_bracket_is_target* to 0.
+        |g:sexp_regput_bracket_is_target| to 0.
 
         Note: If there is no current element, the register contents are put
         before or after the cursor position; moreover, there is a subtle
@@ -965,23 +965,25 @@ Put register before/after (normal)  ~
         adjacent element.
 
 
-Replace selection with register (visual)  ~
+Replace with register (normal and visual)  ~
                                                                 *sexp-replace*
-
-["x] <M-p>                                              *<Plug>(sexp_replace)*
-["x] <M-P>                                            *<Plug>(sexp_replace_P)*
+                                 *<Plug>(sexp_replace)* *<Plug>(sexp_replace_P)*
+Visual  ~
+                                                         *sexp-replace-visual*
+["x] <LocalLeader>p
+["x] <LocalLeader>P
         Replace the visually selected element(s) with `[count]` copies of
         register `x`.
 
         To prevent unbalanced forms, the command aborts with a warning if the
         selection endpoints do not lie within the same node of the sexp tree.
 
-        `<M-P>` does not update the unnamed register.
+        `<LocalLeader>P` does not update the unnamed register.
 
-Replace current element with register (normal)  ~
-
-["x] <LocalLeader><LocalLeader>p                        *<Plug>(sexp_replace)*
-["x] <LocalLeader><LocalLeader>P                      *<Plug>(sexp_replace_P)*
+Normal  ~
+                                                         *sexp-replace-normal*
+["x] <LocalLeader><LocalLeader>p
+["x] <LocalLeader><LocalLeader>P
         Replace element at cursor with `[count]` copies of register `x`.
 
         `<M-P>` does not update the unnamed register.
@@ -1180,7 +1182,7 @@ intended).
 with the "." (repeat) operator when using it to repeat a put/replace
 operation.
 
-                                             *sexp-regput-overriding-builtins*
+                                                      *sexp-regput-p-versus-P*
 p versus P (a Motivating Example)  ~
 Although `<M-j>`, `<M-k>`, `<M-h>`, `<M-l>` can be used to swap adjacent
 elements, they're not ideal for swapping non-adjacent elements. For instance,

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -1053,21 +1053,42 @@ For details, see section |sexp-auto-indent|.
         let g:sexp_auto_indent = -1
 <
                                                     *g:sexp_auto_indent_range*
-Determines how the range for an auto-indent is calculated. Smaller numbers
-prioritize performance; larger numbers prioritize correctness. The algorithm
-used for level 0 assumes the indentation was correct before the command that
-triggered the auto-indent, and may produce incorrect results if this
-pre-condition is not met.
-  0  re-indent only subset of elements determined by conservative algorithm
-  1  re-indent containing form if indent currently configured to align
-     comments or clean whitespace, else fall back to 0
-  2  re-indent containing form unconditionally
-  3  re-indent containing top-level form if indent currently configured to
-     align comments or clean whitespace, else fall back to 2
-  4  re-indent containing top-level form unconditionally
+One or two character string indicating how the line range for an auto-indent
+should be calculated. The characters have the following meanings:
+
+  'm'  use algorithm to find the minimal region required to guarantee
+       correctness. (Assumes the indentation was correct before the operation
+       that triggered the re-indent.)
+  'p'  re-indent the parent list
+  't'  re-indent the toplevel list
+
+There is an inherent tradeoff between performance and speed, with 'm' yielding
+the best performance and 't' most likely to produce correct indentation. If
+neither |g:sexp_indent_aligns_comments| nor |g:sexp_indent_does_clean| is
+enabled, there's probably little advantage to re-indenting the parent or
+toplevel list. However, since comment alignment works best on non-trivial line
+ranges, some users may wish to accept the performance hit of 't' in order to
+keep comments aligned. Others may prefer keeping the re-indent small (and
+fast) with 'm', using `sexp_align_comments_top` (`<M-\>`) to re-align comments
+manually only after they've become unacceptably "ragged".
+
+2-character format:  ~
+So that you needn't remember to change this option every time you enable or
+disable comment alignment, this option also recognizes a 2-character format,
+in which the second character specifies the range to use when comment
+alignment is enabled.
+
+Examples:  ~
 >
+        " Re-indent parent list always.
+        let g:sexp_auto_indent_range = 'p'
+        " Re-indent toplevel if comment alignment enabled, else minimal
+        " region.
+        let g:sexp_auto_indent_range = 'mt'
+
         " Default
-        let g:sexp_auto_indent_range = 1
+        " Re-indent parent if comment alignment enabled, else minimal region
+        let g:sexp_auto_indent_range = 'mp'
 <
                                                     *g:sexp_clone_does_indent*
 Automatically re-indent the target(s) of a multi-line clone operation.

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -897,14 +897,14 @@ Motivation  ~
 Vim's builtin register put commands (e.g., `p`, `P`, etc.) are useful for
 plain text, but decidedly suboptimal for working with S-expressions. If you've
 ever been annoyed by the need to fix incorrect surrounding whitespace, broken
-alignment, or even unbalanced forms after pasting text into a lisp buffer,
+alignment, or even unbalanced forms after pasting text into a Lisp buffer,
 vim-sexp's "smart paste" commands are for you! The commands are broken into
 disctinct command and operator variants: the commands operate on a target
-determined by the cursor location, whereas the operators give you "cybernetic
-arms", allowing you to put or replace forms at a distance. The feature is
-highly customizable, with options whose names bear the "sexp_regput" prefix.
-Even if you normally stick with plugin defaults, you should definitely look at
-the following sections if you wish to get the most out of this feature:
+determined by the cursor location; the operators give you "cybernetic arms",
+which can put or replace forms at a distance. The feature is highly
+customizable, with option names bearing the "sexp_regput" prefix. Even if you
+normally stick with plugin defaults, you should definitely look at the
+following sections if you wish to get the most out of this feature:
 
         |sexp-regput-telescopic-motion|       replace-at-a-distance
         |sexp-regput-overriding-builtins|     more convenient mappings
@@ -917,8 +917,9 @@ usage is documented with the corresponding command. Commands that replace
 existing elements have distinct `p` and `P` variants: by analogy with builtin
 `p` and `P`, only the former updates the unnamed register (|@"|). By default,
 the cursor is left at the head of the put text, but this can be changed with
-option |g:sexp_regput_curpos| and its command-specific variants. All put
-(paste) commands and operators perform an automatic re-indent on a range whose
+option |g:sexp_regput_curpos| and its command-specific variants
+|g:sexp_regput_curpos_op| and |g:sexp_regput_curpos_child|. All smart-paste
+commands and operators perform an automatic re-indent on a range whose
 size is determined by |g:sexp_auto_indent_range|. By default, vim-sexp
 attempts to validate register contents before pasting them. To learn more
 about this behavior, including how to disable or customize it, see
@@ -927,7 +928,7 @@ about this behavior, including how to disable or customize it, see
 Note: If vim-repeat is installed, all smart-paste commands can be repeated
 with the "." command. Smart-paste operators can be repeated if and only if
 their operand is a sexp object/motion. (This is an inherent limitation, due to
-the fact that Vim's API does not expose the object/motion to the opfunc.)
+the fact that Vim's API does not expose the object/motion to the 'opfunc'.)
 
 Note: Although most users will probably wish to remap the builtin put
 commands to vim-sexp's smarter, Lisp-aware counterparts, the builtins will not
@@ -1031,20 +1032,20 @@ Replace operator (normal)  ~
         any partially selected S-expressions. As with the visual replace
         commands, the motion endpoints must lie within the same node of the
         sexp tree unless you've set |g:sexp_regput_tele_motion| to enable
-        "telescopic mode", as described in |sexp-operator-telescopic-motion|.
+        "telescopic mode", as described in |sexp-regput-telescopic-motion|.
 
-        The commands ending in `P` do not update the unnamed register.
+        The operator ending in `P` does not update the unnamed register.
 
         Examples:  ~
-        1. `<M-p>af`  Replace current list
-        2. `<M-P>ie`  Replace current element without updating `@"`
-        3. `<M-p>2ic` Replace second child of current list
-        4. `<M-p>3E`  Replace current and next two elements
+        1. `<M-p>af`      Replace current list
+        2. `<M-P>ie`      Replace current element without updating `@"`
+        3. `<M-p>2ic`     Replace second child of current list
+        4. `<M-p>3<M-e>`  Replace current and next two elements
 
         ** Important Note **  ~
         For a powerful approach to replacing elements in distant branches of
         the sexp tree, (optionally) without even moving the cursor, see
-        |sexp-operator-telescopic-motion|.
+        |sexp-regput-telescopic-motion|.
 
 Put operator (normal)  ~
                                                            *sexp-put-operator*
@@ -1060,25 +1061,27 @@ Put operator (normal)  ~
         edge of the range corresponding to the put direction matters. As with
         the replace operator, both motion endpoints must lie within the same
         node of the sexp tree, unless you've set |g:sexp_regput_tele_motion|
-        to enable "telescopic mode", as described in
-        |sexp-operator-telescopic-motion|.
+        to enable "telescopic mode" (see |sexp-regput-telescopic-motion|).
+        Additionaly, the selection must include the edge of the target in the
+        direction of the put: i.e., partial selections not allowed.
 
         Examples:  ~
-        1. `<piC`  Put before final element of current list
-                 Note: Equivalent to `2<LocalLeader>>p` (i.e., put into second
-                 slot from tail of list)
-        2. `>p3E`  Put after the second element beyond the current element
-                 Note: `3E` is used instead of `2W` because the `W` motion is
-                 exclusive, and thus, would not include the desired target
-                 element.
+        1. `<piC`      Put before final element of current list
+                     Note: Equivalent to `2<LocalLeader>>p` (i.e., put into
+                     second slot from tail of list)
+        2. `>p3<M-e>`  Put after the second element beyond the current element
+                     Note: `3<M-e>` is used instead of `2<M-w>` because the
+                     `<M-w>` motion is exclusive, and thus, would not include
+                     the desired target element.
 
         ** Important Note **  ~
-        For a powerful approach to putting before/after elements in distant
-        branches of the sexp tree, (optionally) without moving the cursor, see
-        |sexp-operator-telescopic-motion|.
+        In its default mode, this command works best with text/sexp objects.
+        For a more powerful mode of operation that puts into distant branches
+        of the sexp tree, (optionally) without moving the cursor, see
+        |sexp-regput-telescopic-motion|.
 
 "Telescopic" Mode (***Experimental*** - Requires Vim Version >= 8.1) ~
-                                             *sexp-operator-telescopic-motion*
+                     *sexp-regput-tele-motion* *sexp-regput-telescopic-motion*
 
         By default, vim-sexp's put/replace operators will refuse to operate on
         an "unbalanced" region whose endpoints are not both contained within
@@ -1914,6 +1917,7 @@ operators use "telescopic mode" rather than traditional Vim motions/objects.
      tree nodes.
   2  Like 1, but always use "telescopic mode" for the put operator.
   3  Always use "telescopic mode".
+See |sexp-regput-telescopic-motion| for details...
 >
         " Default
         let g:sexp_regput_tele_motion = 0
@@ -1959,13 +1963,12 @@ assumption is violated. Thus, register content validation performed with a
 string parser is more likely to generate "false positives" than the
 corresponding buffer parse.
 
-As an example, consider an attempt to paste `^String` in a Clojure buffer,
-which generates a warning with the string parser, but not with the buffer
-parser. Although the "reader macro" `^` expects to be followed by both the
-metadata and its target element, the buffer parser is able to recover by
-inserting a `MISSING` node in lieu of the missing metadata target; the string
-parser treats the missing metadata target as an error, triggering a warning
-and prompt.
+As an example, an attempt to paste `^String` in a Clojure buffer will generate
+a warning with the string parser, but not with the buffer parser. Although the
+"reader macro" `^` expects to be followed by both the metadata and its target
+element, the buffer parser is able to recover by inserting a `MISSING` node in
+lieu of the missing metadata target; the string parser treats the missing
+metadata target as an error, triggering a warning and prompt.
 
 Caveat: This option is ignored if Treesitter is unavailable.
 >

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -904,7 +904,7 @@ be changed with option |g:sexp_regput_curpos| and its several variants. All
 put (paste) commands and operators perform an automatic re-indent on a range
 whose size is determined by |g:sexp_auto_indent_range|. By default, vim-sexp
 attempts to validate register contents before pasting them. To learn more
-about this behavior, including how to disable/customize it, see
+about this behavior, including how to disable or customize it, see
 |sexp-regput-register-parsing|.
 
 Note: If vim-repeat is installed, all smart-paste commands can be repeated
@@ -975,7 +975,7 @@ Replace current element with register (normal)  ~
 
         Feel free to unmap in |g:sexp_mappings|.
 
-Put register into list (normal)  ~
+Put register into current list (normal)  ~
 
 ["x] <LocalLeader>[p                                *<Plug>(sexp_put_at_head)*
 ["x] <LocalLeader>]p                                *<Plug>(sexp_put_at_tail)*
@@ -1000,7 +1000,7 @@ Replace operator (normal)  ~
 ["x] <M-P>                                         *<Plug>(sexp_replace_op_P)*
         Works just like the corresponding non-operator replace commands, but
         instead of the element at the cursor, replaces the S-expression(s)
-        covered by the operator motion/object range.
+        selected by the operator motion/object range.
 
                                              *sexp-replace-target-constraints*
         The target range may contain multiple S-expressions, but must not
@@ -1015,12 +1015,12 @@ Replace operator (normal)  ~
 
         Examples:  ~
         1. Replace current list:  `<M-p>af`
-        2. Replace current element without updating @":  `<M-P>ae`
+        2. Replace current element without updating @":  `<M-P>ie`
         3. Replace second child of current list:  `<M-p>2ic`
         4. Replace current and next two elements: `<M-p>3E`
 
         For a powerful approach to replacing elements in distant branches of
-        the sexp tree, (optionally) without moving the cursor, see
+        the sexp tree, (optionally) without even moving the cursor, see
         |sexp-operator-telescopic-mode|.
 
 
@@ -1031,8 +1031,7 @@ Put operator (normal)  ~
 ["x] `<p`                                         *<Plug>(sexp_put_before_op)*
         Works just like the corresponding non-operator put before/after
         commands, but instead of the element at the cursor, puts before/after
-        the first/last element covered (fully or partially) by the
-        motion/object range.
+        the first/last element selected by the motion/object range.
 
                                                  *sexp-put-target-constraints*
         The target may contain multiple elements, but only the element at the
@@ -1064,9 +1063,10 @@ Put operator (normal)  ~
         |g:sexp_regput_enable_teleop| enables an alternative interpretation of
         operator motions, which gives them meaning even when they reach across
         tree levels: rather than selecting the forms "moved over", a motion
-        can select the form "reached" by the motion search. The concept is
-        best illustrated with an example, for which the following option
-        settings are assumed:
+        can select the form "reached" by the motion search. Because this mode
+        permits "action at a distance", it is known as "telescopic mode". The
+        concept is best illustrated with an example, for which the following
+        option settings are assumed:
 
           `g:sexp_regput_enable_teleop == 1`
           `g:sexp_regput_curpos == 2`
@@ -1081,16 +1081,47 @@ Put operator (normal)  ~
           <M-p>?foo<CR>
           <M-p>ie
 <
-        Because this mode permits "action at a distance", it is known as
-        "telescopic" mode. This feature is still considered experimental
-        because additional work is needed to ensure it works properly with all
+        Note that |g:sexp_regput_enable_teleop| is not a simple flag but an
+        enumerated value. Setting it to 1 enables "telescopic mode" only for
+        jumps to other levels of the sexp tree. To enable telescopic mode
+        unconditionally, even within the same sexp tree node, set to 2 or 3: 3
+        if you want this behavior for all operators, 2 if you want it only for
+        the put operator (for which the traditional motion interpretation
+        tends to be less useful). The following example illustrates the
+        difference between conditionally and unconditionally enabled
+        "telescopic mode".
+
+        Unnamed:      `blammo`
+        Options:      `g:sexp_regput_enable_teleop == 1`
+                      `g:sexp_regput_curpos_op == 2`
+        Initial Form: `(|foo bar baz)`
+        Command:      `<M-p>fz`
+        
+        `g:sexp_regput_enable_teleop == 1`
+        Final:       `(|blammo)`
+        Explanation: Under the traditional motion interpretation, `fz` selects
+        all 3 elements in the list, and thus all 3 elements are replaced by
+        the contents of the unnamed register.
+
+        `g:sexp_regput_enable_teleop == 3`
+        Final:       `(|foo bar blammo)`
+        Explanation: In "telescopic mode", `fz` targets only the final element
+        of the list ("baz"), and thus, only that element is replaced.
+<
+        Note: Regardless of the setting of |g:sexp_regput_enable_teleop|,
+        telescopic mode is inhibited when vim-sexp can tell that a text object
+        (or vim-sexp object) was used as the target of the operator.
+
+        **CAVEAT**: This feature is still considered experimental because
+        additional work is needed to ensure it works properly with all
         vim-sexp motions, but it already works well with non-sexp search
         operators (e.g., `/` and `?`) and even works with motion plugins like
         vim-easymotion. The issue with vim-sexp motions is that they sometimes
         exclude brackets from the motion in a way that is generally helpful to
-        the user, but which breaks the telescopic selection logic.
-        Fortunately, there's a workaround, which should be implemented in a
-        subsequent version...
+        the user, but breaks the telescopic selection logic. Fortunately,
+        there's a workaround, which should be implemented in a subsequent
+        version...
+
 
 Overriding Builtin Put Commands  ~
 You may not have much need for Vim's builtin put commands once you become
@@ -1888,6 +1919,21 @@ Set to 1 to make the replace operator use partial element selections.
         let g:sexp_regput_replace_expanded = 0
 <
 
+                                                 *g:sexp_regput_enable_teleop*
+Enumerated value that determines the conditions under which put/replace
+operators use "telescopic mode" rather than traditional Vim motions/objects.
+  0  Never use "telescopic mode".
+  1  Use "telescopic mode" for motions whose endpoints lie in different sexp
+     tree nodes.
+  2  Like 1, but always use "telescopic mode" for the put operator.
+  3  Always use "telescopic mode".
+
+
+
+>
+        " Default
+        let g:sexp_regput_enable_teleop = 0
+<
 Expert options ~
 
                                                      *g:sexp_inhibit_failsafe*
@@ -1994,10 +2040,14 @@ Note: To unbind a command, simply set its <lhs> to an empty string.
             \ 'sexp_put_after':                 '<LocalLeader>p',
             \ 'sexp_replace_op':                '<M-p>',
             \ 'sexp_replace_op_P':              '<M-P>',
-            \ 'sexp_replace':                   '<M-p>',
-            \ 'sexp_replace_P':                 '<M-P>',
+            \ 'sexp_replace':                   {'x': '<LocalLeader>p',
+            \                                    'n': '<LocalLeader><LocalLeader>p'},
+            \ 'sexp_replace_P':                 {'x': '<LocalLeader>P',
+            \                                    'n': '<LocalLeader><LocalLeader>P'},
             \ 'sexp_put_at_head':               '<p',
             \ 'sexp_put_at_tail':               '>p',
+            \ 'sexp_put_at_head':               '<LocalLeader>[p',
+            \ 'sexp_put_at_tail':               '<LocalLeader>]p',
             \ }
 <
 Override Example: ~

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -899,12 +899,12 @@ well as an optional [count] whose usage is documented with the corresponding
 command. Commands that replace existing elements have distinct `p` and `P`
 variants: by analogy with builtin `p` and `P`, the former updates the unnamed
 register (`@"`); the latter does not. By default, the cursor will be left at
-the head of the put text, but this can be changed with option
-|g:sexp_regput_curpos|. All put (paste) commands perform an automatic
-re-indent on a range whose size is determined by |g:sexp_auto_indent_range|.
-By default, vim-sexp attempts to validate register contents before pasting
-them. To learn more about this behavior, including how to disable/customize
-it, see |sexp-regput-register-parsing|.
+the head of the put text, but this can be changed with options
+|g:sexp_regput_curpos| and |g:sexp_regput_into_curpos|. All put (paste)
+commands perform an automatic re-indent on a range whose size is determined by
+|g:sexp_auto_indent_range|. By default, vim-sexp attempts to validate register
+contents before pasting them. To learn more about this behavior, including how
+to disable/customize it, see |sexp-regput-register-parsing|.
 
 Note: Although most users will probably wish to remap the builtin put
 operators to vim-sexp's smarter, Lisp-aware counterparts, the builtin put
@@ -1024,13 +1024,21 @@ same thing with only 3 commands, regardless of list length:
         ]p       replace final element with unnamed register
         2[p      replace second element of list with unnamed register
 <
+Caveat: In some scenarios, the sequence above may require an extra movement or
+two to move cursor off a child list bracket to prevent the child list from
+being treated as the target of the "replace child" command. The exact sequence
+may depend on the following option settings:
+        |g:sexp_regput_bracket_is_child|
+        |g:sexp_regput_into_curpos|
                                               *sexp-regput-cursor-positioning*
 Cursor Positioning  ~
 By default, the cursor is positioned at the start of the pasted form(s), but
-if you prefer that the cursor be left at the end (as it is for Vim's builtin
-`p` operator), simply set |g:sexp_regput_curpos| to 1. Alternatively, for a
-more "telescopic" (put at-a-distance) feel, set the option to 2 to preserve
-the original (pre-paste) cursor position.
+if you prefer that the cursor be left at the end (as with Vim's builtin `p`
+operator), set |g:sexp_regput_curpos| and/or |g:sexp_regput_into_curpos| to 1.
+Two options are provided to allow the put commands that put into lists to be
+configured independently of the commands that target the element at cursor.
+Alternatively, for a more "telescopic" (put at-a-distance) feel, set the
+option to 2 to preserve the original (pre-paste) cursor position.
 
                                                 *sexp-regput-register-parsing*
 Register Parsing  ~
@@ -1271,8 +1279,8 @@ For details, see section |sexp-auto-indent|.
         let g:sexp_auto_indent = -1
 <
                                                     *g:sexp_auto_indent_range*
-One or two character string indicating how the line range for an auto-indent
-should be calculated. The characters have the following meanings:
+One of the following characters indicating how the line range for an
+auto-indent should be calculated:
 
   'm'  use algorithm to find the minimal region required to guarantee
        correctness. (Assumes the indentation was correct before the operation
@@ -1290,11 +1298,13 @@ keep comments aligned. Others may prefer keeping the re-indent small (and
 fast) with 'm', using `sexp_align_comments_top` (`<M-\>`) to re-align comments
 manually only after they've become unacceptably "ragged".
 
-2-character format:  ~
+2-character format (DEPRECATED):  ~
 So that you needn't remember to change this option every time you enable or
 disable comment alignment, this option also recognizes a 2-character format,
 in which the second character specifies the range to use when comment
 alignment is enabled.
+**Note:** The 2-character format will probably be deleted in the near future
+(before initial feature release), so it's best not to rely on it.
 
 Examples:  ~
 >
@@ -1622,7 +1632,7 @@ For details, see |sexp-regput-overriding-builtins|.
 <
                                                         *g:sexp_regput_curpos*
 Determines where cursor is placed after a register put ("smart paste")
-command:
+command that targets current element (or cursor position):
   0  head of put form(s)
   1  tail of put form(s)
   2  preserve original cursor position (as closely as possible)
@@ -1631,6 +1641,18 @@ For details, see |sexp-regput-cursor-positioning|.
 >
         " Default
         let g:sexp_regput_curpos = 0
+<
+                                                   *g:sexp_regput_into_curpos*
+Determines where cursor is placed after a register put ("smart paste")
+command that puts into a list (both insert and replace variants):
+  0  head of put form(s)
+  1  tail of put form(s)
+  2  preserve original cursor position (as closely as possible)
+  
+For details, see |sexp-regput-cursor-positioning|.
+>
+        " Default
+        let g:sexp_regput_into_curpos = 0
 <
                                              *g:sexp_regput_bracket_is_target*
 When this is set, |<Plug>(sexp_put_before)| and |<Plug>(sexp_put_after)| are

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -893,23 +893,26 @@ LIST MANIPULATION (normal, visual) ~
 REGISTER PUT ("SMART PASTE") COMMANDS (normal, visual) ~
                                         *sexp-smart-paste* *sexp-register-put*
 
-All of the register put (paste) commands accept an optional register name via
-the standard Vim mechanism (e.g., `"ap` to put from the `"a` register), as
-well as an optional [count] whose usage is documented with the corresponding
-command. Commands that replace existing elements have distinct `p` and `P`
-variants: by analogy with builtin `p` and `P`, the former updates the unnamed
-register (`@"`); the latter does not. By default, the cursor will be left at
-the head of the put text, but this can be changed with options
+All of the register put (paste) commands (and operators) accept an optional
+register name via the standard Vim mechanism (e.g., `"ap` to put from the `"a`
+register), as well as an optional [count] whose usage is documented with the
+corresponding command. Commands that replace existing elements have distinct
+`p` and `P` variants: by analogy with builtin `p` and `P`, the former updates
+the unnamed register (|@"|); the latter does not. By default, the cursor will
+be left at the head of the put text, but this can be changed with options
 |g:sexp_regput_curpos| and |g:sexp_regput_into_curpos|. All put (paste)
 commands perform an automatic re-indent on a range whose size is determined by
 |g:sexp_auto_indent_range|. By default, vim-sexp attempts to validate register
 contents before pasting them. To learn more about this behavior, including how
 to disable/customize it, see |sexp-regput-register-parsing|.
 
+Note: If vim-repeat is installed, the replace commands/operators can be
+repeated with the |.| command.
+
 Note: Although most users will probably wish to remap the builtin put
-operators to vim-sexp's smarter, Lisp-aware counterparts, the builtin put
-operators will not be overridden without an explicit request via one of the
-methods discussed in |sexp-regput-overriding-builtins|.
+commands to vim-sexp's smarter, Lisp-aware counterparts, the builtins will not
+be overridden without an explicit request via one of the methods discussed in
+|sexp-regput-overriding-builtins|.
 
 Put register before/after (normal)  ~
                                                                     *sexp_put*
@@ -941,14 +944,42 @@ Put register before/after (normal)  ~
         line as the cursor forces a line break between the put text and the
         adjacent element.
 
-Replace element/selection with register (normal, visual)  ~
+Replace operator (normal)  ~
+                                                       *sexp-replace-operator*
+
+["x] <M-p>                                           *<Plug>(sexp_replace_op)*
+["x] <M-P>                                         *<Plug>(sexp_replace_op_P)*
+        Replace a target determined by one of the following with `[count]`
+        copies of register x:
+
+                * a motion
+                * a builtin text object
+                * a vim-sexp object (e.g., inner/outer element/list/child)
+
+                                             *sexp-replace-target-constraints*
+        Note: The target may contain multiple S-expressions, but may not cross
+        list boundaries, and must not contain partial S-expressions, unless
+        |g:sexp_regput_replace_expanded| is set, in which case, the target
+        will be expanded to include all of any partially selected
+        S-expressions.
+
+        Note: The `[count]` mentioned above is the count for the replace
+        operator itself; the motion/object that determines the target may have
+        its own count: e.g., `3<M-p>2ic` would replace the 2nd inner child
+        of the current list with 3 copies of the unnamed register.
+
+        The commands ending in `P` do not update the unnamed register.
+
+Replace visual selection with register (visual)  ~
 
 ["x] <M-p>                                              *<Plug>(sexp_replace)*
 ["x] <M-P>                                            *<Plug>(sexp_replace_P)*
-        Replace the current element or visual selection with [count] copies of
-        register `x`, first expanding the visual selection to include all of any
-        partially selected elements. `<M-P>` does not update the unnamed
-        register.
+        Replace the visually selected S-expression(s) with `[count]` copies of
+        register `x`.
+        Note: Constraints on the visual selection work just like constraints
+        on operator targets. (See |sexp-replace-target-constraints|.)
+
+        `<M-P>` does not update the unnamed register.
 
 Put register into list (normal)  ~
 
@@ -960,25 +991,13 @@ Put register into list (normal)  ~
 
         See also |sexp-regput-definition-of-current-list|.
 
-Replace child with register (normal)  ~
-
-["x] <LocalLeader>[p                            *<Plug>(sexp_replace_at_head)*
-["x] <LocalLeader>]p                            *<Plug>(sexp_replace_at_tail)*
-["x] <LocalLeader>[P                          *<Plug>(sexp_replace_at_head_P)*
-["x] <LocalLeader>]P                          *<Plug>(sexp_replace_at_tail_P)*
-        Replace the [count]th child from head (`<LocalLeader>[p`) or tail
-        (`<LocalLeader>]p`) with register x. The commands ending in `P` do not
-        update the unnamed register.
-
-        See also |sexp-regput-definition-of-current-list|.
-
                                        *sexp-regput-definition-of-current-list*
 Definition of "Current List"  ~
-By default, the preceding two commands treat a list whose bracket or macro
-char is under the cursor as the current list. Some users may prefer that a
-list be treated as a simple child element when the cursor is positioned on one
-of its terminals. The advantage of such an approach is consistency: as long as
-the cursor is positioned on element terminals, the result of the put will not
+By default, the preceding command treats a list whose bracket or macro char is
+under the cursor as the current list. Some users may prefer that a list be
+treated as a simple child element when the cursor is positioned on one of its
+terminals. The advantage of such an approach is consistency: as long as the
+cursor is positioned on element terminals, the result of the put will not
 depend on whether the element is a list or atom; in either case, the
 containing list is the target of the put. If you wish to enable this approach,
 set |g:sexp_regput_bracket_is_child| to 1.
@@ -987,28 +1006,23 @@ cursor is on the terminals of a toplevel list.
 
                                              *sexp-regput-overriding-builtins*
 Overriding Builtin Put Commands  ~
-You may not have much need for Vim's builtin put operators once you become
-comfortable with vim-sexp's "smart paste" commands. Since the default mappings
-are not as convenient as builtins, you may wish to remap Vim's builtin put
-operators to vim-sexp smart paste commands. The following snippet is provided
-to facilitate this. Either copy it into your |g:sexp_mappings| list to serve
-as a basis for further customization or set |g:sexp_regput_override_builtins|
-to use it as-is.
+You may not have much need for Vim's builtin put commands once you become
+comfortable with vim-sexp's "smart paste" commands and operators. Since the
+default mappings are not as convenient as builtins, you may wish to remap
+Vim's builtin put operators to vim-sexp smart paste commands. The following
+snippet is provided to facilitate this. Either copy it into your
+|g:sexp_mappings| list to serve as a basis for further customization or set
+|g:sexp_regput_override_builtins| to use it as-is.
 >
-    \ 'sexp_put_before':                   {'n': 'P'},
-    \ 'sexp_put_after':                    {'n': 'p'},
-    \ 'sexp_replace':                      {'n': '<M-p>', 'x': 'p'},
-    \ 'sexp_replace_P':                    {'n': '<M-P>', 'x': 'P'},
-    \ 'sexp_put_at_head':                  {'n': '<p'},
-    \ 'sexp_put_at_tail':                  {'n': '>p'},
-    \ 'sexp_replace_at_head':              {'n': '[p'},
-    \ 'sexp_replace_at_tail':              {'n': ']p'},
-    \ 'sexp_replace_at_head_P':            {'n': '[P'},
-    \ 'sexp_replace_at_tail_P':            {'n': ']P'},
+    \ 'sexp_put_before':                   'P',
+    \ 'sexp_put_after':                    'p',
+    \ 'sexp_replace_op':                   '<M-p>',
+    \ 'sexp_replace_op_P':                 '<M-P>',
+    \ 'sexp_replace':                      'p',
+    \ 'sexp_replace_P':                    'P',
+    \ 'sexp_put_at_head':                  '<p',
+    \ 'sexp_put_at_tail':                  '>p',
 <
-Note: Because the put before/after commands are unavailable in visual mode,
-`p` and `P` are also used for visual mode `sexp_replace`, making `vp` and `vP`
-effectively aliases to `<M-p>` and `<M-P>`.
 
 p versus P (a Motivating Example)  ~
 Although `<M-j>`, `<M-k>`, `<M-h>`, `<M-l>` can be used to swap adjacent
@@ -1017,28 +1031,27 @@ if you wished to swap the second and final elements of a list, you'd need to
 perform the number of swaps needed to move the second element to the end of
 the list, then separately, the number of swaps needed to bring the final
 element to the second slot in the list. Very tedious. But using the "replace
-child" variants that update the unnamed register, you could accomplish the
+operator" variant that updates the unnamed register, you could accomplish the
 same thing with only 3 commands, regardless of list length:
 >
-        y2ic     yank second "inner child" into unnamed register
-        ]p       replace final element with unnamed register
-        2[p      replace second element of list with unnamed register
+        y2ic       yank second "inner child" into unnamed register
+        <M-p>iC    replace final element with unnamed register
+        <M-p>2ic   replace second element of list with unnamed register
 <
-Caveat: In some scenarios, the sequence above may require an extra movement or
-two to move cursor off a child list bracket to prevent the child list from
-being treated as the target of the "replace child" command. The exact sequence
-may depend on the following option settings:
-        |g:sexp_regput_bracket_is_child|
-        |g:sexp_regput_into_curpos|
+Note: If the second child in the example happened to be a list, you would need
+to move the cursor off its list bracket after the yank to ensure the replace
+operators targeted the parent list and not the yanked child.
+
                                               *sexp-regput-cursor-positioning*
 Cursor Positioning  ~
 By default, the cursor is positioned at the start of the pasted form(s), but
 if you prefer that the cursor be left at the end (as with Vim's builtin `p`
 operator), set |g:sexp_regput_curpos| and/or |g:sexp_regput_into_curpos| to 1.
-Two options are provided to allow the put commands that put into lists to be
-configured independently of the commands that target the element at cursor.
-Alternatively, for a more "telescopic" (put at-a-distance) feel, set the
-option to 2 to preserve the original (pre-paste) cursor position.
+Two options are provided to allow the put commands that put into lists
+(|<Plug>(sexp_put_at_head)| and |<Plug>(sexp_put_at_tail)|) to be configured
+independently of the others. Alternatively, for a more "telescopic" (put
+at-a-distance) feel, set the option to 2 to preserve the original (pre-paste)
+cursor position.
 
                                                 *sexp-regput-register-parsing*
 Register Parsing  ~
@@ -1632,7 +1645,7 @@ For details, see |sexp-regput-overriding-builtins|.
 <
                                                         *g:sexp_regput_curpos*
 Determines where cursor is placed after a register put ("smart paste")
-command that targets current element (or cursor position):
+command that targets current element, visual selection, or operator target:
   0  head of put form(s)
   1  tail of put form(s)
   2  preserve original cursor position (as closely as possible)
@@ -1643,8 +1656,11 @@ For details, see |sexp-regput-cursor-positioning|.
         let g:sexp_regput_curpos = 0
 <
                                                    *g:sexp_regput_into_curpos*
-Determines where cursor is placed after a register put ("smart paste")
-command that puts into a list (both insert and replace variants):
+Determines where cursor is placed after either of the register put ("smart
+paste") commands that put into a list: i.e.,
+        |<Plug>(sexp_put_at_head)|
+        |<Plug>(sexp_put_at_tail)|
+
   0  head of put form(s)
   1  tail of put form(s)
   2  preserve original cursor position (as closely as possible)
@@ -1652,7 +1668,7 @@ command that puts into a list (both insert and replace variants):
 For details, see |sexp-regput-cursor-positioning|.
 >
         " Default
-        let g:sexp_regput_into_curpos = 0
+        let g:sexp_regput_into_curpos = g:sexp_regput_curpos
 <
                                              *g:sexp_regput_bracket_is_target*
 When this is set, |<Plug>(sexp_put_before)| and |<Plug>(sexp_put_after)| are
@@ -1667,12 +1683,11 @@ list (i.e., `P` from head or `p` from tail).
 <
 
                                               *g:sexp_regput_bracket_is_child*
-When this is set, the register put commands that put into a list (or replace a
-child element) will not treat a non-toplevel list whose brackets/macro chars
-are under the cursor as the target list, but will instead target its parent.
-In other words, setting this option ensures a list is not considered current
-unless the cursor is completely inside it (or there are no more containing
-lists).
+When this is set, the register put commands that put into a list will not
+treat a non-toplevel list whose brackets/macro chars are under the cursor as
+the target list, but will instead target its parent. In other words, setting
+this option ensures a list is not considered current unless the cursor is
+completely inside it (or there are no more containing lists).
 Motivation: To understand why you might wish to set this, see
 |sexp-regput-definition-of-current-list|.
 >
@@ -1853,14 +1868,14 @@ Note: To unbind a command, simply set its <lhs> to an empty string.
             \ 'sexp_emit_tail_element':         '<M-S-k>',
             \ 'sexp_capture_prev_element':      '<M-S-h>',
             \ 'sexp_capture_next_element':      '<M-S-l>',
-            \ 'sexp_put_before':                {'n': 'P'},
-            \ 'sexp_put_after':                 {'n': 'p'},
-            \ 'sexp_replace':                   {'n': 'gp', 'x': 'p'},
-            \ 'sexp_replace_P':                 {'n': 'gP', 'x': 'P'},
-            \ 'sexp_put_at_head':               {'n': '<M-p>'},
-            \ 'sexp_put_at_tail':               {'n': '<M-P>'},
-            \ 'sexp_replace_at_head':           {'n': '<LocalLeader>p'},
-            \ 'sexp_replace_at_tail':           {'n': '<LocalLeader>P'},
+            \ 'sexp_put_before':                '<LocalLeader>P',
+            \ 'sexp_put_after':                 '<LocalLeader>p',
+            \ 'sexp_replace_op':                '<M-p>',
+            \ 'sexp_replace_op_P':              '<M-P>',
+            \ 'sexp_replace':                   '<M-p>',
+            \ 'sexp_replace_P':                 '<M-P>',
+            \ 'sexp_put_at_head':               '<p',
+            \ 'sexp_put_at_tail':               '>p',
             \ }
 <
 Override Example: ~

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -1090,7 +1090,7 @@ Put operator (normal)  ~
         following option settings are assumed:
 
           |g:sexp_regput_tele_motion| >= 1
-          |g:sexp_regput_curpos| == 2
+          |g:sexp_regput_curpos_op| == 2
 >
           (foo (bar)
                (|baz))

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -895,17 +895,17 @@ REGISTER PUT ("SMART PASTE") COMMANDS (normal, visual) ~
 
 All of the register put (paste) commands and operators accept an optional
 register name via the standard Vim mechanism (e.g., `"ap` to put from the `"a`
-register). The non-operator put commands also accept an optional `[count]`,
-whose usage is documented with the corresponding command. Commands that
-replace existing elements have distinct `p` and `P` variants: by analogy with
-builtin `p` and `P`, the former updates the unnamed register (|@"|); the
-latter does not. By default, the cursor is left at the head of the put text,
-but this can be changed with option |g:sexp_regput_curpos| and its several
-variants. All put (paste) commands and operators perform an automatic
-re-indent on a range whose size is determined by |g:sexp_auto_indent_range|.
-By default, vim-sexp attempts to validate register contents before pasting
-them. To learn more about this behavior, including how to disable/customize
-it, see |sexp-regput-register-parsing|.
+register). The non-operator commands also accept an optional `[count]`, whose
+usage is documented with the corresponding command. Commands that replace
+existing elements have distinct `p` and `P` variants: by analogy with builtin
+`p` and `P`, the former updates the unnamed register (|@"|); the latter does
+not. By default, the cursor is left at the head of the put text, but this can
+be changed with option |g:sexp_regput_curpos| and its several variants. All
+put (paste) commands and operators perform an automatic re-indent on a range
+whose size is determined by |g:sexp_auto_indent_range|. By default, vim-sexp
+attempts to validate register contents before pasting them. To learn more
+about this behavior, including how to disable/customize it, see
+|sexp-regput-register-parsing|.
 
 Note: If vim-repeat is installed, all smart-paste commands can be repeated
 with the "." command. Smart-paste operators can be repeated if and only if
@@ -918,7 +918,7 @@ be overridden without an explicit request via one of the methods discussed in
 |sexp-regput-overriding-builtins|.
 
 Put register before/after (normal)  ~
-                                                                    *sexp_put*
+                                                                    *sexp-put*
 
 ["x]<LocalLeader>p                                    *<Plug>(sexp_put_after)*
 ["x]<LocalLeader>P                                   *<Plug>(sexp_put_before)*
@@ -936,55 +936,137 @@ Put register before/after (normal)  ~
                 <LocalLeader>p ==> |<Plug>(sexp_put_at_head)|
                 <LocalLeader>P ==> |<Plug>(sexp_put_at_tail)|
         I.e., the register text will be inserted into the head or tail of the
-        list at an offset determined by [count]. If you would prefer that this
+        list at an offset determined by `[count]`. If you prefer that this
         command treat lists just like regular elements, simply set option
         *g:sexp_regput_bracket_is_target* to 0.
 
         Note: If there is no current element, the register contents are put
         before or after the cursor position; moreover, there is a subtle
         difference between `<LocalLeader>p` and `<LocalLeader>P` in this case:
-        in particular, putting _away from_ an adjacent element on the same
+        in particular, putting *away from* an adjacent element on the same
         line as the cursor forces a line break between the put text and the
         adjacent element.
+
+
+Replace selection with register (visual)  ~
+                                                                *sexp-replace*
+
+["x] <M-p>                                              *<Plug>(sexp_replace)*
+["x] <M-P>                                            *<Plug>(sexp_replace_P)*
+        Replace the visually selected element(s) with `[count]` copies of
+        register `x`.
+
+        To prevent unbalanced forms, the command aborts with a warning if the
+        selection endpoints do not lie within the same node of the sexp tree.
+
+        `<M-P>` does not update the unnamed register.
+
+Replace current element with register (normal)  ~
+
+["x] <LocalLeader><LocalLeader>p                        *<Plug>(sexp_replace)*
+["x] <LocalLeader><LocalLeader>P                      *<Plug>(sexp_replace_P)*
+        Replace element at cursor with `[count]` copies of register `x`.
+
+        `<M-P>` does not update the unnamed register.
+
+        Note: The mapping for this command is intentionally long (and
+        inconvenient) since you can get the same behavior with the
+        corresponding replace operator: i.e., `<M-p>ie`
+
+        Feel free to unmap in |g:sexp_mappings|.
+
+Put register into list (normal)  ~
+
+["x] <LocalLeader>[p                                *<Plug>(sexp_put_at_head)*
+["x] <LocalLeader>]p                                *<Plug>(sexp_put_at_tail)*
+        Put register `x` into the current list, just before the `[count]`th
+        child from head (`<LocalLeader>[p`) or after the `[count]`th child
+        from tail (`<LocalLeader>]p`).
+
+        Note: The mapping for this command is intentionally long (and
+        inconvenient) since you can get the same behavior with the
+        corresponding put operator followed by an inner/outer "child object"
+        with a `[count]`: e.g.,
+                `>p2ic` to put after the second child.
+
+        Feel free to unmap in |g:sexp_mappings|.
+
+        See also |sexp-regput-definition-of-current-list|.
 
 Replace operator (normal)  ~
                                                        *sexp-replace-operator*
 
 ["x] <M-p>                                           *<Plug>(sexp_replace_op)*
 ["x] <M-P>                                         *<Plug>(sexp_replace_op_P)*
-        Replace a target determined by a motion or text/sexp object with the
-        contents of register x. 
+        Works just like the corresponding non-operator replace commands, but
+        instead of the element at the cursor, replaces the S-expression(s)
+        covered by the operator motion/object range.
 
                                              *sexp-replace-target-constraints*
-        The target may contain multiple S-expressions, and must not contain
-        partial S-expressions, unless |g:sexp_regput_replace_expanded| is set,
-        in which case, the target will be expanded to include all of any
-        partially selected S-expressions. Moreover, the motion endpoints must
-        lie within the same node of the sexp tree unless you've set option
-        |g:sexp_regput_enable_teleop|, which is the subject of the following
-        section.
-
-        Note: Unlike the non-operator smart paste commands, the replace
-        operator does not use a `[count]`. If you supply one, Vim's operator
-        mechanism will use it as a multiplier for any count used with the
-        motion/object (probably not what you intended).
-        **Warning**: Use counts only with the motion/operator and do not
-        use a count with the "." (repeat) operator when using it to repeat a
-        replace operation.
+        The target range may contain multiple S-expressions, but must not
+        contain partial S-expressions, unless |g:sexp_regput_replace_expanded|
+        is set, in which case, the target will be expanded to include all of
+        any partially selected S-expressions. As with the visual replace
+        commands, the motion endpoints must lie within the same node of the
+        sexp tree unless you've set |g:sexp_regput_enable_teleop| to enable
+        "telescopic mode", as described in |sexp-operator-telescopic-mode|.
 
         The commands ending in `P` do not update the unnamed register.
 
+        Examples:  ~
+        1. Replace current list:  `<M-p>af`
+        2. Replace current element without updating @":  `<M-P>ae`
+        3. Replace second child of current list:  `<M-p>2ic`
+        4. Replace current and next two elements: `<M-p>3E`
+
+        For a powerful approach to replacing elements in distant branches of
+        the sexp tree, (optionally) without moving the cursor, see
+        |sexp-operator-telescopic-mode|.
+
+
+Put operator (normal)  ~
+                                                       *sexp-put-operator*
+
+["x] `>p`                                          *<Plug>(sexp_put_after_op)*
+["x] `<p`                                         *<Plug>(sexp_put_before_op)*
+        Works just like the corresponding non-operator put before/after
+        commands, but instead of the element at the cursor, puts before/after
+        the first/last element covered (fully or partially) by the
+        motion/object range.
+
+                                                 *sexp-put-target-constraints*
+        The target may contain multiple elements, but only the element at the
+        edge of the range determined by the put direction matters. As with the
+        replace operator, both motion endpoints must lie within the same node
+        of the sexp tree, unless you've set |g:sexp_regput_enable_teleop| to
+        enable "telescopic mode", as described in
+        |sexp-operator-telescopic-mode|.
+
+        Examples:  ~
+        1. Put before final element of current list:  `<piC`
+           Note: Equivalent to `2<LocalLeader>]p` (put into second slot from
+           tail of list)
+        2. Put after the second element beyond the current element: `>p3E`
+           Note: `3E` is used instead of `2W` because the `W` motion is
+           exclusive, and thus, would not include any part of the desired
+           target element.
+
+        For a powerful approach to putting before/after elements in distant
+        branches of the sexp tree, (optionally) without moving the cursor, see
+        |sexp-operator-telescopic-mode|.
+
 "Telescopic" Mode (***Experimental*** - Requires Vim Version >= 8.1) ~
-                                                *sexp-replace-telescopic-mode*
-        By default, vim-sexp's replace operators will refuse to operate on an
-        "unbalanced" region whose endpoints are not both contained within the
-        same node of the sexp tree. While this is necessary to minimize the
-        risk of creating unbalanced forms, setting option
-        |g:sexp_regput_enable_teleop| enables an additional interpretation of
+                                               *sexp-operator-telescopic-mode*
+        By default, vim-sexp's put/replace operators will refuse to operate on
+        an "unbalanced" region whose endpoints are not both contained within
+        the same node of the sexp tree. While this is necessary to minimize
+        the risk of creating unbalanced forms, setting option
+        |g:sexp_regput_enable_teleop| enables an alternative interpretation of
         operator motions, which gives them meaning even when they reach across
         tree levels: rather than selecting the forms "moved over", a motion
-        can select the form "reached" by the motion search. Here's an
-        illustrative example, which assumes the following option settings:
+        can select the form "reached" by the motion search. The concept is
+        best illustrated with an example, for which the following option
+        settings are assumed:
 
           `g:sexp_regput_enable_teleop == 1`
           `g:sexp_regput_curpos == 2`
@@ -1000,70 +1082,46 @@ Replace operator (normal)  ~
           <M-p>ie
 <
         Because this mode permits "action at a distance", it is known as
-        "telescopic" mode. It may also be referred to as "endpoint" mode. This
-        feature is still considered experimental because additional work is
-        needed to ensure it works properly with all vim-sexp motions, but it
-        already works well with non-sexp search operators (e.g., `/` and `?`)
-        and even works with motion plugins like vim-easymotion. The issue with
-        vim-sexp motions is that they sometimes exclude brackets from the
-        motion in a way that is generally helpful to the user, but which
-        breaks the telescopic selection logic. Fortunately, there's a
-        workaround, which should be implemented in a subsequent version...
+        "telescopic" mode. This feature is still considered experimental
+        because additional work is needed to ensure it works properly with all
+        vim-sexp motions, but it already works well with non-sexp search
+        operators (e.g., `/` and `?`) and even works with motion plugins like
+        vim-easymotion. The issue with vim-sexp motions is that they sometimes
+        exclude brackets from the motion in a way that is generally helpful to
+        the user, but which breaks the telescopic selection logic.
+        Fortunately, there's a workaround, which should be implemented in a
+        subsequent version...
 
-Replace visual selection with register (visual)  ~
-
-["x] <M-p>                                              *<Plug>(sexp_replace)*
-["x] <M-P>                                            *<Plug>(sexp_replace_P)*
-        Replace the visually selected S-expression(s) with `[count]` copies of
-        register `x`.
-        Note: Constraints on the visual selection work just like constraints
-        on operator targets. (See |sexp-replace-target-constraints|.)
-
-        `<M-P>` does not update the unnamed register.
-
-Put register into list (normal)  ~
-
-["x] <LocalLeader><p                                *<Plug>(sexp_put_at_head)*
-["x] <LocalLeader>>p                                *<Plug>(sexp_put_at_tail)*
-        Put register x into the current list, just before the `[count]`th
-        child from head (`<LocalLeader><p`) or after the `[count]`th child
-        from tail (`<LocalLeader>>p`).
-
-        See also |sexp-regput-definition-of-current-list|.
-
-                                       *sexp-regput-definition-of-current-list*
-Definition of "Current List"  ~
-By default, the preceding command treats a list whose bracket or macro char is
-under the cursor as the current list. Some users may prefer that a list be
-treated as a simple child element when the cursor is positioned on one of its
-terminals. The advantage of such an approach is consistency: as long as the
-cursor is positioned on element terminals, the result of the put will not
-depend on whether the element is a list or atom; in either case, the
-containing list is the target of the put. If you wish to enable this approach,
-set |g:sexp_regput_bracket_is_child| to 1.
-Note: Since a toplevel list has no parent, this option does not apply when the
-cursor is on the terminals of a toplevel list.
-
-                                             *sexp-regput-overriding-builtins*
 Overriding Builtin Put Commands  ~
 You may not have much need for Vim's builtin put commands once you become
 comfortable with vim-sexp's "smart paste" commands and operators. Since the
 default mappings are not as convenient as builtins, you may wish to remap
 Vim's builtin put operators to vim-sexp smart paste commands. The following
 snippet is provided to facilitate this. Either copy it into your
-|g:sexp_mappings| list to serve as a basis for further customization or set
-|g:sexp_regput_override_builtins| to use it as-is.
+|g:sexp_mappings| list to serve as a basis for further customization or simply
+set |g:sexp_regput_override_builtins| to use it as-is.
 >
     \ 'sexp_put_before':                   'P',
     \ 'sexp_put_after':                    'p',
-    \ 'sexp_replace_op':                   '<M-p>',
-    \ 'sexp_replace_op_P':                 '<M-P>',
-    \ 'sexp_replace':                      'p',
-    \ 'sexp_replace_P':                    'P',
-    \ 'sexp_put_at_head':                  '<p',
-    \ 'sexp_put_at_tail':                  '>p',
+    \ 'sexp_replace':                      {'x': 'p', 'n': '<LocalLeader>p'},
+    \ 'sexp_replace_P':                    {'x': 'P', 'n': '<LocalLeader>P'},
+    \ 'sexp_put_at_head':                  '[p',
+    \ 'sexp_put_at_tail':                  ']p',
 <
 
+REGISTER PUT (SMART-PASTE) (ADDITIONAL DETAILS...)
+
+                                                 *sexp-regput-operator-counts*
+Put/Replace Operator Counts  ~
+Unlike the non-operator smart paste commands, the put/replace operators do not
+use a `[count]`. If you supply one, Vim's operator mechanism will use it as a
+multiplier for any count used with the motion/object (probably not what you
+intended).
+**Warning**: Use counts only with the motion/operator and do not use a count
+with the "." (repeat) operator when using it to repeat a put/replace
+operation.
+
+                                             *sexp-regput-overriding-builtins*
 p versus P (a Motivating Example)  ~
 Although `<M-j>`, `<M-k>`, `<M-h>`, `<M-l>` can be used to swap adjacent
 elements, they're not ideal for swapping non-adjacent elements. For instance,
@@ -1087,11 +1145,13 @@ Cursor Positioning  ~
 By default, the cursor is positioned at the start of the pasted form(s), but
 if you prefer that the cursor be left at the end (as with Vim's builtin `p`
 operator), set |g:sexp_regput_curpos| and/or |g:sexp_regput_into_curpos| to 1.
-Two options are provided to allow the put commands that put into lists
-(|<Plug>(sexp_put_at_head)| and |<Plug>(sexp_put_at_tail)|) to be configured
-independently of the others. Alternatively, for a more "telescopic" (put
-at-a-distance) feel, set the option to 2 to preserve the original (pre-paste)
-cursor position.
+Alternatively, for a more "telescopic" (put at-a-distance) feel, set the
+option to 2 to preserve the original (pre-paste) cursor position.
+Note: The following variants of |g:sexp_regput_curpos| are provided to permit
+command-specific tailoring of cursor placement:
+        |g:sexp_regput_into_curpos|
+        |g:sexp_regput_op_curpos|
+        |g:sexp_regput_op_tele_curpos|
 
                                                 *sexp-regput-register-parsing*
 Register Parsing  ~
@@ -1213,6 +1273,20 @@ unconditionally.
 Note: This option does not _force_ leading comments to be appended; it merely
 requests that comments be treated the same as other elements for the purposes
 of determining single/multi-line put.
+
+                                       *sexp-regput-definition-of-current-list*
+Definition of "Current List"  ~
+By default, the "put into list" commands (|<Plug>(sexp_put_at_head)| and
+|<Plug>(sexp_put_at_tail)|) treat a list whose bracket or macro char is under
+the cursor as the current list. Some users may prefer that a list be treated
+as a simple child element when the cursor is positioned on one of its
+terminals. The advantage of such an approach is consistency: as long as the
+cursor is positioned on element terminals, the result of the put will not
+depend on whether the element is a list or atom; in either case, the
+**containing** list is the target of the put. If you wish to enable this
+approach, set |g:sexp_regput_bracket_is_child| to 1.
+Note: Since a toplevel list has no parent, this option does not apply when the
+cursor is on the terminals of a toplevel list.
 
 
 INSERT MODE MAPPINGS (insert, optional) ~
@@ -1684,31 +1758,32 @@ For details, see |sexp-regput-overriding-builtins|.
         let g:sexp_regput_override_builtins = 1
 <
                                                         *g:sexp_regput_curpos*
-Determines where cursor is placed after a register put ("smart paste")
-command that targets current element, visual selection, or operator target:
-  0  head of put form(s)
-  1  tail of put form(s)
-  2  preserve original cursor position (as closely as possible)
-  
-For details, see |sexp-regput-cursor-positioning|.
->
-        " Default
-        let g:sexp_regput_curpos = 0
-<
                                                    *g:sexp_regput_into_curpos*
-Determines where cursor is placed after either of the register put ("smart
-paste") commands that put into a list: i.e.,
-        |<Plug>(sexp_put_at_head)|
-        |<Plug>(sexp_put_at_tail)|
-
+                                                     *g:sexp_regput_op_curpos*
+                                                *g:sexp_regput_op_tele_curpos*
+Determines where cursor is placed after the corresponding register put or
+replace ("smart paste") command.
   0  head of put form(s)
   1  tail of put form(s)
   2  preserve original cursor position (as closely as possible)
   
+To make cursor positioning work the same for all commands/operators, simply
+set |g:sexp_regput_curpos| to the desired value.
+
+For users who desire different behavior for different command/operator
+classes, additional option variants are provided, organized hierarchically
+into the following tree, in which child elements inherit their values from
+their parents, recursively:
+
+        sexp_regput_curpos
+                sexp_regput_into_curpos
+                sexp_regput_op_curpos
+                        sexp_regput_op_tele_curpos
+
 For details, see |sexp-regput-cursor-positioning|.
 >
-        " Default
-        let g:sexp_regput_into_curpos = g:sexp_regput_curpos
+        " Default (all other variants default to -1)
+        let g:sexp_regput_curpos = 0
 <
                                              *g:sexp_regput_bracket_is_target*
 When this is set, |<Plug>(sexp_put_before)| and |<Plug>(sexp_put_after)| are
@@ -1804,6 +1879,13 @@ create an issue report.)
 >
         " Default
         let g:sexp_regput_inhibit_regparse = 0
+<
+
+                                              *g:sexp_regput_replace_expanded*
+Set to 1 to make the replace operator use partial element selections.
+>
+        " Default
+        let g:sexp_regput_replace_expanded = 0
 <
 
 Expert options ~

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -898,9 +898,15 @@ the standard Vim mechanism (e.g., `"ap` to put from the `"a` register), as
 well as an optional [count] whose usage is documented with the corresponding
 command. Commands that replace existing elements have distinct `p` and `P`
 variants: by analogy with builtin `p` and `P`, the former updates the unnamed
-register (`@"`); the latter does not. Finally, all put (paste) commands
-perform an automatic re-indent on a range whose size is determined by
-|g:sexp_auto_indent_range|.
+register (`@"`); the latter does not. By default, the cursor will be left at
+the head of the put text, but this can be changed with option
+|g:sexp_regput_curpos|. All put (paste) commands perform an automatic
+re-indent on a range whose size is determined by |g:sexp_auto_indent_range|.
+
+Note: Although most users will probably wish to remap the builtin put
+operators to vim-sexp's smarter, Lisp-aware counterparts, the builtin put
+operators will not be overridden without an explicit request via one of the
+methods discussed in |sexp-overriding-builtins|.
 
 Put register before/after (normal)  ~
                                                                     *sexp_put*
@@ -976,7 +982,7 @@ cursor is on the terminals of a toplevel list.
 
 IMPORTANT NOTE: |g:sexp_regput_bracket_is_child| is not yet supported.
 
-                                                *sexp-regput-builtin-overrides*
+                                             *sexp-regput-overriding-builtins*
 Overriding Builtin Put Commands  ~
 You may not have much need for Vim's builtin put operators once you become
 comfortable with vim-sexp's "smart paste" commands. Since the default mappings
@@ -1000,6 +1006,14 @@ to use it as-is.
 Note: Because the put before/after commands are unavailable in visual mode,
 `p` and `P` are also used for visual mode `sexp_replace`, making `vp` and `vP`
 effectively aliases to `<M-p>` and `<M-P>`.
+
+                                              *sexp-regput-cursor-positioning*
+Cursor Positioning  ~
+By default, the cursor is positioned at the start of the pasted form(s), but
+if you prefer that the cursor be left at the end (as it is for Vim's builtin
+`p` operator), simply set |g:sexp_regput_curpos| to 1. Alternatively, for a
+more "telescopic" (put at-a-distance) feel, set the option to 2 to preserve
+the original (pre-paste) cursor position.
 
                                              *sexp-regput-single-vs-multiline*
 Single vs Multi-line  ~
@@ -1564,10 +1578,22 @@ full (level 2) optimization.
                                              *g:sexp_regput_override_builtins*
 When this is set, several of Vim's builtin put operators are remapped to
 vim-sexp's "smart paste" commands.
-For details, see |sexp-regput-builtin-overrides|.
+For details, see |sexp-regput-overriding-builtins|.
 >
         " Default
         let g:sexp_regput_override_builtins = 1
+<
+                                                        *g:sexp_regput_curpos*
+Determines where cursor is placed after a register put ("smart paste")
+command:
+  0  head of put form(s)
+  1  tail of put form(s)
+  2  preserve original cursor position (as closely as possible)
+  
+For details, see |sexp-regput-cursor-positioning|.
+>
+        " Default
+        let g:sexp_regput_curpos = 0
 <
                                              *g:sexp_regput_bracket_is_target*
 When this is set, |<Plug>(sexp_put_before)| and |<Plug>(sexp_put_after)| are
@@ -1582,9 +1608,12 @@ list (i.e., `P` from head or `p` from tail).
 <
 
                                               *g:sexp_regput_bracket_is_child*
-When this is set, the register put commands that put into a list will not
-treat a non-toplevel list whose brackets/macro chars are under the cursor as
-the target list, but will instead target its parent.
+When this is set, the register put commands that put into a list (or replace a
+child element) will not treat a non-toplevel list whose brackets/macro chars
+are under the cursor as the target list, but will instead target its parent.
+In other words, setting this option ensures a list is not considered current
+unless the cursor is completely inside it (or there are no more containing
+lists).
 Motivation: To understand why you might wish to set this, see
 |sexp-regput-definition-of-current-list|.
 >

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -901,11 +901,11 @@ alignment, or even unbalanced forms after pasting text into a Lisp buffer,
 vim-sexp's "smart paste" commands are for you! The commands are broken into
 disctinct command and operator variants: the commands operate on a target
 determined by the cursor location; the operators give you "cybernetic arms",
-which can put or replace forms at a distance. The feature is highly
-customizable, with option names bearing the "sexp_regput" prefix. Even if you
-normally stick with plugin defaults, you should definitely read the section
-|sexp-regput-telescopic-motion| to ensure you get the most out of this
-feature.
+which can put or replace forms at a distance using "telescopic mode". The
+feature is highly customizable, with option names bearing the "sexp_regput"
+prefix. Even if you normally use plugin defaults, you should definitely read
+the section |sexp-regput-telescopic-motion| to ensure you get the most out of
+the operators.
 
 Overview  ~
 All of the register put (paste) commands and operators accept an optional
@@ -1024,10 +1024,11 @@ Replace operator (normal)  ~
         The target range may contain multiple S-expressions, but must not
         contain partial S-expressions, unless |g:sexp_regput_replace_expanded|
         is set, in which case, the target will be expanded to include all of
-        any partially selected S-expressions. As with the visual replace
-        commands, the motion endpoints must lie within the same node of the
-        sexp tree unless you've set |g:sexp_regput_tele_motion| to enable
-        "telescopic mode", as described in |sexp-regput-telescopic-motion|.
+        any partial selections. The target can be specified either with a
+        traditional operator-pending motion/object or with a "telescopic
+        motion", as described in section |sexp-regput-telescopic-motion|. If a
+        traditional motion is used, the motion endpoints must lie within the
+        same node of the sexp tree.
 
         The operator ending in `P` does not update the unnamed register.
 
@@ -1052,13 +1053,15 @@ Put operator (normal)  ~
         or last element selected by the operator's motion/object.
 
                                                  *sexp-put-target-constraints*
-        The target may contain multiple elements, but only the element at the
-        edge of the range corresponding to the put direction matters. As with
-        the replace operator, both motion endpoints must lie within the same
-        node of the sexp tree, unless you've set |g:sexp_regput_tele_motion|
-        to enable "telescopic mode" (see |sexp-regput-telescopic-motion|).
-        Additionaly, the selection must include the edge of the target in the
-        direction of the put: i.e., partial selections not allowed.
+        As with the replace operator, the target can be specified with either
+        a traditional operator-pending motion/object or a "telescopic motion"
+        (see |sexp-regput-telescopic-motion|). If a traditional motion is
+        used, the motion endpoints must lie within the same node of the sexp
+        tree, and although the range may contain multiple elements, only the
+        element at the edge of the range corresponding to the put direction
+        matters. Additionaly, the selection must include the edge of the
+        target in the direction of the put: i.e., partial selections not
+        allowed.
 
         Examples:  ~
         1. `<piC`      Put before final element of current list
@@ -1070,27 +1073,24 @@ Put operator (normal)  ~
                      the desired target element.
 
         ** Important Note **  ~
-        In its default mode, this command works best with text/sexp objects.
-        For a more powerful mode of operation that puts into distant branches
-        of the sexp tree, (optionally) without moving the cursor, see
+        For a powerful approach to putting into distant branches of the sexp
+        tree, (optionally) without moving the cursor, see
         |sexp-regput-telescopic-motion|.
 
 "Telescopic" Mode (***Experimental*** - Requires Vim Version >= 8.1) ~
                      *sexp-regput-tele-motion* *sexp-regput-telescopic-motion*
 
-        By default, vim-sexp's put/replace operators will refuse to operate on
-        an "unbalanced" region whose endpoints are not both contained within
-        the same node of the sexp tree. While this is necessary to minimize
-        the risk of creating unbalanced forms, setting option
-        |g:sexp_regput_tele_motion| enables an alternative interpretation of
-        operator motions, which gives them meaning even when they reach across
-        tree levels: rather than selecting the forms "moved over", a
-        "telescopic" motion selects the form "reached" by the motion search.
-        The concept is best illustrated with an example, for which the
-        following option settings are assumed:
-
-          |g:sexp_regput_tele_motion| >= 1
-          |g:sexp_regput_curpos_op| == 2
+        The smart-paste operators support both the traditional type of
+        operator motion/object (e.g., `iw` and `af`) as well as a new type
+        known as "telescopic motion". Rather than selecting the forms "moved
+        over", a telescopic motion treats the operator motion as a regular
+        search, selecting only the form on which the motion "lands". By
+        default, vim-sexp treats motions that look like "objects" (either text
+        objects or sexp objects) in the traditional way. Motions that cross
+        list boundaries are treated as "telescopic". Option
+        |g:sexp_regput_tele_motion| determines whether non-object motions
+        within a single node of the sexp tree are treated as traditional or
+        "telescopic" motions. The concept is best illustrated with an example:
 >
           (foo (bar)
                (|baz))
@@ -1103,21 +1103,28 @@ Put operator (normal)  ~
           <M-p>ie            replace current element with @"
 <
         Although use of the unnamed register to swap words is idiomatic Vim,
-        telescopic motions streamline the pattern by obviating the need to
-        move the cursor back and forth between the elements being swapped and
-        by handling any required re-indentation.
+        using the replace operator in telescopic mode streamlines the pattern
+        by obviating the need to move the cursor back and forth between the
+        elements being swapped and by automating any required re-indentation.
 
         Option Format  ~
                                               *sexp-tele-motion-option-format*
         Note that |g:sexp_regput_tele_motion| is not a simple flag but an
-        enumerated value. Setting it to 1 enables "telescopic mode" only for
-        jumps to other parts of the sexp tree. To enable telescopic mode
-        unconditionally (even within the same sexp tree node), set to 2 or 3:
-        3 if you want telescopic behavior for both put and replace operators,
-        2 if you want it only for the put operator (for which the traditional
-        motion interpretation tends to be less useful than it is for the
-        replace operator). The following example illustrates the difference
-        between conditionally and unconditionally enabled "telescopic mode".
+        enumerated value. Setting it to 1 enables "telescopic mode" only when
+        the endpoints of the motion range lie in different nodes of the sexp
+        tree. Because such motions cross list boundaries, interpreting them as
+        traditional motions/objects risks producing unbalanced forms; in
+        telescopic mode, however, such motions simply designate a distant form
+        as the target of a replacement or a put. Increasing the option value
+        to 2 or 3 permits use of telescopic mode even for motions that do not
+        cross list boundaries:
+          2 makes telescopic mode the default only for the put operator (for
+            which traditional motion interpretation is generally less useful).
+          3 makes telescopic behavior the default for both put and replace
+            operators.
+
+        The following example illustrates the difference between traditional
+        and telescopic modes as default.
 
         With cursor position indicated by `|` in the following form, and
         "blammo" in the unnamed register...
@@ -1129,22 +1136,26 @@ Put operator (normal)  ~
 
         g:sexp_regput_tele_motion == 1  ~
 >
-        (|blammo)
+        => (|blammo)
 <
-        Explanation: Under the traditional motion interpretation, `fz` selects
-        all 3 elements in the list, and thus all 3 elements are replaced by
-        the contents of the unnamed register.
+        Explanation: Since the motion does not cross list boundaries, and an
+        option value of 1 makes traditional mode the default, `fz` is
+        interpreted as a traditional motion selecting all 3 elements in the
+        list for replacement.
 
         g:sexp_regput_tele_motion == 3  ~
 >
-        (|foo bar blammo)
+        => (|foo bar blammo)
 <
-        Explanation: In "telescopic mode", `fz` targets only the final element
-        of the list ("baz"), and thus, only that element is replaced.
-<
+        Explanation: Because the option value makes telescopic mode the
+        default, `fz` targets only the final element of the list ("baz"), and
+        thus, only that element is replaced. Note that we could just as well
+        have selected the final element with `/baz<CR>`: in telescopic mode,
+        it is not necessary to select entire elements.
+
         Note: Regardless of the setting of |g:sexp_regput_tele_motion|,
         telescopic mode is inhibited when vim-sexp can tell that a text object
-        (or vim-sexp object) was used as the target of the operator.
+        (or vim-sexp object) was used.
 
 
 REGISTER PUT (SMART-PASTE) (ADDITIONAL DETAILS...)
@@ -1917,14 +1928,15 @@ Set to 1 to make the replace operator use partial element selections.
 Enumerated value that determines the conditions under which put/replace
 operators use "telescopic mode" rather than traditional Vim motions/objects.
   0  Never use "telescopic mode".
-  1  Use "telescopic mode" for motions whose endpoints lie in different sexp
-     tree nodes.
-  2  Like 1, but always use "telescopic mode" for the put operator.
-  3  Always use "telescopic mode".
+  1  Use "telescopic mode" only for motions whose endpoints lie in different
+     nodes of the sexp tree (i.e., motions that cross list boundaries)
+  2  Make "telescopic mode" the default for the put operator.
+  3  Make "telescopic mode" the default for both put and replace operators.
+
 See |sexp-regput-telescopic-motion| for details...
 >
         " Default
-        let g:sexp_regput_tele_motion = 0
+        let g:sexp_regput_tele_motion = 2
 <
 
                                        *g:sexp_regput_invalid_register_action*

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -898,7 +898,8 @@ well as an optional [count] whose usage is documented with the corresponding
 command. Commands that replace existing elements have distinct `p` and `P`
 variants: by analogy with builtin `p` and `P`, the former updates the unnamed
 register (`@"`); the latter does not. Finally, all put (paste) commands
-automatically reindent the affected region.
+perform an automatic re-indent on a range whose size is determined by
+|g:sexp_auto_indent_range|.
 
 Put register before/after (normal)  ~
 
@@ -906,6 +907,11 @@ Put register before/after (normal)  ~
 ["x]p                                                 *<Plug>(sexp_put_after)*
         Put [count] copies of register x before (`P`) or after (`p`) the
         current element.
+        Note: If there is no current element, the register contents are put
+        before or after the cursor position and there is a subtle difference
+        between `p` and `P`: in particular, putting _away from_ an adjacent
+        element on the same line as the cursor forces insertion of NL between
+        the put text and the adjacent element.
 
 Replace element with register (normal)  ~
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -1220,20 +1220,20 @@ telescopic, "put-at-a-distance" feel), set `g:sexp_regput_curpos = 1` and
                                                 *sexp-regput-register-parsing*
 Register Parsing  ~
 Before putting a register into the buffer, vim-sexp attempts to parse its
-contents as lisp code of a dialect corresponding to 'filetype'. The primary
+contents as Lisp code of a dialect corresponding to 'filetype'. The primary
 goal of this parsing is to detect problems such as unbalanced parentheses,
 which could render the code in the buffer malformed. A secondary goal is to
 characterize the register contents in a way that can inform decisions about
 how to separate the put text from the surrounding buffer text: e.g., Does the
 text begin or end with a comment? Does it contain multiple toplevel forms?
-The parsing is straightforward when Treesitter is available; when only the
-legacy syntax engine is available, vim-sexp must put the register contents
-into a hidden buffer where its own syntax-aware functions can be used to
-perform the parsing. In either case, the parsing should be completely
-invisible. With the default configuration, you will be prompted to decide
-whether to proceed with a put of invalid register contents. If you don't like
-this behavior, you can customize it with option
-|g:sexp_regput_invalid_register_action|.
+By default, the parsing is performed in a hidden buffer, using Treesitter if
+it's available, else vim-sexp's own syntax-aware functions. If the parse
+detects potential problems, you will be prompted to determine whether you wish
+to proceed with the put. If you wish to avoid the prompt, you can customize
+the default action with option |g:sexp_regput_invalid_register_action|. With
+Treesitter, it is also possible to request use of a string parser in lieu of
+the hidden buffer parse. See |g:sexp_regput_use_string_parser| for details.
+
 Note: Although it is possible to disable parsing altogether, it is not
 recommended. For details, see |g:sexp_regput_inhibit_regparse|.
 
@@ -1899,32 +1899,6 @@ For additional details, see |sexp-regput-list-shape-preservation|.
         let g:sexp_regput_ignore_list_shape = 0
 <
 
-                                       *g:sexp_regput_invalid_register_action*
-Enumerated value that determines how to handle an attempt to put text that
-fails to parse as valid lisp (of a dialect determined by buffer 'filetype').
-  -1  Present continue/abort prompt to user
-   0  Abort paste with warning
-   1  Paste with warning
-   2  Paste silently
-
->
-        " Default
-        let g:sexp_regput_invalid_register_action = -1
-<
-                                              *g:sexp_regput_inhibit_regparse*
-Set to 1 to inhibit the parsing of register contents described in
-|sexp-regput-register-parsing|. With parsing disabled, vim-sexp uses only
-simplistic, regex-based matching to determine the most critical information
-about the register: e.g., whether it contains comments. However, this approach
-is not able to fully and correctly characterize the register contents and
-makes no attempt to detect errors; thus, unless you're having issues with the
-parser, it's best not to disable it. (And if you do experience issues, please
-create an issue report.)
->
-        " Default
-        let g:sexp_regput_inhibit_regparse = 0
-<
-
                                               *g:sexp_regput_replace_expanded*
 Set to 1 to make the replace operator use partial element selections.
 >
@@ -1940,13 +1914,65 @@ operators use "telescopic mode" rather than traditional Vim motions/objects.
      tree nodes.
   2  Like 1, but always use "telescopic mode" for the put operator.
   3  Always use "telescopic mode".
-
-
-
 >
         " Default
         let g:sexp_regput_tele_motion = 0
 <
+
+                                       *g:sexp_regput_invalid_register_action*
+Enumerated value that determines how to handle an attempt to put text that
+fails to parse as valid lisp (of a dialect determined by buffer 'filetype').
+  -1  Present continue/abort prompt to user
+   0  Abort paste with warning
+   1  Paste with warning
+   2  Paste silently
+
+>
+        " Default
+        let g:sexp_regput_invalid_register_action = -1
+<
+
+                                              *g:sexp_regput_inhibit_regparse*
+Set to 1 to inhibit the parsing of register contents described in
+|sexp-regput-register-parsing|. With parsing disabled, vim-sexp uses only
+simplistic, regex-based matching to determine the most critical information
+about the register: e.g., whether it contains comments. However, this approach
+is not able to fully and correctly characterize the register contents and
+makes no attempt to detect errors; thus, unless you're having issues with the
+parser, it's best not to disable it. (And if you do experience issues, please
+create an issue report.)
+>
+        " Default
+        let g:sexp_regput_inhibit_regparse = 0
+<
+
+                                             *g:sexp_regput_use_string_parser*
+Set to 1 to request use of a Treesitter string parser instead of the default
+buffer parser. Although a string parser has the advantage of not requiring
+creation of a hidden buffer in which to parse the register contents, it has
+one significant drawback: it's more likely to indicate errors than a buffer
+parser. When Treesitter parses a buffer, it sometimes inserts `MISSING` nodes
+in the hope that subsequent user edits will fill in the missing syntactic
+element(s). A string parser, on the other hand, assumes the string represents
+a complete and valid Lisp form and will simply emit an `ERROR` node if that
+assumption is violated. Thus, register content validation performed with a
+string parser is more likely to generate "false positives" than the
+corresponding buffer parse.
+
+As an example, consider an attempt to paste `^String` in a Clojure buffer,
+which generates a warning with the string parser, but not with the buffer
+parser. Although the "reader macro" `^` expects to be followed by both the
+metadata and its target element, the buffer parser is able to recover by
+inserting a `MISSING` node in lieu of the missing metadata target; the string
+parser treats the missing metadata target as an error, triggering a warning
+and prompt.
+
+Caveat: This option is ignored if Treesitter is unavailable.
+>
+        " Default
+        let g:sexp_regput_use_string_parser = 0
+<
+
 Expert options ~
 
                                                      *g:sexp_inhibit_failsafe*

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -895,18 +895,18 @@ REGISTER PUT ("SMART PASTE") COMMANDS (normal, visual) ~
 
 All of the register put (paste) commands (and operators) accept an optional
 register name via the standard Vim mechanism (e.g., `"ap` to put from the `"a`
-register), as well as an optional [count] whose usage is documented with the
+register), as well as an optional `[count]` whose usage is documented with the
 corresponding command. Commands that replace existing elements have distinct
 `p` and `P` variants: by analogy with builtin `p` and `P`, the former updates
 the unnamed register (|@"|); the latter does not. By default, the cursor will
-be left at the head of the put text, but this can be changed with options
-|g:sexp_regput_curpos| and |g:sexp_regput_into_curpos|. All put (paste)
-commands perform an automatic re-indent on a range whose size is determined by
+be left at the head of the put text, but this can be changed with option
+|g:sexp_regput_curpos| and its several variants. All put (paste) commands
+perform an automatic re-indent on a range whose size is determined by
 |g:sexp_auto_indent_range|. By default, vim-sexp attempts to validate register
 contents before pasting them. To learn more about this behavior, including how
 to disable/customize it, see |sexp-regput-register-parsing|.
 
-Note: If vim-repeat is installed, the replace commands/operators can be
+Note: If vim-repeat is installed, the non-operator smart-paste commands can be
 repeated with the |.| command.
 
 Note: Although most users will probably wish to remap the builtin put

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -914,13 +914,14 @@ methods discussed in |sexp-regput-overriding-builtins|.
 Put register before/after (normal)  ~
                                                                     *sexp_put*
 
-["x]<LocalLeader>P                                   *<Plug>(sexp_put_before)*
 ["x]<LocalLeader>p                                    *<Plug>(sexp_put_after)*
+["x]<LocalLeader>P                                   *<Plug>(sexp_put_before)*
         Put [count] copies of register x before (`<LocalLeader>P`) or after
         (`<LocalLeader>p`) the current element; alternatively, works like "put
         register into list" when the conditions in the following paragraph are
         met.
 
+                                            *sexp-regput-behavior-on-bracket*
         Special Behavior on List Brackets  ~
         By default, if this command is executed with the cursor on a list
         bracket (or the macro chars preceding an open), and the put direction
@@ -942,31 +943,32 @@ Put register before/after (normal)  ~
 
 Replace element/selection with register (normal, visual)  ~
 
-["x]<M-P>                                             *<Plug>(sexp_replace_P)*
-["x]<M-p>                                               *<Plug>(sexp_replace)*
+["x] <M-p>                                              *<Plug>(sexp_replace)*
+["x] <M-P>                                            *<Plug>(sexp_replace_P)*
         Replace the current element or visual selection with [count] copies of
-        register x, first expanding the visual selection to include all of any
-        partially selected elements. With `<M-P>`, the unnamed register (`@"`)
-        is not updated.
+        register `x`, first expanding the visual selection to include all of any
+        partially selected elements. `<M-P>` does not update the unnamed
+        register.
 
 Put register into list (normal)  ~
 
-["x]<LocalLeader><p                                 *<Plug>(sexp_put_at_head)*
-["x]<LocalLeader>>p                                 *<Plug>(sexp_put_at_tail)*
-        Put register x into the current list, making it the [count]th child
-        from head (`<LocalLeader><p`) or tail (`<LocalLeader>>p`).
+["x] <LocalLeader><p                                *<Plug>(sexp_put_at_head)*
+["x] <LocalLeader>>p                                *<Plug>(sexp_put_at_tail)*
+        Put register x into the current list, just before the `[count]`th
+        child from head (`<LocalLeader><p`) or after the `[count]`th child
+        from tail (`<LocalLeader>>p`).
 
         See also |sexp-regput-definition-of-current-list|.
 
 Replace child with register (normal)  ~
 
-["x]<LocalLeader>[p                              *<Plug>(sexp_replace_at_head)*
-["x]<LocalLeader>]p                              *<Plug>(sexp_replace_at_tail)*
-["x]<LocalLeader>[P                            *<Plug>(sexp_replace_at_head_P)*
-["x]<LocalLeader>]P                            *<Plug>(sexp_replace_at_tail_P)*
+["x] <LocalLeader>[p                            *<Plug>(sexp_replace_at_head)*
+["x] <LocalLeader>]p                            *<Plug>(sexp_replace_at_tail)*
+["x] <LocalLeader>[P                          *<Plug>(sexp_replace_at_head_P)*
+["x] <LocalLeader>]P                          *<Plug>(sexp_replace_at_tail_P)*
         Replace the [count]th child from head (`<LocalLeader>[p`) or tail
-        (`<LocalLeader>]p`) with register x. With the versions ending in `P`,
-        the unnamed register (`@"`) is not updated.
+        (`<LocalLeader>]p`) with register x. The commands ending in `P` do not
+        update the unnamed register.
 
         See also |sexp-regput-definition-of-current-list|.
 
@@ -1008,6 +1010,20 @@ Note: Because the put before/after commands are unavailable in visual mode,
 `p` and `P` are also used for visual mode `sexp_replace`, making `vp` and `vP`
 effectively aliases to `<M-p>` and `<M-P>`.
 
+p versus P (a Motivating Example)  ~
+Although `<M-j>`, `<M-k>`, `<M-h>`, `<M-l>` can be used to swap adjacent
+elements, they're not ideal for swapping non-adjacent elements. For instance,
+if you wished to swap the second and final elements of a list, you'd need to
+perform the number of swaps needed to move the second element to the end of
+the list, then separately, the number of swaps needed to bring the final
+element to the second slot in the list. Very tedious. But using the "replace
+child" variants that update the unnamed register, you could accomplish the
+same thing with only 3 commands, regardless of list length:
+>
+        y2ic     yank second "inner child" into unnamed register
+        ]p       replace final element with unnamed register
+        2[p      replace second element of list with unnamed register
+<
                                               *sexp-regput-cursor-positioning*
 Cursor Positioning  ~
 By default, the cursor is positioned at the start of the pasted form(s), but

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -980,8 +980,6 @@ set |g:sexp_regput_bracket_is_child| to 1.
 Note: Since a toplevel list has no parent, this option does not apply when the
 cursor is on the terminals of a toplevel list.
 
-IMPORTANT NOTE: |g:sexp_regput_bracket_is_child| is not yet supported.
-
                                              *sexp-regput-overriding-builtins*
 Overriding Builtin Put Commands  ~
 You may not have much need for Vim's builtin put operators once you become

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -893,22 +893,24 @@ LIST MANIPULATION (normal, visual) ~
 REGISTER PUT ("SMART PASTE") COMMANDS (normal, visual) ~
                                         *sexp-smart-paste* *sexp-register-put*
 
-All of the register put (paste) commands (and operators) accept an optional
+All of the register put (paste) commands and operators accept an optional
 register name via the standard Vim mechanism (e.g., `"ap` to put from the `"a`
-register). The non-operator commands also accept an optional `[count]` , whose
-usage is documented with the corresponding command. Commands that replace
-existing elements have distinct `p` and `P` variants: by analogy with builtin
-`p` and `P`, the former updates the unnamed register (|@"|); the latter does
-not. By default, the cursor is left at the head of the put text, but this
-can be changed with option |g:sexp_regput_curpos| and its several variants.
-All put (paste) commands and operators perform an automatic re-indent on a
-range whose size is determined by |g:sexp_auto_indent_range|. By default,
-vim-sexp attempts to validate register contents before pasting them. To learn
-more about this behavior, including how to disable/customize it, see
-|sexp-regput-register-parsing|.
+register). The non-operator put commands also accept an optional `[count]`,
+whose usage is documented with the corresponding command. Commands that
+replace existing elements have distinct `p` and `P` variants: by analogy with
+builtin `p` and `P`, the former updates the unnamed register (|@"|); the
+latter does not. By default, the cursor is left at the head of the put text,
+but this can be changed with option |g:sexp_regput_curpos| and its several
+variants. All put (paste) commands and operators perform an automatic
+re-indent on a range whose size is determined by |g:sexp_auto_indent_range|.
+By default, vim-sexp attempts to validate register contents before pasting
+them. To learn more about this behavior, including how to disable/customize
+it, see |sexp-regput-register-parsing|.
 
-Note: If vim-repeat is installed, the all smart-paste commands and operators
-can be repeated with the |.| command.
+Note: If vim-repeat is installed, all smart-paste commands can be repeated
+with the "." command. Smart-paste operators can be repeated if and only if
+their operand is a sexp object/motion. (This is an inherent limitation, due to
+the fact that Vim's API does not expose the object/motion to the opfunc.)
 
 Note: Although most users will probably wish to remap the builtin put
 commands to vim-sexp's smarter, Lisp-aware counterparts, the builtins will not
@@ -920,7 +922,7 @@ Put register before/after (normal)  ~
 
 ["x]<LocalLeader>p                                    *<Plug>(sexp_put_after)*
 ["x]<LocalLeader>P                                   *<Plug>(sexp_put_before)*
-        Put [count] copies of register x before (`<LocalLeader>P`) or after
+        Put `[count]` copies of register x before (`<LocalLeader>P`) or after
         (`<LocalLeader>p`) the current element; alternatively, works like "put
         register into list" when the conditions in the following paragraph are
         met.
@@ -951,28 +953,40 @@ Replace operator (normal)  ~
 ["x] <M-p>                                           *<Plug>(sexp_replace_op)*
 ["x] <M-P>                                         *<Plug>(sexp_replace_op_P)*
         Replace a target determined by a motion or text/sexp object with the
-        contents of register x. For motions/objects whose endpoints are both
-        within a single level of the sexp tree, the selection or moved-over
-        region determines the replacement target.
+        contents of register x. 
 
                                              *sexp-replace-target-constraints*
         The target may contain multiple S-expressions, and must not contain
         partial S-expressions, unless |g:sexp_regput_replace_expanded| is set,
         in which case, the target will be expanded to include all of any
-        partially selected S-expressions.
+        partially selected S-expressions. Moreover, the motion endpoints must
+        lie within the same node of the sexp tree unless you've set option
+        |g:sexp_regput_enable_teleop|, which is the subject of the following
+        section.
 
-**Experimental**  ~
+        Note: Unlike the non-operator smart paste commands, the replace
+        operator does not use a `[count]`. If you supply one, Vim's operator
+        mechanism will use it as a multiplier for any count used with the
+        motion/object (probably not what you intended).
+        **Warning**: Use counts only with the motion/operator and do not
+        use a count with the "." (repeat) operator when using it to repeat a
+        replace operation.
+
+        The commands ending in `P` do not update the unnamed register.
+
+"Telescopic" Mode (***Experimental*** - Requires Vim Version >= 8.1) ~
                                                 *sexp-replace-telescopic-mode*
-        Unless you set |g:sexp_regput_op_tele|, vim-sexp will refuse to
-        operate on a region whose defining motion's endpoints are at different
-        levels of the sexp tree. This is done to minimize the risk of creating
-        unbalanced forms. There is, however, another way of looking at
-        operator motions, which gives them meaning when they span multiple
-        levels: rather than selecting the forms "moved over", a motion can
-        select the form "reached" by the motion search. Here's an illustrative
-        example, which assumes the following option settings:
+        By default, vim-sexp's replace operators will refuse to operate on an
+        "unbalanced" region whose endpoints are not both contained within the
+        same node of the sexp tree. While this is necessary to minimize the
+        risk of creating unbalanced forms, setting option
+        |g:sexp_regput_enable_teleop| enables an additional interpretation of
+        operator motions, which gives them meaning even when they reach across
+        tree levels: rather than selecting the forms "moved over", a motion
+        can select the form "reached" by the motion search. Here's an
+        illustrative example, which assumes the following option settings:
 
-          `g:sexp_regput_op_tele == 1`
+          `g:sexp_regput_enable_teleop == 1`
           `g:sexp_regput_curpos == 2`
 >
           (foo (bar)
@@ -987,24 +1001,14 @@ Replace operator (normal)  ~
 <
         Because this mode permits "action at a distance", it is known as
         "telescopic" mode. It may also be referred to as "endpoint" mode. This
-        feature is still considered experimental because some additional work
-        is needed to ensure it works properly with all vim-sexp motions, but
-        it already works well with non-sexp search operators (e.g., `/` and
-        `?`) and even works with motion plugins like vim-easymotion. The issue
-        with vim-sexp motions is that they sometimes exclude brackets from the
+        feature is still considered experimental because additional work is
+        needed to ensure it works properly with all vim-sexp motions, but it
+        already works well with non-sexp search operators (e.g., `/` and `?`)
+        and even works with motion plugins like vim-easymotion. The issue with
+        vim-sexp motions is that they sometimes exclude brackets from the
         motion in a way that is generally helpful to the user, but which
         breaks the telescopic selection logic. Fortunately, there's a
         workaround, which should be implemented in a subsequent version...
-
-        Note: Unlike the non-operator smart paste commands, the replace
-        operator does not use a `[count]`. If you supply one, Vim's operator
-        mechanism will use it as a multiplier for any count used with the
-        motion/object (probably not what you intended).
-        **Warning**: Use counts only with the motion/operator and do not
-        use a count with the "." (repeat) operator when using it to repeat a
-        replace operation.
-
-        The commands ending in `P` do not update the unnamed register.
 
 Replace visual selection with register (visual)  ~
 

--- a/doc/vim-sexp.txt
+++ b/doc/vim-sexp.txt
@@ -890,7 +890,7 @@ LIST MANIPULATION (normal, visual) ~
         ((|)) () foo bar
         (|) () () foo bar
 <
-REGISTER PUT (PASTE) COMMANDS (normal, visual) ~
+REGISTER PUT ("SMART PASTE") COMMANDS (normal, visual) ~
 
 All of the register put (paste) commands accept an optional register name via
 the standard Vim mechanism (e.g., `"ap` to put from the `"a` register), as
@@ -902,16 +902,31 @@ perform an automatic re-indent on a range whose size is determined by
 |g:sexp_auto_indent_range|.
 
 Put register before/after (normal)  ~
+                                                                    *sexp_put*
 
 ["x]P                                                *<Plug>(sexp_put_before)*
 ["x]p                                                 *<Plug>(sexp_put_after)*
         Put [count] copies of register x before (`P`) or after (`p`) the
-        current element.
+        current element; alternatively, works like "put register into list"
+        when the conditions in the following paragraph are met.
+
+        Special Behavior on List Brackets  ~
+        By default, if this command is executed with the cursor on a list
+        bracket (or the macro chars preceding an open), and the put direction
+        is towards the list interior, it will be handled as the corresponding
+        "put register into list" command:
+                p ==> |<Plug>(sexp_put_at_head)|
+                P ==> |<Plug>(sexp_put_at_tail)|
+        I.e., the register text will be inserted into the head or tail of the
+        list at an offset determined by [count]. If you do not like this
+        behavior, and want this command to treat lists just like regular
+        elements, simply set option *g:sexp_regput_bracket_is_target* to 0.
+
         Note: If there is no current element, the register contents are put
-        before or after the cursor position and there is a subtle difference
-        between `p` and `P`: in particular, putting _away from_ an adjacent
-        element on the same line as the cursor forces insertion of NL between
-        the put text and the adjacent element.
+        before or after the cursor position; moreover, there is a subtle
+        difference between `p` and `P` in this case: in particular, putting
+        _away from_ an adjacent element on the same line as the cursor forces
+        a line break between the put text and the adjacent element.
 
 Replace element with register (normal)  ~
 
@@ -934,6 +949,8 @@ Put register into list (normal)  ~
         Put register x into the current list, making it the [count]th child
         from head (`<M-p>`) or tail (`<M-P>`).
 
+        See also |sexp-regput-definition-of-current-list|.
+
 Replace child with register (normal)  ~
 
 ["x]<LocalLeader>p                               *<Plug>(sexp_replace_at_head)*
@@ -941,6 +958,124 @@ Replace child with register (normal)  ~
         Replace the [count]th child from head (`<LocalLeader>p`) or tail
         (`<LocalLeader>P>`) with register x. With `<LocalLeader>P`, the
         unnamed register (`@"`) is not updated.
+
+        See also |sexp-regput-definition-of-current-list|.
+
+                                       *sexp-regput-definition-of-current-list*
+Definition of "current list"  ~
+By default, the preceding two commands treat a list whose bracket or macro
+char is under the cursor as the current list. Some users may prefer that a
+list be treated as a simple child element when the cursor is positioned on one
+of its terminals. The advantage of such an approach is consistency: as long as
+the cursor is positioned on element terminals, the result of the put will not
+depend on whether the element is a list or atom; in either case, the
+containing list is the target of the put. If you wish to enable this approach,
+set |g:sexp_regput_bracket_is_child| to 1.
+Note: Since a toplevel list has no parent, this option does not apply when the
+cursor is on the terminals of a toplevel list.
+
+                                             *sexp-regput-single-vs-multiline*
+Single vs Multi-line  ~
+Vim-sexp contains a significant amount of logic for deciding how to separate
+the put register contents from the surrounding forms. The goal of this logic
+is to minimize (and where possible, eliminate) the need for manual whitespace
+adjustments after the put has completed.
+
+To decide whether the put text should be separated from what precedes and
+follows it by newline(s), space or even nothing at all (at list head/tail),
+the put logic considers factors such as the following:
+
+        * Is the element adjacent to the put target currently alone?
+        * Does the register contain multiple toplevel forms?
+        * Does the register contain multiple lines?
+        * Does the register begin or end with a comment?
+        * Will the put text come immediately before or after a comment?
+        * Is the register "linewise" (taking option
+          |g:sexp_regput_untrimmed_is_linewise| into account)?
+
+As with the "Outer Element" whitespace selection logic, the put logic attempts
+to produce results that obey Ruby's "Principle of Least Surprise" and Perl's
+"Do What I Mean" philosophy. If you discover areas in which you feel it could
+do a better job of this, please open an issue. Suggestions for improvement are
+always welcome.
+
+                                               *sexp-regput-register-linewise*
+Register "Linewise" Status  ~
+Since vim-sexp's put logic determines appropriate whitespace separators for
+both ends of the put text, any leading or trailing whitespace in the register
+is stripped before buffer insertion. Before it is stripped, however, vim-sexp
+uses it to determine whether the register should be considered "linewise". A
+register's linewise status can affect the results of a put in
+option-dependent ways: for examples, see |sexp-regput-single-vs-multiline|
+and |sexp-regput-comment-logic|. By default, vim-sexp's definition of a
+"linewise" register is the same as Vim's: a register ending in newline is
+linewise. However, you may prefer to relax this requirement to treat a put
+register with _any_ leading or trailing whitespace as "linewise". The
+advantage of this definition is that it makes it easier to use the type of
+yank performed to influence the type of put.
+
+As an example, consider the following:
+>
+        (foo (bar 42) baz)
+<
+Suppose you want to yank the form `(bar 42)` and paste it on its own line
+(i.e., not appended or prepended to an existing line). An easy way to
+guarantee this result is to make the yank register "linewise", but because the
+form is surrounded by other forms, it cannot be yanked in a way that will make
+it "linewise" in the Vim sense. But with the expanded definition of
+"linewise", you could yank with `yae` to include surrounding whitespace,
+thereby making the register "linewise" in the vim-sexp sense and ensuring it
+will be put to its own line. To enable this expanded definition, set option
+|g:sexp_regput_untrimmed_is_linewise| to 1.
+
+
+"Directionality" of Put Commands  ~
+Put commands that have a "target" element (e.g., the element under the cursor
+for |<Plug>(sexp_put_before)| or |<Plug>(sexp_put_after)|) are considered
+directional and treat the target element differently from an adjacent element.
+In particular, the put text may be made colinear with the target (i.e.,
+separated from it by only a <Space> character), but will never be joined to an
+adjacent element that was not already colinear with the target. Commands that
+put into a list are also directional; the target, in this case, is the
+`[count]`th element in the list, which serves as the insert/append location for
+the register contents. Put commands that replace elements are non-directional.
+They attempt, as much as possible, to preserve the separation of the replaced
+form(s) from surrounding forms on both sides.
+
+                                         *sexp-regput-list-shape-preservation*
+List "Shape" Preservation Logic  ~
+By default, when a register containing a single toplevel element is put into
+the second or third position of a list that has the following canonical shape
+(ignoring alignment), the put logic will choose the whitespace separators
+surrounding the put text in an effort to preserve the shape.
+>
+        (func ARG1
+              ARG2
+              .
+              .)
+<
+
+If you don't like this behavior, you can disable it by setting option
+|sexp_regput_ignore_list_shape| to 1.
+
+
+                                                   *sexp-regput-comment-logic*
+Constraints on Comments  ~
+Vim-sexp examines the put register to determine whether it contains leading or
+trailing comments, and will always ensure that a trailing comment is separated
+from what follows by at least a newline. Leading comments are not as
+inherently problematic as trailing comments. However, though appending a
+comment to a form is always syntactically valid, it may not always make sense.
+Because vim-sexp has no way of knowing what the comment modifies, it defaults
+to ensuring a leading comment is never appended to an existing form. If you
+wish to allow leading comments to be appended in certain cases, you can set
+|g:sexp_regput_allow_comment_append| to a nonzero value: 1 to allow an append
+only when the register is not "linewise"; 2 to allow an append
+unconditionally.
+Note: This option does not _force_ leading comments to be appended; it merely
+requests that comments be treated the same as other elements for the purposes
+of determining single/multi-line put.
+
 
 INSERT MODE MAPPINGS (insert, optional) ~
 
@@ -1400,15 +1535,84 @@ full (level 2) optimization.
         " Default
         let g:sexp_aligncom_density_weight = 5
 <
+                                             *g:sexp_regput_bracket_is_target*
+When this is set, |<Plug>(sexp_put_before)| and |<Plug>(sexp_put_after)| are
+silently converted to |<Plug>(sexp_put_at_head)| and |<Plug>(sexp_put_at_tail)|,
+respectively, when the cursor is on a list's bracket or macro chars and the
+put direction is towards the list interior.
+Note: This option does not apply when the put command puts "away from" the
+list (i.e., `P` from head or `p` from tail).
+>
+        " Default
+        let g:sexp_regput_bracket_is_target = 1
+<
+
+                                              *g:sexp_regput_bracket_is_child*
+When this is set, the register put commands that put into a list will not
+treat a non-toplevel list whose brackets/macro chars are under the cursor as
+the target list, but will instead target its parent.
+Motivation: To understand why you might wish to set this, see
+|sexp-regput-definition-of-current-list|.
+>
+        " Default
+        let g:sexp_regput_bracket_is_child = 0
+<
+
+                                          *g:sexp_regput_allow_comment_append*
+Determines the conditions under which register put commands are permitted to
+append a comment to an existing form:
+  0  Never append
+  1  Allow append unless put register is linewise (taking option
+     |g:sexp_regput_untrimmed_is_linewise| into account)
+  2  Always allow append
+For details, see |sexp-regput-comment-logic|.
+>
+        " Default
+        let g:sexp_regput_allow_comment_append = 0
+<
+
+                                         *g:sexp_regput_untrimmed_is_linewise*
+If set, a put register containing _any_ leading or trailing whitespace will be
+considered "linewise".
+Note: A register's "linewise" status has implications for the following
+options:
+        |g:sexp_regput_linewise_forces_multiline|
+        |g:sexp_regput_allow_comment_append|
+
+For details, see |sexp-regput-register-linewise-status|.
+>
+        " Default
+        let g:sexp_regput_untrimmed_is_linewise = 1
+<
+
+                                     *g:sexp_regput_linewise_forces_multiline*
+If set, a put is always multiline when the put register is "linewise" in the
+vim-sexp sense (see |g:sexp_regput_untrimmed_is_linewise|).
+For additional details, see |sexp-regput-register-linewise-status|.
+>
+        " Default
+        let g:sexp_regput_linewise_forces_multiline = 1
+<
+
+                                             *g:sexp_regput_ignore_list_shape*
+Set to 1 to inhibit the special logic that attempts to preserve canonical list
+shape when a register put targets the second or third slot of a list.
+For additional details, see |sexp-regput-list-shape-preservation|.
+>
+        " Default
+        let g:sexp_regput_ignore_list_shape = 0
+<
+
 Expert options ~
 
                                                      *g:sexp_inhibit_failsafe*
-In the absence of bugs, this plugin should never modify non-whitespace text
-(though it may occasionally **relocate** brackets). In the real world,
-however, bugs happen; thus, the function responsible for modifying text
-contains redundant logic to ensure that if a bug results in a request to
-delete non-whitespace, the request will be refused with a warning. The regex
-search used by this logic is fairly inexpensive and unlikely to be a
+In the absence of bugs, very few of the commands provided by this plugin
+modify non-whitespace text (though a few may occasionally _relocate_
+brackets). In the real world, however, bugs happen; accordingly, the function
+primarily responsible for buffer modifications contains redundant logic to
+detect and refuse (with a warning) any attempt to delete non-whitespace by
+commands not expected to do so (e.g., |<Plug>(sexp_align_comments)|). The
+regex search used by this logic is fairly inexpensive and unlikely to be a
 performance concern; however, for users who prioritize performance and trust
 the developer, their version control system, Vim's undo engine, or some
 combination of the above, an option is provided to inhibit this "failsafe"

--- a/lua/sexp/ts.lua
+++ b/lua/sexp/ts.lua
@@ -512,11 +512,11 @@ function M.nearest_bracket(closing, open_re, close_re)
   return {0, 0, 0, 0}
 end
 
+---@param tree TSTree
 ---@param codestr string    # string representing lisp form(s) to validate
 ---@param filetype string?  # lisp variant to use for validation
----                         # TODO: Should be unnecessary, as it defaults to current buf
 ---@return ParseResult
-function M.analyze_codestr(codestr, filetype)
+local function analyze_codestr(tree, codestr, filetype)
   ---@local ParseResult
   -- Note: Table structure matches corresponding dict in legacy Vim implementation.
   local ret = {
@@ -536,8 +536,6 @@ function M.analyze_codestr(codestr, filetype)
     ((ERROR) @str
       (#trim! @str 1 1 1 1))
   ]])
-  -- Note: Intentionally parsing raw (unstripped) input string.
-  local tree = vim.treesitter.get_string_parser(codestr, ft):parse()[1]
   local root = tree:root()
   -- Execute query for errors, saving only the first one in return table.
   local _, node = vim.iter(query:iter_captures(root, 0)):next()
@@ -603,6 +601,42 @@ function M.analyze_codestr(codestr, filetype)
     end
   end
   return ret
+end
+
+-- Use Treesitter to analyze the input 'codestr' as filetype 'filetype', returning a
+-- ParseResult, else nil.
+-- Preconditions: If the optional 'strparse' flag is set, attempt to use a string parser;
+-- otherwise, assume caller has already placed us in a buffer with the correct filetype
+-- and contents.
+---@param codestr string    # string representing lisp form(s) to validate
+---@param filetype string?  # lisp variant to use for validation
+---@param strparse boolean? # true if using string parser
+---@return ParseResult?
+---@return string?          # error msg if ParseResult is nil
+function M.analyze_codestr(codestr, filetype, strparse)
+  ---@type vim.treesitter.LanguageTree?
+  local ltree
+  ---@type TSTree?
+  local tree
+  if strparse then
+    -- Note: Intentionally parsing raw (unstripped) input string.
+    ltree = vim.treesitter.get_string_parser(codestr, filetype or vim.bo.ft)
+  else
+    -- Note: For versions < 0.12, error=false is needed to ensure nil,errmsg is returned
+    -- if parser can't be created.
+    -- TODO: Decide whether we want to bother with the 2nd return value (errmsg). The
+    -- problem is that luaeval() doesn't make it easy to obtain; also, the other sexp.ts
+    -- functions just return a single value.
+    ltree = vim.treesitter.get_parser(nil, nil, {error = false})
+  end
+  if not ltree then
+    -- Couldn't get LanguageTree.
+    -- Note: Only get_parser() (not get_string_parser()) can return nil.
+    return nil
+  end
+  -- Attempt the parse.
+  tree = ltree:parse()[1]
+  return tree and analyze_codestr(tree, codestr, filetype) or nil
 end
 
 return M

--- a/lua/sexp/ts.lua
+++ b/lua/sexp/ts.lua
@@ -10,6 +10,7 @@ local ApiRange = require'sexp.range'
 ---@field err_count integer
 ---@field elem_count integer
 ---@field is_ml boolean
+---@field linewise boolean
 ---@field has_com boolean
 ---@field s_is_com boolean
 ---@field e_is_com boolean
@@ -19,9 +20,9 @@ local ApiRange = require'sexp.range'
 
 --local dbg = require'dp':get('sexp', {enabled=true})
 
-local reltime = vim.fn.reltime
-local reltimefloat = vim.fn.reltimefloat
-local reltimestr = vim.fn.reltimestr
+--local reltime = vim.fn.reltime
+--local reltimefloat = vim.fn.reltimefloat
+--local reltimestr = vim.fn.reltimestr
 
 local bracket = [[\v\(|\)|\[|\]|\{|\}]]
 local delimiter = bracket .. [[|\s]]
@@ -516,6 +517,7 @@ end
 ---@return ParseResult
 function M.analyze_codestr(codestr, filetype)
   ---@local ParseResult
+  -- Note: Table structure matches corresponding dict in legacy Vim implementation.
   local ret = {
     err_count = 0,
     elem_count = 0,
@@ -533,6 +535,7 @@ function M.analyze_codestr(codestr, filetype)
     ((ERROR) @str
       (#trim! @str 1 1 1 1))
   ]])
+  -- Note: Intentionally parsing raw (unstripped) input string.
   local tree = vim.treesitter.get_string_parser(codestr, ft):parse()[1]
   local root = tree:root()
   -- Execute query for errors and save the location of each.
@@ -563,7 +566,8 @@ function M.analyze_codestr(codestr, filetype)
     -- Design Decision: Err on side of caution by using all children for multiline check,
     -- not just first and last named child.
     -- Note: Intentionally using children rather than root to preclude possibility of
-    -- leading/trailing blanks affecting line count.
+    -- leading/trailing whitespace (which should show up only in root) affecting line
+    -- count.
     first = root:child(0) --[[@as TSNode --]]
     last = root:child(ret.elem_count - 1) --[[@as TSNode --]]
     local s, e = ApiPos:new(first:start()):to_vim4(),
@@ -575,6 +579,25 @@ function M.analyze_codestr(codestr, filetype)
   -- just first and last named child.
   local s, e = ApiPos:new(root:start()):to_vim4(), ApiPos:new(root:end_()):to_vim4(true)
   ret.is_ml = s[2] ~= e[2]
+  -- Perform 'linewise' check that takes option into account.
+  -- If trailing newline, no need to check further.
+  ret.linewise = codestr:sub(-1) == "\n"
+  if not ret.linewise and vim.g.sexp_regput_untrimmed_is_linewise ~= 0 then
+    -- One more chance...
+    local s_is_ws, e_is_ws = codestr:sub(1):match("%s"), codestr:sub(-1):match("%s")
+    if s_is_ws or e_is_ws then
+      -- Found leading/trailing whitespace but need to ensure it's not ignored.
+      local erow, ecol = vim.fn.line('$') - 1, vim.fn.col({vim.fn.line('$'), '$'}) - 1
+      local snode = root:named_descendant_for_range(0, 0, 0, 1)
+      local enode = root:named_descendant_for_range(erow, ecol, erow, ecol+1)
+      ret.linewise =
+        s_is_ws and snode and not is_node_rgn_type(snode, "str_com_chr")
+        or e_is_ws and enode and not is_node_rgn_type(enode, "str_com_chr")
+    end
+  else
+    ret.linewise = 0
+  end
+  print("linewise=" .. tostring(ret.linewise))
   return ret
 end
 

--- a/lua/sexp/ts.lua
+++ b/lua/sexp/ts.lua
@@ -7,14 +7,15 @@ local ApiRange = require'sexp.range'
 -- This class is used to communicate the results of parsing text as current filetype.
 -- Intended Use Case: Characterize contents of register used as source of put.
 ---@class ParseResult
----@field err_count integer
 ---@field elem_count integer
+---@field err_loc VimPos4
+---@field err_hint string
 ---@field is_ml boolean
 ---@field linewise boolean
 ---@field has_com boolean
 ---@field s_is_com boolean
 ---@field e_is_com boolean
----@field error_ranges VimPos4Range[]
+---@field err_ranges VimPos4Range[]
 ---@field node_ranges VimPos4Range[]
 ---@field text string
 
@@ -519,12 +520,12 @@ function M.analyze_codestr(codestr, filetype)
   ---@local ParseResult
   -- Note: Table structure matches corresponding dict in legacy Vim implementation.
   local ret = {
-    err_count = 0,
     elem_count = 0,
+    err_loc = {0,0,0,0}, err_hint = "",
     is_ml = false,
     has_com = false, s_is_com = false, e_is_com = false,
     node_ranges = {},
-    error_ranges = {},
+    err_ranges = {},
     -- Surrounding whitespace is always superseded by builtin separator logic.
     text = vim.trim(codestr),
   }
@@ -538,12 +539,13 @@ function M.analyze_codestr(codestr, filetype)
   -- Note: Intentionally parsing raw (unstripped) input string.
   local tree = vim.treesitter.get_string_parser(codestr, ft):parse()[1]
   local root = tree:root()
-  -- Execute query for errors and save the location of each.
-  for _, node, _ in query:iter_captures(root, 0) do
-    table.insert(ret.error_ranges,
-      {ApiPos:new(node:start()):to_vim4(), ApiPos:new(node:end_()):to_vim4(true)})
+  -- Execute query for errors, saving only the first one in return table.
+  local _, node = vim.iter(query:iter_captures(root, 0)):next()
+  if node then
+    ret.err_loc = ApiPos:new(node:start()):to_vim4()
+    -- TODO: Should we attempt to provide hint?
+    ret.err_hint = ""
   end
-  ret.err_count = #ret.error_ranges
   -- Accumulate ranges of all (named) top-level nodes and ensure 'has_com' is set
   -- iff any of the nodes is a comment.
   ---@type TSNode
@@ -581,12 +583,17 @@ function M.analyze_codestr(codestr, filetype)
   ret.is_ml = s[2] ~= e[2]
   -- Perform 'linewise' check that takes option into account.
   -- If trailing newline, no need to check further.
+  -- TODO: I think this check is overkill: in particular, I don't know of any lisps which
+  -- permit forms to end in an ignored whitespace char.
   ret.linewise = codestr:sub(-1) == "\n"
   if not ret.linewise and vim.g.sexp_regput_untrimmed_is_linewise ~= 0 then
     -- One more chance...
-    local s_is_ws, e_is_ws = codestr:sub(1):match("%s"), codestr:sub(-1):match("%s")
+    local s_is_ws, e_is_ws = codestr:sub(1, 1):match("%s"), codestr:sub(-1):match("%s")
     if s_is_ws or e_is_ws then
       -- Found leading/trailing whitespace but need to ensure it's not ignored.
+      -- TODO: Is this really necessary? I don't know of any lisps that permit forms to
+      -- end with literal, escaped whitespace; moreover, the legacy Vim parser doesn't
+      -- currently check for it.
       local erow, ecol = vim.fn.line('$') - 1, vim.fn.col({vim.fn.line('$'), '$'}) - 1
       local snode = root:named_descendant_for_range(0, 0, 0, 1)
       local enode = root:named_descendant_for_range(erow, ecol, erow, ecol+1)
@@ -594,10 +601,7 @@ function M.analyze_codestr(codestr, filetype)
         s_is_ws and snode and not is_node_rgn_type(snode, "str_com_chr")
         or e_is_ws and enode and not is_node_rgn_type(enode, "str_com_chr")
     end
-  else
-    ret.linewise = 0
   end
-  print("linewise=" .. tostring(ret.linewise))
   return ret
 end
 

--- a/lua/sexp/ts.lua
+++ b/lua/sexp/ts.lua
@@ -612,7 +612,6 @@ end
 ---@param filetype string?  # lisp variant to use for validation
 ---@param strparse boolean? # true if using string parser
 ---@return ParseResult?
----@return string?          # error msg if ParseResult is nil
 function M.analyze_codestr(codestr, filetype, strparse)
   ---@type vim.treesitter.LanguageTree?
   local ltree

--- a/lua/sexp/ts.lua
+++ b/lua/sexp/ts.lua
@@ -2,6 +2,21 @@ local M = {}
 local ApiPos = require'sexp.pos'
 local ApiRange = require'sexp.range'
 
+---@alias VimPos4Range [VimPos4, VimPos4]
+
+-- This class is used to communicate the results of parsing text as current filetype.
+-- Intended Use Case: Characterize contents of register used as source of put.
+---@class ParseResult
+---@field err_count integer
+---@field elem_count integer
+---@field is_ml boolean
+---@field has_com boolean
+---@field s_is_com boolean
+---@field e_is_com boolean
+---@field error_ranges VimPos4Range[]
+---@field node_ranges VimPos4Range[]
+---@field text string
+
 --local dbg = require'dp':get('sexp', {enabled=true})
 
 local reltime = vim.fn.reltime
@@ -201,7 +216,8 @@ function M.current_region_terminal(rgn, dir)
     dbg:logf("current_region_terminal returning %s",
       dir == 1 and ApiPos:new(node:end_()) or ApiPos:new(node:start()))
       ]]
-    return dir == 1 and ApiPos:new(node:end_()):to_vim4(true) or ApiPos:new(node:start()):to_vim4()
+    return dir == 1 and ApiPos:new(node:end_()):to_vim4(true)
+      or ApiPos:new(node:start()):to_vim4()
   else
     -- Caller is responsible for ensuring this doesn't happen!
     -- Note: Return must permit caller to differentiate between nullpos and no Treesitter
@@ -492,6 +508,74 @@ function M.nearest_bracket(closing, open_re, close_re)
   -- Didn't find matching bracket.
   -- TODO: Decide whether to return nil to force fallback to legacy logic.
   return {0, 0, 0, 0}
+end
+
+---@param codestr string    # string representing lisp form(s) to validate
+---@param filetype string?  # lisp variant to use for validation
+---                         # TODO: Should be unnecessary, as it defaults to current buf
+---@return ParseResult
+function M.analyze_codestr(codestr, filetype)
+  ---@local ParseResult
+  local ret = {
+    err_count = 0,
+    elem_count = 0,
+    is_ml = false,
+    has_com = false, s_is_com = false, e_is_com = false,
+    node_ranges = {},
+    error_ranges = {},
+    -- Surrounding whitespace is always superseded by builtin separator logic.
+    text = vim.trim(codestr),
+  }
+  -- Construct query used to check text for errors.
+  ---@type string
+  local ft = filetype or vim.bo.ft
+  local query = vim.treesitter.query.parse(ft, [[
+    ((ERROR) @str
+      (#trim! @str 1 1 1 1))
+  ]])
+  local tree = vim.treesitter.get_string_parser(codestr, ft):parse()[1]
+  local root = tree:root()
+  -- Execute query for errors and save the location of each.
+  for _, node, _ in query:iter_captures(root, 0) do
+    table.insert(ret.error_ranges,
+      {ApiPos:new(node:start()):to_vim4(), ApiPos:new(node:end_()):to_vim4(true)})
+  end
+  ret.err_count = #ret.error_ranges
+  -- Accumulate ranges of all (named) top-level nodes and ensure 'has_com' is set
+  -- iff any of the nodes is a comment.
+  ---@type TSNode
+  for n in root:iter_children() do
+    if n:named() then
+      ret.has_com = ret.has_com or is_node_rgn_type(n, 'comment')
+      table.insert(ret.node_ranges,
+        {ApiPos:new(n:start()):to_vim4(), ApiPos:new(n:end_()):to_vim4(true)})
+    end
+  end
+  -- For convenience, also store the child count.
+  ret.elem_count = root:named_child_count()
+  if ret.elem_count > 0 then
+    -- Determine whether first/last children are comments.
+    -- Note: elem_count check precludes possibility of nil return from named_child().
+    local first = root:named_child(0) --[[@as TSNode --]]
+    local last = root:named_child(ret.elem_count - 1) --[[@as TSNode --]]
+    ret.s_is_com = is_node_rgn_type(first, 'comment')
+    ret.e_is_com = is_node_rgn_type(last, 'comment')
+    -- Design Decision: Err on side of caution by using all children for multiline check,
+    -- not just first and last named child.
+    -- Note: Intentionally using children rather than root to preclude possibility of
+    -- leading/trailing blanks affecting line count.
+    first = root:child(0) --[[@as TSNode --]]
+    last = root:child(ret.elem_count - 1) --[[@as TSNode --]]
+    local s, e = ApiPos:new(first:start()):to_vim4(),
+      ApiPos:new(last:end_()):to_vim4(true)
+    -- TODO: Consider storing line count rather than boolean.
+    ret.is_ml = s[2] ~= e[2]
+  end
+  -- Design Decision: Err on side of caution by using entire tree for multiline check, not
+  -- just first and last named child.
+  local s, e = ApiPos:new(root:start()):to_vim4(), ApiPos:new(root:end_()):to_vim4(true)
+  ret.is_ml = s[2] ~= e[2]
+  return ret
 end
 
 return M

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -241,6 +241,11 @@ let s:sexp_mappings = {
     \ 'sexp_emit_tail_element':            '<M-S-k>',
     \ 'sexp_capture_prev_element':         '<M-S-h>',
     \ 'sexp_capture_next_element':         '<M-S-l>',
+    \ 'sexp_put_before':                   '<LocalLeader>P',
+    \ 'sexp_put_after':                    '<LocalLeader>p',
+    \ 'sexp_replace':                      '<LocalLeader><LocalLeader>p',
+    \ 'sexp_put_at_head':                  '<M-p>',
+    \ 'sexp_put_at_tail':                  '<M-P>',
     \ }
 
 if !empty(g:sexp_filetypes)
@@ -396,8 +401,7 @@ function! s:sexp_create_mappings()
                \ 'sexp_indent_top',          'sexp_indent_and_clean_top',
                \ 'sexp_align_comments',      'sexp_align_comments_top',
                \ 'sexp_put_before',          'sexp_put_after',
-               \ 'sexp_put_at_head',         'sexp_put_at_tail',
-        ]
+               \ 'sexp_put_at_head',         'sexp_put_at_tail']
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -423,7 +427,8 @@ function! s:sexp_create_mappings()
                \ 'sexp_clone_list_sl',            'sexp_clone_element_sl',
                \ 'sexp_clone_list_ml',            'sexp_clone_element_ml',
                \ 'sexp_indent',                   'sexp_indent_and_clean',
-               \ 'sexp_align_comments']
+               \ 'sexp_align_comments',           'sexp_replace',
+               \ ]
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -658,14 +663,19 @@ Defplug  xnoremap sexp_capture_prev_element sexp#docount_stateful(v:prevcount, '
 Defplug! nnoremap sexp_capture_next_element sexp#docount_stateful(v:count, 'sexp#stackop', 'n', 1, 1)
 Defplug  xnoremap sexp_capture_next_element sexp#docount_stateful(v:prevcount, 'sexp#stackop', 'v', 1, 1)
 
+" Put register before/after
+DefplugN nnoremap sexp_put_before  sexp#put(v:count, 0)
+DefplugN nnoremap sexp_put_after   sexp#put(v:count, 1)
 " Replace with register
+DefplugN nnoremap sexp_replace sexp#replace('n', v:count)
 DefplugN xnoremap sexp_replace sexp#replace('v', v:prevcount)
-" Put before/after from register
-DefplugN nnoremap sexp_put_before  sexp#put_at(v:count, 0)
-DefplugN nnoremap sexp_put_after   sexp#put_at(v:count, 1)
-" Put (into list) at head/tail
-DefplugN nnoremap sexp_put_at_head sexp#put_into(v:count, 0)
-DefplugN nnoremap sexp_put_at_tail sexp#put_into(v:count, 1)
+" Put register at child index
+DefplugN nnoremap sexp_put_at_head sexp#put_child(v:count, 0)
+DefplugN nnoremap sexp_put_at_tail sexp#put_child(v:count, 1)
+" Replace child with register
+DefplugN nnoremap sexp_replace_at_head sexp#replace_child(v:count, 0)
+DefplugN nnoremap sexp_replace_at_tail sexp#replace_child(v:count, 1)
+" TODO: Consider creating an operator version of replace with register.
 
 """ Insert mode mappings {{{1
 

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -288,9 +288,12 @@ let s:sexp_mappings = {
     \ 'sexp_capture_next_element':         {'nx': '<M-S-l>'},
     \ 'sexp_put_before':                   {'n': 'P'},
     \ 'sexp_put_after':                    {'n': 'p'},
-    \ 'sexp_replace':                      {'n': '<LocalLeader>p', 'x': 'p'},
+    \ 'sexp_replace':                      {'n': 'gp', 'x': 'p'},
+    \ 'sexp_replace_P':                    {'n': 'gP', 'x': 'P'},
     \ 'sexp_put_at_head':                  {'n': '<M-p>'},
     \ 'sexp_put_at_tail':                  {'n': '<M-P>'},
+    \ 'sexp_replace_at_head':              {'n': '<LocalLeader>p'},
+    \ 'sexp_replace_at_tail':              {'n': '<LocalLeader>P'},
     \ }
 
 if !empty(g:sexp_filetypes)
@@ -431,8 +434,7 @@ endfunction
 "   plug: command name specified as the ... in <plug>(...)
 "   msg:  warning msg
 function! s:mapwarn(plug, msg)
-    call s:warn(printf("Invalid entry for g:sexp_mappings['%s']: %s",
-                \ a:plug, a:msg))
+    call s:warn(printf("g:sexp_mappings['%s']: %s", a:plug, a:msg))
 endfunction
 
 " Convert a single value in the sexp_mappings dict to a denormalized form conducive to use
@@ -755,16 +757,19 @@ Defplug  xnoremap sexp_capture_next_element sexp#docount_stateful(v:prevcount, '
 " Put register before/after
 DefplugN nnoremap sexp_put_before  sexp#put(v:count, 0)
 DefplugN nnoremap sexp_put_after   sexp#put(v:count, 1)
-" Replace with register
-DefplugN nnoremap sexp_replace sexp#replace('n', v:count)
-DefplugN xnoremap sexp_replace sexp#replace('v', v:prevcount)
-" Put register at child index
+" Replace element/selection with register
+DefplugN nnoremap sexp_replace   sexp#replace('n', v:count, 'p')
+DefplugN nnoremap sexp_replace_P sexp#replace('n', v:count, 'P')
+DefplugN xnoremap sexp_replace   sexp#replace('v', v:prevcount, 'p')
+DefplugN xnoremap sexp_replace_P sexp#replace('v', v:prevcount, 'P')
+" Put register into list
 DefplugN nnoremap sexp_put_at_head sexp#put_child(v:count, 0)
 DefplugN nnoremap sexp_put_at_tail sexp#put_child(v:count, 1)
 " Replace child with register
-DefplugN nnoremap sexp_replace_at_head sexp#replace_child(v:count, 0)
-DefplugN nnoremap sexp_replace_at_tail sexp#replace_child(v:count, 1)
-" TODO: Consider creating an operator version of replace with register.
+DefplugN nnoremap sexp_replace_at_head   sexp#replace_child(v:count, 0, 'p')
+DefplugN nnoremap sexp_replace_at_head_P sexp#replace_child(v:count, 0, 'P')
+DefplugN nnoremap sexp_replace_at_tail   sexp#replace_child(v:count, 1, 'p')
+DefplugN nnoremap sexp_replace_at_tail_P sexp#replace_child(v:count, 1, 'P')
 
 """ Insert mode mappings {{{1
 

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -218,79 +218,79 @@ if !exists('g:sexp_mappings')
 endif
 
 let s:sexp_mappings = {
-    \ 'sexp_outer_list':                   'af',
-    \ 'sexp_inner_list':                   'if',
-    \ 'sexp_outer_top_list':               'aF',
-    \ 'sexp_inner_top_list':               'iF',
-    \ 'sexp_outer_string':                 'as',
-    \ 'sexp_inner_string':                 'is',
-    \ 'sexp_outer_element':                'ae',
-    \ 'sexp_inner_element':                'ie',
-    \ 'sexp_outer_child_tail':             'aC',
-    \ 'sexp_outer_child_head':             'ac',
-    \ 'sexp_inner_child_tail':             'iC',
-    \ 'sexp_inner_child_head':             'ic',
-    \ 'sexp_move_to_prev_bracket':         '(',
-    \ 'sexp_move_to_next_bracket':         ')',
-    \ 'sexp_move_to_prev_element_head':    '<M-b>',
-    \ 'sexp_move_to_next_element_head':    '<M-w>',
-    \ 'sexp_move_to_prev_element_tail':    'g<M-e>',
-    \ 'sexp_move_to_next_element_tail':    '<M-e>',
-    \ 'sexp_flow_to_prev_close':           '<M-[>',
-    \ 'sexp_flow_to_next_open':            '<M-]>',
-    \ 'sexp_flow_to_prev_open':            '<M-{>',
-    \ 'sexp_flow_to_next_close':           '<M-}>',
-    \ 'sexp_flow_to_prev_leaf_head':       '<M-S-b>',
-    \ 'sexp_flow_to_next_leaf_head':       '<M-S-w>',
-    \ 'sexp_flow_to_prev_leaf_tail':       '<M-S-g>',
-    \ 'sexp_flow_to_next_leaf_tail':       '<M-S-e>',
-    \ 'sexp_move_to_prev_top_element':     '[[',
-    \ 'sexp_move_to_next_top_element':     ']]',
-    \ 'sexp_select_prev_element':          '[e',
-    \ 'sexp_select_next_element':          ']e',
-    \ 'sexp_indent':                       '==',
-    \ 'sexp_indent_top':                   '=-',
-    \ 'sexp_indent_and_clean':             '<M-=>',
-    \ 'sexp_indent_and_clean_top':         '<M-->',
-    \ 'sexp_align_comments':               '<LocalLeader>a',
-    \ 'sexp_align_comments_top':           '<LocalLeader>A',
-    \ 'sexp_round_head_wrap_list':         '<LocalLeader>i',
-    \ 'sexp_round_tail_wrap_list':         '<LocalLeader>I',
-    \ 'sexp_square_head_wrap_list':        '<LocalLeader>[',
-    \ 'sexp_square_tail_wrap_list':        '<LocalLeader>]',
-    \ 'sexp_curly_head_wrap_list':         '<LocalLeader>{',
-    \ 'sexp_curly_tail_wrap_list':         '<LocalLeader>}',
-    \ 'sexp_round_head_wrap_element':      '<LocalLeader>w',
-    \ 'sexp_round_tail_wrap_element':      '<LocalLeader>W',
-    \ 'sexp_square_head_wrap_element':     '<LocalLeader>e[',
-    \ 'sexp_square_tail_wrap_element':     '<LocalLeader>e]',
-    \ 'sexp_curly_head_wrap_element':      '<LocalLeader>e{',
-    \ 'sexp_curly_tail_wrap_element':      '<LocalLeader>e}',
-    \ 'sexp_insert_at_list_head':          '<LocalLeader>h',
-    \ 'sexp_insert_at_list_tail':          '<LocalLeader>l',
-    \ 'sexp_splice_list':                  '<LocalLeader>@',
-    \ 'sexp_convolute':                    '<LocalLeader>?',
-    \ 'sexp_clone_list':                   '<LocalLeader>c',
-    \ 'sexp_clone_list_sl':                '',
-    \ 'sexp_clone_list_ml':                '',
-    \ 'sexp_clone_element':                '<LocalLeader>C',
-    \ 'sexp_clone_element_sl':             '',
-    \ 'sexp_clone_element_ml':             '',
-    \ 'sexp_raise_list':                   '<LocalLeader>o',
-    \ 'sexp_raise_element':                '<LocalLeader>O',
-    \ 'sexp_swap_list_backward':           '<M-k>',
-    \ 'sexp_swap_list_forward':            '<M-j>',
-    \ 'sexp_swap_element_backward':        '<M-h>',
-    \ 'sexp_swap_element_forward':         '<M-l>',
-    \ 'sexp_emit_head_element':            '<M-S-j>',
-    \ 'sexp_emit_tail_element':            '<M-S-k>',
-    \ 'sexp_capture_prev_element':         '<M-S-h>',
-    \ 'sexp_capture_next_element':         '<M-S-l>',
-    \ 'sexp_put_before':                   '<LocalLeader>P',
-    \ 'sexp_put_after':                    '<LocalLeader>p',
-    \ 'sexp_replace':                      '<LocalLeader><LocalLeader>p',
-    \ 'sexp_put_at_head':                  '<M-p>',
-    \ 'sexp_put_at_tail':                  '<M-P>',
+    \ 'sexp_outer_list':                   {'xo': 'af'},
+    \ 'sexp_inner_list':                   {'xo': 'if'},
+    \ 'sexp_outer_top_list':               {'xo': 'aF'},
+    \ 'sexp_inner_top_list':               {'xo': 'iF'},
+    \ 'sexp_outer_string':                 {'xo': 'as'},
+    \ 'sexp_inner_string':                 {'xo': 'is'},
+    \ 'sexp_outer_element':                {'xo': 'ae'},
+    \ 'sexp_inner_element':                {'xo': 'ie'},
+    \ 'sexp_outer_child_tail':             {'xo': 'aC'},
+    \ 'sexp_outer_child_head':             {'xo': 'ac'},
+    \ 'sexp_inner_child_tail':             {'xo': 'iC'},
+    \ 'sexp_inner_child_head':             {'xo': 'ic'},
+    \ 'sexp_move_to_prev_bracket':         {'nxo': '('},
+    \ 'sexp_move_to_next_bracket':         {'nxo': ')'},
+    \ 'sexp_move_to_prev_element_head':    {'nxo': '<M-b>'},
+    \ 'sexp_move_to_next_element_head':    {'nxo': '<M-w>'},
+    \ 'sexp_move_to_prev_element_tail':    {'nxo': 'g<M-e>'},
+    \ 'sexp_move_to_next_element_tail':    {'nxo': '<M-e>'},
+    \ 'sexp_flow_to_prev_close':           {'nx': '<M-[>'},
+    \ 'sexp_flow_to_next_open':            {'nx': '<M-]>'},
+    \ 'sexp_flow_to_prev_open':            {'nx': '<M-{>'},
+    \ 'sexp_flow_to_next_close':           {'nx': '<M-}>'},
+    \ 'sexp_flow_to_prev_leaf_head':       {'nx': '<M-S-b>'},
+    \ 'sexp_flow_to_next_leaf_head':       {'nx': '<M-S-w>'},
+    \ 'sexp_flow_to_prev_leaf_tail':       {'nx': '<M-S-g>'},
+    \ 'sexp_flow_to_next_leaf_tail':       {'nx': '<M-S-e>'},
+    \ 'sexp_move_to_prev_top_element':     {'nxo': '[['},
+    \ 'sexp_move_to_next_top_element':     {'nxo': ']]'},
+    \ 'sexp_select_prev_element':          {'nxo': '[e'},
+    \ 'sexp_select_next_element':          {'nxo': ']e'},
+    \ 'sexp_indent':                       {'n': '==', 'x': '='},
+    \ 'sexp_indent_top':                   {'n': '=-'},
+    \ 'sexp_indent_and_clean':             {'n': '<M-=>'},
+    \ 'sexp_indent_and_clean_top':         {'n': '<M-->'},
+    \ 'sexp_align_comments':               {'n': '<LocalLeader>a'},
+    \ 'sexp_align_comments_top':           {'n': '<LocalLeader>A'},
+    \ 'sexp_round_head_wrap_list':         {'nx': '<LocalLeader>i'},
+    \ 'sexp_round_tail_wrap_list':         {'nx': '<LocalLeader>I'},
+    \ 'sexp_square_head_wrap_list':        {'nx': '<LocalLeader>['},
+    \ 'sexp_square_tail_wrap_list':        {'nx': '<LocalLeader>]'},
+    \ 'sexp_curly_head_wrap_list':         {'nx': '<LocalLeader>{'},
+    \ 'sexp_curly_tail_wrap_list':         {'nx': '<LocalLeader>}'},
+    \ 'sexp_round_head_wrap_element':      {'nx': '<LocalLeader>w'},
+    \ 'sexp_round_tail_wrap_element':      {'nx': '<LocalLeader>W'},
+    \ 'sexp_square_head_wrap_element':     {'nx': '<LocalLeader>e['},
+    \ 'sexp_square_tail_wrap_element':     {'nx': '<LocalLeader>e]'},
+    \ 'sexp_curly_head_wrap_element':      {'nx': '<LocalLeader>e{'},
+    \ 'sexp_curly_tail_wrap_element':      {'nx': '<LocalLeader>e}'},
+    \ 'sexp_insert_at_list_head':          {'n': '<LocalLeader>h'},
+    \ 'sexp_insert_at_list_tail':          {'n': '<LocalLeader>l'},
+    \ 'sexp_splice_list':                  {'n': '<LocalLeader>@'},
+    \ 'sexp_convolute':                    {'n': '<LocalLeader>?'},
+    \ 'sexp_clone_list':                   {'nx': '<LocalLeader>c'},
+    \ 'sexp_clone_list_sl':                {'nx': ''},
+    \ 'sexp_clone_list_ml':                {'nx': ''},
+    \ 'sexp_clone_element':                {'nx': '<LocalLeader>C'},
+    \ 'sexp_clone_element_sl':             {'nx': ''},
+    \ 'sexp_clone_element_ml':             {'nx': ''},
+    \ 'sexp_raise_list':                   {'nx': '<LocalLeader>o'},
+    \ 'sexp_raise_element':                {'nx': '<LocalLeader>O'},
+    \ 'sexp_swap_list_backward':           {'nx': '<M-k>'},
+    \ 'sexp_swap_list_forward':            {'nx': '<M-j>'},
+    \ 'sexp_swap_element_backward':        {'nx': '<M-h>'},
+    \ 'sexp_swap_element_forward':         {'nx': '<M-l>'},
+    \ 'sexp_emit_head_element':            {'nx': '<M-S-j>'},
+    \ 'sexp_emit_tail_element':            {'nx': '<M-S-k>'},
+    \ 'sexp_capture_prev_element':         {'nx': '<M-S-h>'},
+    \ 'sexp_capture_next_element':         {'nx': '<M-S-l>'},
+    \ 'sexp_put_before':                   {'n': 'P'},
+    \ 'sexp_put_after':                    {'n': 'p'},
+    \ 'sexp_replace':                      {'n': '<LocalLeader>p', 'x': 'p'},
+    \ 'sexp_put_at_head':                  {'n': '<M-p>'},
+    \ 'sexp_put_at_tail':                  {'n': '<M-P>'},
     \ }
 
 if !empty(g:sexp_filetypes)
@@ -406,89 +406,131 @@ function! s:repeat_set(buf, count)
     augroup END
 endfunction
 
+" Display warning with requested highlighting.
+function! s:warn(msg, ...)
+    let hl = a:0 ? a:1 : 'WarningMsg'
+    try
+        exe 'echohl' hl
+        echomsg a:msg
+    finally
+        echohl None
+    endtry
+endfunction
+
+" Return input lhs in canonical form to facilitate comparison.
+function! s:canonicalize_lhs(lhs)
+    let ret = a:lhs
+    " TODO: Use information in help section key-notation to create a function for
+    " canonicalizing lhs.
+    " ...
+    return ret
+endfunction
+
+" Simplify warning displays for mappings.
+" -- Args --
+"   plug: command name specified as the ... in <plug>(...)
+"   msg:  warning msg
+function! s:mapwarn(plug, msg)
+    call s:warn(printf("Invalid entry for g:sexp_mappings['%s']: %s",
+                \ a:plug, a:msg))
+endfunction
+
+" Convert a single value in the sexp_mappings dict to a denormalized form conducive to use
+" in map creation.
+" Args:
+"   plug:         command name (i.e., the ... in <Plug>(...))
+"   entry:        lhs specification in one of the following forms:
+"   entry:        '<lhs>'
+"                 | {'<modes1>': '<lhs1>', ..., '<modesN>': '<lhsN>'}
+"   valid_modes:  string of chars in [nxo] constraining the modes for this command
+"                 default: 'nox'
+"                 override: subset of modes defined by default
+function! s:parse_map_entry(plug, entry, valid_modes)
+    let maps = {}
+    let valid_modes = empty(a:valid_modes) ? 'novx' : a:valid_modes
+    for [modes, lhs] in items(a:entry)
+        " Convert v to x: e.g., 'nvo' => 'nxo'
+        let modes = substitute(modes, 'v', 'x', 'g')
+        " Collapse multiple occurrences of same mode: e.g., {'x': ..., 'xo': ...}.
+        let modes = substitute(
+            \ join(sort(split(modes, '\zs')), ''), '\v(.)\1+', '\1', 'g')
+        " Loop over sorted/uniquified mode chars.
+        for mode in split(modes, '\zs')
+            " TODO: Distinguish between defaults and user here?
+            if mode !~ '[' . valid_modes . ']'
+                call s:mapwarn(a:plug, printf("Unrecognized mode %s", mode))
+                continue
+            endif
+            " We have a valid mode, but has it already been specified for this plug?
+            if has_key(maps, mode)
+                " TODO: Consider just ignoring malformed entry altogether since this is
+                " effectively UB without ordered keys.
+                call s:mapwarn(a:plug, printf(
+                    \ "Conflicting lhs specifications for mode %s: old=%s new=%s",
+                    \ mode, maps[mode], lhs))
+                continue
+            endif
+            " We have a valid mode that hasn't appeared in another key.
+            let maps[mode] = lhs
+        endfor
+    endfor
+    return maps
+endfunction
+
 " Bind <Plug> mappings in current buffer to values in g:sexp_mappings or
 " s:sexp_mappings
 function! s:sexp_create_mappings()
-
-    for plug in ['sexp_replace']
-        let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
-        if !empty(lhs)
-            execute 'xmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
-        endif
-    endfor
-
-    for plug in ['sexp_outer_list',           'sexp_inner_list',
-               \ 'sexp_outer_top_list',       'sexp_inner_top_list',
-               \ 'sexp_outer_string',         'sexp_inner_string',
-               \ 'sexp_outer_element',        'sexp_inner_element',
-               \ 'sexp_outer_child_tail',     'sexp_outer_child_head',
-               \ 'sexp_inner_child_tail',     'sexp_inner_child_head']
-        let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
-        if !empty(lhs)
-            execute 'xmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
-            execute 'omap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
-        endif
-    endfor
-
-    for plug in ['sexp_move_to_prev_bracket',      'sexp_move_to_next_bracket',
-               \ 'sexp_move_to_prev_element_head', 'sexp_move_to_next_element_head',
-               \ 'sexp_move_to_prev_element_tail', 'sexp_move_to_next_element_tail',
-               \ 'sexp_move_to_prev_top_element',  'sexp_move_to_next_top_element',
-               \ 'sexp_select_prev_element',       'sexp_select_next_element']
-        let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
-        if !empty(lhs)
-            execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
-            execute 'xmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
-            execute 'omap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
-        endif
-    endfor
-
-    for plug in ['sexp_insert_at_list_head', 'sexp_insert_at_list_tail',
-               \ 'sexp_convolute',           'sexp_splice_list',
-               \ 'sexp_indent_top',          'sexp_indent_and_clean_top',
-               \ 'sexp_align_comments',      'sexp_align_comments_top',
-               \ 'sexp_put_before',          'sexp_put_after',
-               \ 'sexp_put_at_head',         'sexp_put_at_tail']
-        let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
-        if !empty(lhs)
-            execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
-        endif
-    endfor
-
-    for plug in ['sexp_round_head_wrap_list',     'sexp_round_tail_wrap_list',
-               \ 'sexp_square_head_wrap_list',    'sexp_square_tail_wrap_list',
-               \ 'sexp_curly_head_wrap_list',     'sexp_curly_tail_wrap_list',
-               \ 'sexp_round_head_wrap_element',  'sexp_round_tail_wrap_element',
-               \ 'sexp_square_head_wrap_element', 'sexp_square_tail_wrap_element',
-               \ 'sexp_curly_head_wrap_element',  'sexp_curly_tail_wrap_element',
-               \ 'sexp_raise_list',               'sexp_raise_element',
-               \ 'sexp_swap_list_backward',       'sexp_swap_list_forward',
-               \ 'sexp_swap_element_backward',    'sexp_swap_element_forward',
-               \ 'sexp_emit_head_element',        'sexp_emit_tail_element',
-               \ 'sexp_capture_prev_element',     'sexp_capture_next_element',
-               \ 'sexp_flow_to_prev_close',       'sexp_flow_to_next_open',
-               \ 'sexp_flow_to_prev_open',        'sexp_flow_to_next_close',
-               \ 'sexp_flow_to_prev_leaf_head',   'sexp_flow_to_next_leaf_head',
-               \ 'sexp_flow_to_prev_leaf_tail',   'sexp_flow_to_next_leaf_tail',
-               \ 'sexp_clone_list',               'sexp_clone_element',
-               \ 'sexp_clone_list_sl',            'sexp_clone_element_sl',
-               \ 'sexp_clone_list_ml',            'sexp_clone_element_ml',
-               \ 'sexp_indent',                   'sexp_indent_and_clean',
-               \ 'sexp_align_comments',           'sexp_replace',
-               \ ]
-        let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
-        if !empty(lhs)
-            execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
-            if plug =~ '^sexp_indent' && lhs == '=='
-                " Special Case: Just as == overrides Vim's default normal mode
-                " command, = must override Vim's default visual mode command.
-                " Rationale: Prevents ambiguity that leads to map delay.
-                let lhs = '='
+    " Note: {s,g}entry stand for {s,g}:sexp_mappings entry, respectively.
+    for [plug, sentry] in items(s:sexp_mappings)
+        " Get corresponding user override if it exists.
+        let gentry = get(g:sexp_mappings, plug, {})
+        " Parse entry into a flat dict of modechar => lhs: e.g.,
+        " {'nx': '\s', 'o': '\t'} => {'n': '\s', 'x': '\s', 'o': \t'}
+        let sm = s:parse_map_entry(plug, sentry, '')
+        " Default map determines the valid keys.
+        let valid_modes_arr = sort(keys(sm))
+        let valid_modes_str = join(valid_modes_arr, '')
+        " Now parse any user-defined override
+        let gm = {}
+        if type(gentry) == type({})
+            " Empty dict indicates no user-override.
+            if !empty(gentry)
+                let gm = s:parse_map_entry(plug, gentry, valid_modes_str)
             endif
-            execute 'xmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
+        elseif type(gentry) == type('')
+            " Create dict that uses specified lhs for all valid modes.
+            for mode in valid_modes_arr
+                let gm[mode] = gentry
+            endfor
+        else
+            " Note: Leave gm empty to ensure default is used.
+            call s:mapwarn(sprintf(
+                \ "Invalid format: must be string or dict."
+                \ . " (:help g:sexp_mappings)", string(gentry)))
         endif
+
+        " Loop over all modes which are valid for this command.
+        for mode in valid_modes_arr
+            " Use mode-specific override if it exists, else default, which must exist.
+            let lhs = get(gm, mode, get(sm, mode))
+            " Check for map conflict.
+            " Assumption: maparg() can handle distinct but equivalent forms of lhs (e.g.,
+            " <LocalLeader> vs \, <C-...> vs <c-...>, etc...)
+            " TODO: Could alternatively check only mappings created by this plugin, but
+            " that would entail canonicalizing lhs and storing in dict of some sort.
+            let rhs = maparg(lhs, mode)
+            if !empty(rhs)
+                " Warn before overwriting existing map.
+                " TODO: Consider adding option for this.
+                call s:mapwarn(plug, printf("lhs %s already mapped to %s in mode %s",
+                            \ lhs, rhs, mode))
+            endif
+            " Create the mapping.
+            execute mode . 'map <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
+        endfor
     endfor
 
+    " Insert-mode mappings
     if g:sexp_enable_insert_mode_mappings
         imap <silent><buffer> (    <Plug>(sexp_insert_opening_round)
         imap <silent><buffer> [    <Plug>(sexp_insert_opening_square)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -357,6 +357,14 @@ endfunction
 " Bind <Plug> mappings in current buffer to values in g:sexp_mappings or
 " s:sexp_mappings
 function! s:sexp_create_mappings()
+
+    for plug in ['sexp_replace']
+        let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
+        if !empty(lhs)
+            execute 'xmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
+        endif
+    endfor
+
     for plug in ['sexp_outer_list',           'sexp_inner_list',
                \ 'sexp_outer_top_list',       'sexp_inner_top_list',
                \ 'sexp_outer_string',         'sexp_inner_string',
@@ -386,7 +394,10 @@ function! s:sexp_create_mappings()
     for plug in ['sexp_insert_at_list_head', 'sexp_insert_at_list_tail',
                \ 'sexp_convolute',           'sexp_splice_list',
                \ 'sexp_indent_top',          'sexp_indent_and_clean_top',
-               \ 'sexp_align_comments',      'sexp_align_comments_top']
+               \ 'sexp_align_comments',      'sexp_align_comments_top',
+               \ 'sexp_put_before',          'sexp_put_after',
+               \ 'sexp_put_at_head',         'sexp_put_at_tail',
+        ]
         let lhs = get(g:sexp_mappings, plug, s:sexp_mappings[plug])
         if !empty(lhs)
             execute 'nmap <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
@@ -646,6 +657,15 @@ Defplug! nnoremap sexp_capture_prev_element sexp#docount_stateful(v:count, 'sexp
 Defplug  xnoremap sexp_capture_prev_element sexp#docount_stateful(v:prevcount, 'sexp#stackop', 'v', 0, 1)
 Defplug! nnoremap sexp_capture_next_element sexp#docount_stateful(v:count, 'sexp#stackop', 'n', 1, 1)
 Defplug  xnoremap sexp_capture_next_element sexp#docount_stateful(v:prevcount, 'sexp#stackop', 'v', 1, 1)
+
+" Replace with register
+DefplugN xnoremap sexp_replace sexp#replace('v', v:prevcount)
+" Put before/after from register
+DefplugN nnoremap sexp_put_before  sexp#put_at(v:count, 0)
+DefplugN nnoremap sexp_put_after   sexp#put_at(v:count, 1)
+" Put (into list) at head/tail
+DefplugN nnoremap sexp_put_at_head sexp#put_into(v:count, 0)
+DefplugN nnoremap sexp_put_at_tail sexp#put_into(v:count, 1)
 
 """ Insert mode mappings {{{1
 

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -305,6 +305,8 @@ function! s:defplug(flags, mapmode, name, ...)
 	" maps defined with DEFPLUG would even work correctly.
 	" TODO: Consider removing DEFPLUG and simplifying this function accordingly: e.g.,
 	" the prefix/postfix assignments could be inlined below.
+    " CAVEAT!: This path does not invoke {pre,post}_op(), which means it may actually be
+    " broken, since pre_op() is what ensures correct settings of options like 've'.
         execute lhs . ' ' . rhs
         return 1
     endif

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -214,6 +214,10 @@ if !exists('g:sexp_aligncom_optlevel')
     let g:sexp_aligncom_optlevel = 2
 endif
 
+if !exists('g:sexp_put_treats_list_as_element')
+    let g:sexp_put_treats_list_as_element = 0
+endif
+
 " Expert options
 if !exists('g:sexp_inhibit_failsafe')
     let g:sexp_inhibit_failsafe = 0
@@ -800,18 +804,18 @@ Defplug  xnoremap sexp_capture_next_element sexp#docount_stateful(v:prevcount, '
 DefplugN nnoremap sexp_put_before  sexp#put(v:count, 0)
 DefplugN nnoremap sexp_put_after   sexp#put(v:count, 1)
 " Replace element/selection with register
-DefplugN nnoremap sexp_replace   sexp#replace('n', v:count, 'p')
-DefplugN nnoremap sexp_replace_P sexp#replace('n', v:count, 'P')
-DefplugN xnoremap sexp_replace   sexp#replace('v', v:prevcount, 'p')
-DefplugN xnoremap sexp_replace_P sexp#replace('v', v:prevcount, 'P')
+DefplugN nnoremap sexp_replace   sexp#replace('n', v:count, 0)
+DefplugN nnoremap sexp_replace_P sexp#replace('n', v:count, 1)
+DefplugN xnoremap sexp_replace   sexp#replace('v', v:prevcount, 0)
+DefplugN xnoremap sexp_replace_P sexp#replace('v', v:prevcount, 1)
 " Put register into list
 DefplugN nnoremap sexp_put_at_head sexp#put_child(v:count, 0)
 DefplugN nnoremap sexp_put_at_tail sexp#put_child(v:count, 1)
 " Replace child with register
-DefplugN nnoremap sexp_replace_at_head   sexp#replace_child(v:count, 0, 'p')
-DefplugN nnoremap sexp_replace_at_head_P sexp#replace_child(v:count, 0, 'P')
-DefplugN nnoremap sexp_replace_at_tail   sexp#replace_child(v:count, 1, 'p')
-DefplugN nnoremap sexp_replace_at_tail_P sexp#replace_child(v:count, 1, 'P')
+DefplugN nnoremap sexp_replace_at_head   sexp#replace_child(v:count, 0, 0)
+DefplugN nnoremap sexp_replace_at_head_P sexp#replace_child(v:count, 0, 1)
+DefplugN nnoremap sexp_replace_at_tail   sexp#replace_child(v:count, 1, 0)
+DefplugN nnoremap sexp_replace_at_tail_P sexp#replace_child(v:count, 1, 1)
 
 """ Insert mode mappings {{{1
 

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -249,7 +249,8 @@ if !exists('g:sexp_regput_curpos')
 endif
 
 if !exists('g:sexp_regput_into_curpos')
-    let g:sexp_regput_into_curpos = 0
+    " Default to the base variant that isn't specific to "put into" commands.
+    let g:sexp_regput_into_curpos = get(g:, 'sexp_regput_curpos', 0)
 endif
 
 if !exists('g:sexp_regput_invalid_register_action')
@@ -258,6 +259,10 @@ endif
 
 if !exists('g:sexp_regput_inhibit_regparse')
     let g:sexp_regput_inhibit_regparse = 0
+endif
+
+if !exists('g:sexp_regput_replace_expanded')
+    let g:sexp_regput_replace_expanded = 0
 endif
 
 " Expert options
@@ -282,6 +287,8 @@ endif
 let s:sexp_mapping_preset__regput = {
     \ 'sexp_put_before':                   {'n': 'P'},
     \ 'sexp_put_after':                    {'n': 'p'},
+    \ 'sexp_replace':                      {'x': 'p'},
+    \ 'sexp_replace_P':                    {'x': 'P'},
 \ }
 
 let s:sexp_mappings = {
@@ -357,6 +364,8 @@ let s:sexp_mappings = {
     \ 'sexp_put_after':                    {'n': '<LocalLeader>p'},
     \ 'sexp_replace_op':                   {'n': '<M-p>'},
     \ 'sexp_replace_op_P':                 {'n': '<M-P>'},
+    \ 'sexp_replace':                      {'x': '<M-p>'},
+    \ 'sexp_replace_P':                    {'x': '<M-P>'},
     \ 'sexp_put_at_head':                  {'n': '<p'},
     \ 'sexp_put_at_tail':                  {'n': '>p'},
     \ }
@@ -368,9 +377,6 @@ if !empty(g:sexp_filetypes)
     augroup END
 endif
 
-" Autoload and detect repeat.vim
-silent! call repeat#set('')
-let s:have_repeat_set = exists('*repeat#set')
 " If it's available, use <Cmd> modifier at the head of command rhs.
 " Rationale: The idiomatic (but now obsolete) `:<c-u>` has the undesirable side-effect of
 " generating a 'CmdlineChanged' autocmd event for *every character* in the command line
@@ -380,98 +386,42 @@ let s:have_repeat_set = exists('*repeat#set')
 let s:have_cmd = has('nvim') || v:version >= 900
 """ Functions {{{1
 
-command! -nargs=+       DEFPLUG  call <SID>defplug('000', <f-args>)
-command! -nargs=+ -bang Defplug  call <SID>defplug('1' . string(!empty('<bang>')) . '0', <f-args>)
-command! -nargs=+ -bang DefplugN call <SID>defplug('1' . string(!empty('<bang>')) . '1', <f-args>)
-
-" Create a <Plug> mapping. The 'flags' faux bitfield dictates behavior:
-"
-"   * flags == 0**: Map rhs as a key sequence
-"   * flags == 100: Map rhs as an expression
-"   * flags == 110: Map rhs as an expression, and setup repeat
-"   * flags == 101: Map rhs as an expression, and do not set '`
-"   * flags == 111: Map rhs as an expression, set up repeat, and do not set '`
-"
-" We don't use an actual bitfield because the bitwise functions and() and or()
-" were not introduced until patch 7.3.377.
-"
-function! s:defplug(flags, mapmode, name, ...)
-    let lhs = a:mapmode . ' <silent> <Plug>(' . a:name . ')'
-    let rhs = join(a:000)
-
-    let asexpr = a:flags[0] == '1'
-    let repeat = a:flags[1] == '1'
-    let nojump = a:flags[2] == '1'
-    let opmode = a:mapmode[0] ==# 'o'
-
-    " Build prefix/postfix for wrapping rhs.
-    let prefix = 'call sexp#pre_op("' . a:mapmode[0] . '", "' . a:name . '")'
-    \ . ' \| try \| '
-    let postfix = ' \| finally'
-    \ . ' \| call sexp#post_op("' . a:mapmode[0] . '", "' . a:name . '")'
-    \ . ' \| endtry'
-
-    " Key sequence
-    if !asexpr
-	" Note: All the DEFPLUGs have been converted to DefplugN to ensure they handle
-	" counts correctly. Since this block has no special v:count handling, it's unlikely
-	" maps defined with DEFPLUG would even work correctly.
-	" TODO: Consider removing DEFPLUG and simplifying this function accordingly: e.g.,
-	" the prefix/postfix assignments could be inlined below.
-    " CAVEAT!: This path does not invoke {pre,post}_op(), which means it may actually be
-    " broken, since pre_op() is what ensures correct settings of options like 've'.
-        execute lhs . ' ' . rhs
-        return 1
-    endif
-
-    " Common mapping prefix
-    " RE: vv
-    "   Due to a ?bug? in vim, we need to set curwin->w_curswant to the
-    "   current cursor position by entering and exiting character-wise visual
-    "   mode before completing an operator-pending command so that the cursor
-    "   returns to its original position after an = command.
-    " RE: b:sexp_count
-    "   v:count and v:prevcount can change while the concatenated commands are executing.
-    "   To ensure the count passed to functions is the one corresponding to the executed
-    "   map, we cache either v:count or v:prevcount (whichever is present in the raw
-    "   command) just after the cmd leader and replace all references to the vim count
-    "   with references to the cached var.
-    let use_count = rhs =~ 'v:prevcount' && !s:have_cmd ? 'v:prevcount' : 'v:count'
-    let prefix = lhs . ' '
-                 \ . (s:have_cmd ? '<cmd>' : ':<c-u>') . ' let b:sexp_count = ' . use_count
-                 \ . (s:have_cmd ? ' \| call sexp#ensure_normal_mode()' : '') . ' \| '
-                 \ . prefix
-                 \ . (nojump ? '' : 'execute "normal! ' . (opmode ? 'vv' : '') . 'm`" \| ')
-                 \ . 'call ' . substitute(rhs, 'v:\%(prev\)\?count', 'b:sexp_count', 'g')
-    " Expression, non-repeating
-    if !repeat || !s:have_repeat_set
-        execute prefix . postfix . '<CR>'
-    " Expression, repeating, operator-pending mode
-    elseif opmode
-        execute prefix
-                \ . ' \| if v:operator ==? "c" \| '
-                \ . '  call <SID>repeat_set(v:operator . "\<Plug>(' . a:name . ')\<lt>C-r>.\<lt>C-Bslash>\<lt>C-n>", b:sexp_count) \| '
-                \ . 'else \| '
-                \ . '  call <SID>repeat_set(v:operator . "\<Plug>(' . a:name . ')", b:sexp_count) \| '
-                \ . 'endif'
-                \ . postfix . '<CR>'
-    " Expression, repeating, non-operator-pending mode
-    else
-        execute prefix . ' \| call <SID>repeat_set("\<Plug>(' . a:name . ')", b:sexp_count)'
-                \ . postfix . '<CR>'
-    endif
+" Convert list of bools to flags dict provided to s:defplug.
+" Rationale: Serializing the dict in the plug function arglist aids in readability.
+" -- Args --
+"   asexpr: create <expr> mapping
+"           TODO: Consider renaming this "asoper" since it's currently meant exclusively
+"           for use with operators.
+"   repeat: set up repeat (if repeat plugin available)
+"   nojump: inhibit set of '`
+function! s:defplug_flags(asexpr, repeat, nojump)
+    return {'asexpr': a:asexpr, 'repeat': a:repeat, 'nojump': a:nojump}
 endfunction
 
-" Calls repeat#set() and registers a one-time CursorMoved handler to correctly
-" set the value of g:repeat_tick.
-"
-" cf. https://github.com/tpope/vim-repeat/issues/8#issuecomment-13951082
-function! s:repeat_set(buf, count)
-    call repeat#set(a:buf, a:count)
-    augroup sexp_repeat
-        autocmd!
-        autocmd CursorMoved <buffer> let g:repeat_tick = b:changedtick | autocmd! sexp_repeat
-    augroup END
+" These commands invoke s:defplug() with arguments that will ensure creation of the
+" desired <Plug> mappings, which in turn, invoke sexp#plug#wrapper() when the map is
+" invoked.
+" Note: Defoper* relies on <expr> maps to define sexp operators.
+command! -nargs=+ -bang Defoper  call <SID>defplug(s:defplug_flags(1, !empty('<bang>'), 0), <f-args>)
+command! -nargs=+ -bang DefoperN call <SID>defplug(s:defplug_flags(1, !empty('<bang>'), 1), <f-args>)
+command! -nargs=+ -bang Defplug  call <SID>defplug(s:defplug_flags(0, !empty('<bang>'), 0), <f-args>)
+command! -nargs=+ -bang DefplugN call <SID>defplug(s:defplug_flags(0, !empty('<bang>'), 1), <f-args>)
+
+" Create a <Plug> mapping. The 'flags' dict provided by the Def* map influences behavior:
+function! s:defplug(flags, mapmode, name, ...)
+    let rhs = join(a:000)
+    let asexpr = a:flags.asexpr
+    let prefix = a:mapmode . (asexpr ? ' <expr>' : '')
+        \ . ' <silent> <Plug>(' . a:name . ')'
+
+    " Note: sexp#plug#wrapper() is called when map is invoked to handle both regular maps
+    " and sexp operators.
+    " Note: %s intentionally used to serialize the 'flags' dict.
+    execute prefix . printf(
+        \ '%s sexp#plug#wrapper(%s, "%s", "%s", v:count, "%s")%s',
+        \ asexpr ? '' : (s:have_cmd ? ' <cmd>' : ' :<c-u>') . ' call',
+        \ a:flags, a:mapmode, a:name, rhs,
+        \ (!asexpr ? '<cr>' : ''))
 endfunction
 
 " Display warning with requested highlighting.
@@ -483,15 +433,6 @@ function! s:warn(msg, ...)
     finally
         echohl None
     endtry
-endfunction
-
-" Return input lhs in canonical form to facilitate comparison.
-function! s:canonicalize_lhs(lhs)
-    let ret = a:lhs
-    " TODO: Use information in help section key-notation to create a function for
-    " canonicalizing lhs.
-    " ...
-    return ret
 endfunction
 
 " Simplify warning displays for mappings.
@@ -513,23 +454,6 @@ function! s:map_conflict_warn_once(lhs, rhs1, rhs2, mode)
     call sexp#warn#msg_once(s, printf(
         \ "Mapping %s => %s conflicts with existing mapping to %s in mode %s",
         \ a:lhs, a:rhs2, a:rhs1, a:mode))
-endfunction
-
-" TODO: UNTESTED and probably NOT NEEDED!
-function! s:set_nested_key(dict, ...)
-    if a:0 < 2
-        echoerr "set_nested_key: Internal error: requires at least 2 variadic args"
-    endif
-    let [i, dict] = [0, a:dict]
-    " Process all but final key in loop to ensure intermediate dicts exist.
-    while i < a:0 - 2
-        if !has_key(dict, key)
-            let dict[key] = {}
-        endif
-        let dict = dict[key]
-    endfor
-    " Assign value to leaf dict.
-    let dict[a:000[-2]] = a:000[-1]
 endfunction
 
 " Convert a single value in the sexp_mappings dict to a denormalized form conducive to use
@@ -596,6 +520,7 @@ endfunction
 
 " Bind <Plug> mappings in current buffer to values in g:sexp_mappings or
 " s:sexp_mappings
+" TODO: Consider moving more of this infrastructure into the plug autoload module.
 function! s:sexp_create_mappings()
     call sexp#feat#create_notifications()
     " Note: {s,g}entry stand for {s,g}:sexp_mappings entry, respectively.
@@ -884,25 +809,15 @@ Defplug  xnoremap sexp_capture_next_element sexp#docount_stateful(v:prevcount, '
 " Put register before/after
 DefplugN nnoremap sexp_put_before  sexp#put(v:count, 0)
 DefplugN nnoremap sexp_put_after   sexp#put(v:count, 1)
-" Replace element/selection with register
-" TODO: Decide whether/how to use s:defplug for these operators. Either overhaul s:defplug
-" to accommodate or use separate mechanism for operators. Note that s:defplug() probably
-" could use overhaul either way.
-nnoremap <expr> <Plug>(sexp_replace_op)   sexp#replace_op('n', v:count, 0)
-nnoremap <expr> <Plug>(sexp_replace_op_P) sexp#replace_op('n', v:count, 1)
-" TODO: These 2 are going away!
-DefplugN nnoremap sexp_replace   sexp#replace('n', v:count, 0)
-DefplugN nnoremap sexp_replace_P sexp#replace('n', v:count, 1)
+" Replace operator
+Defoper! nnoremap sexp_replace_op   sexp#replace_op('n', v:count, 0)
+Defoper! nnoremap sexp_replace_op_P sexp#replace_op('n', v:count, 1)
+" Replace selection with register
 DefplugN xnoremap sexp_replace   sexp#replace('v', v:prevcount, 0)
 DefplugN xnoremap sexp_replace_P sexp#replace('v', v:prevcount, 1)
 " Put register into list
 DefplugN nnoremap sexp_put_at_head sexp#put_child(v:count, 0)
 DefplugN nnoremap sexp_put_at_tail sexp#put_child(v:count, 1)
-" Replace child with register
-DefplugN nnoremap sexp_replace_at_head   sexp#replace_child(v:count, 0, 0)
-DefplugN nnoremap sexp_replace_at_head_P sexp#replace_child(v:count, 0, 1)
-DefplugN nnoremap sexp_replace_at_tail   sexp#replace_child(v:count, 1, 0)
-DefplugN nnoremap sexp_replace_at_tail_P sexp#replace_child(v:count, 1, 1)
 
 """ Insert mode mappings {{{1
 
@@ -952,6 +867,7 @@ DefplugI sexp_insert_backspace sexp#backspace_insertion()
 
 delcommand DefplugN
 delcommand Defplug
-delcommand DEFPLUG
+delcommand DefoperN
+delcommand Defoper
 
 " vim:ts=4:sw=4:et:tw=90

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -442,7 +442,7 @@ function! s:defplug(flags, mapmode, name, ...)
     " and sexp operators.
     " Note: %s intentionally used to serialize the 'flags' dict.
     execute prefix . printf(
-        \ '%s sexp#plug#wrapper(%s, "%s", "%s", v:count, "%s")%s',
+        \ '%s sexp#plug#wrapper(%s, "%s", "%s", "%s")%s',
         \ asexpr ? '' : (s:have_cmd ? ' <cmd>' : ' :<c-u>') . ' call',
         \ a:flags, a:mapmode, a:name, rhs,
         \ (!asexpr ? '<cr>' : ''))

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -49,6 +49,8 @@ function! s:deprecate_options(optnames, obsolete, helphint)
     endif
 endfunction
 
+call sexp#feat#record_user_awareness()
+
 " Note: The following options were introduced by PR #34 and removed in PR #51. Hopefully,
 " not many users have overridden them, but just in case...
 " TODO: Remove this after a few releases.
@@ -214,6 +216,10 @@ if !exists('g:sexp_aligncom_optlevel')
     let g:sexp_aligncom_optlevel = 2
 endif
 
+if !exists('g:sexp_regput_override_builtins')
+    let g:sexp_regput_override_builtins = 0
+endif
+
 if !exists('g:sexp_regput_bracket_is_target')
     let g:sexp_regput_bracket_is_target = 1
 endif
@@ -246,6 +252,29 @@ endif
 if !exists('g:sexp_mappings')
     let g:sexp_mappings = {}
 endif
+
+" Keymap Presets
+" Motivation: Give user an easy way to enable a (usually feature-specific) set of mappings
+" we don't dare create without permission (usually because they override builtin maps). A
+" keymap preset is selected by a user option: e.g.,
+"   let g:sexp_regput_override_builtins = 1
+" From all such options, logic in sexp_create_mappings() determines a list of enabled
+" presets, each of which causes a dict by the name of s:sexp_mapping_preset__{feat-name},
+" with the same format as s:sexp_mappings, to be searched for overrides.
+" Constraint: A given plug rhs should never belong to multiple presets, as this would give
+" rise to ambiguity when both presets were enabled.
+let s:sexp_mapping_preset__regput = {
+    \ 'sexp_put_before':                   {'n': 'P'},
+    \ 'sexp_put_after':                    {'n': 'p'},
+    \ 'sexp_replace':                      {'n': '<M-p>', 'x': 'p'},
+    \ 'sexp_replace_P':                    {'n': '<M-P>', 'x': 'P'},
+    \ 'sexp_put_at_head':                  {'n': '<p'},
+    \ 'sexp_put_at_tail':                  {'n': '>p'},
+    \ 'sexp_replace_at_head':              {'n': '[p'},
+    \ 'sexp_replace_at_tail':              {'n': ']p'},
+    \ 'sexp_replace_at_head_P':            {'n': '[P'},
+    \ 'sexp_replace_at_tail_P':            {'n': ']P'},
+\ }
 
 let s:sexp_mappings = {
     \ 'sexp_outer_list':                   {'xo': 'af'},
@@ -316,14 +345,16 @@ let s:sexp_mappings = {
     \ 'sexp_emit_tail_element':            {'nx': '<M-S-k>'},
     \ 'sexp_capture_prev_element':         {'nx': '<M-S-h>'},
     \ 'sexp_capture_next_element':         {'nx': '<M-S-l>'},
-    \ 'sexp_put_before':                   {'n': 'P'},
-    \ 'sexp_put_after':                    {'n': 'p'},
-    \ 'sexp_replace':                      {'n': 'gp', 'x': 'p'},
-    \ 'sexp_replace_P':                    {'n': 'gP', 'x': 'P'},
-    \ 'sexp_put_at_head':                  {'n': '<M-p>'},
-    \ 'sexp_put_at_tail':                  {'n': '<M-P>'},
-    \ 'sexp_replace_at_head':              {'n': '<LocalLeader>p'},
-    \ 'sexp_replace_at_tail':              {'n': '<LocalLeader>P'},
+    \ 'sexp_put_before':                   {'n': '<LocalLeader>P'},
+    \ 'sexp_put_after':                    {'n': '<LocalLeader>p'},
+    \ 'sexp_replace':                      {'nx': '<M-p>'},
+    \ 'sexp_replace_P':                    {'nx': '<M-P>'},
+    \ 'sexp_put_at_head':                  {'n': '<LocalLeader><p'},
+    \ 'sexp_put_at_tail':                  {'n': '<LocalLeader>>p'},
+    \ 'sexp_replace_at_head':              {'n': '<LocalLeader>[p'},
+    \ 'sexp_replace_at_tail':              {'n': '<LocalLeader>]p'},
+    \ 'sexp_replace_at_head_P':            {'n': '<LocalLeader>[P'},
+    \ 'sexp_replace_at_tail_P':            {'n': '<LocalLeader>]P'},
     \ }
 
 if !empty(g:sexp_filetypes)
@@ -539,11 +570,37 @@ function! s:parse_map_entry(plug, entry, valid_modes)
     return maps
 endfunction
 
+" Return preset mapping override for specified plug, else {}.
+" See note on Keymap Presets.
+function! s:check_for_mapping_preset(plug)
+    " TODO: Add more preset groups as necessary.
+    let feats = {'regput': g:sexp_regput_override_builtins}
+    for [feat, enable] in items(feats)
+        if enable
+            " Get preset dict whose format is same as s:sexp_mappings[].
+            let o = s:sexp_mapping_preset__{feat}
+            " Does this preset group define an override for this plug?
+            if has_key(o, a:plug)
+                " Replace the default with the enabled override.
+                " Note: A plug should never be represented in 2 distinct feature sets.
+                return o[a:plug]
+            endif
+        endif
+    endfor
+    return {}
+endfunction
+
 " Bind <Plug> mappings in current buffer to values in g:sexp_mappings or
 " s:sexp_mappings
 function! s:sexp_create_mappings()
+    call sexp#feat#create_notifications()
     " Note: {s,g}entry stand for {s,g}:sexp_mappings entry, respectively.
     for [plug, sentry] in items(s:sexp_mappings)
+        " Check for preset override.
+        let override = s:check_for_mapping_preset(plug)
+        if !empty(override)
+            let sentry = override
+        endif
         " Get corresponding user override if it exists.
         let gentry = get(g:sexp_mappings, plug, {})
         " Parse entry into a flat dict of modechar => lhs: e.g.,

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -581,6 +581,10 @@ function! s:sexp_create_mappings()
         for mode in valid_modes_arr
             " Use mode-specific override if it exists, else default, which must exist.
             let lhs = get(gm, mode, get(sm, mode))
+            if empty(lhs)
+                " No lhs mapping for this one, so skip it.
+                continue
+            endif
             " Check for a conflicting map defined for the current buffer.
             " Assumption: maparg() can handle distinct but equivalent forms of lhs (e.g.,
             " <LocalLeader> vs \, <C-...> vs <c-...>, etc...)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -463,8 +463,10 @@ function! s:mapwarn(plug, msg)
     call s:warn(printf("g:sexp_mappings['%s']: %s", a:plug, a:msg))
 endfunction
 
-" Warn once-only (per buffer) for the specified map conflict.
-function! s:map_conflict_warn_once(lhs, rhs1, rhs2, mode)
+" Warn once-only (per buffer) for the specified map conflict (or ambiguity).
+" -- Optional Args --
+" a:1  ambiguous (not conflict)
+function! s:map_conflict_warn_once(lhs, rhs1, rhs2, mode, ...)
     " Note: Unambiguously order the components of the key to ensure we don't warn twice
     " for the same conflict when s:sexp_create_mappings() is called twice.
     " Explanation: In the initial call, the second map overwrites the first, but then in
@@ -472,8 +474,8 @@ function! s:map_conflict_warn_once(lhs, rhs1, rhs2, mode)
     let s = call(function('sexp#warn#join_hashable'),
                 \ [a:mode, a:lhs] + sort([a:rhs1, a:rhs2]))
     call sexp#warn#msg_once(s, printf(
-        \ "Mapping %s => %s conflicts with existing mapping to %s in mode %s",
-        \ a:lhs, a:rhs2, a:rhs1, a:mode))
+        \ "Mapping %s => %s %s with existing mapping to %s in mode %s",
+        \ a:lhs, a:rhs2, (a:0 ? "is ambiguous" : "conflicts"), a:rhs1, a:mode))
 endfunction
 
 " Convert a single value in the sexp_mappings dict to a denormalized form conducive to use
@@ -538,6 +540,47 @@ function! s:check_for_mapping_preset(plug)
     return {}
 endfunction
 
+" Warn user if the input args represent a mapping that would conflict or be ambiguous with
+" an existing map (either global or buffer).
+" Return:
+"   0  no problem
+"   1  ambiguity
+"   2  conflict
+function! s:check_for_map_conflicts(lhs, mode, plug)
+    let rhs = '<Plug>(' . a:plug . ')'
+    " Assumption: maparg() can handle distinct but equivalent forms of lhs (e.g.,
+    " <LocalLeader> vs \, <C-...> vs <c-...>, etc...)
+    " TODO: Could alternatively check only mappings created by this plugin, but
+    " that would entail canonicalizing lhs and storing in dict of some sort.
+    " Assumption: maparg returns a buffer map before a global one, but in the absence of a
+    " buffer map, will return a global one.
+    " Design Decision: Warn about both buffer and global map conflicts/ambiguities.
+    " Caveat: The check against <plug>(...) ensures we don't warn about our own mapping if
+    " this function is called multiple times.
+    " Note: 'rhs' key won't exist if the rhs is a Lua callback (stored in 'callback').
+    let m = maparg(a:lhs, a:mode, 0, 1)
+    if !empty(m) && has_key(m, 'rhs') && m.rhs !=? '<nop>'
+        \ && m.rhs !=? rhs
+        " Warn before overwriting existing map.
+        " TODO: Consider adding option for this.
+        call s:map_conflict_warn_once(a:lhs, m.rhs, rhs, a:mode)
+        return 2
+    endif
+    " Also check for map ambiguities.
+    let m = mapcheck(a:lhs, a:mode)
+    " Caveat: Don't warn if the ambiguous map appears to be this one, created on an
+    " earlier call to sexp_create_mappings().
+    " Note: Although it should be safe to compare full rhs (including <Plug>(...)
+    " wrapper), Vim docs don't explicitly state that "<Plug>" will appear untranslated in
+    " the rhs returned by mapcheck; thus, to be safe, just compare the plug name itself.
+    if !empty(m) && m !~ '(' . a:plug . ')'
+        " Pass optional 'ambiguous' flag to indicate not true conflict.
+        call s:map_conflict_warn_once(a:lhs, m, rhs, a:mode, 1)
+        return 1
+    endif
+    return 0
+endfunction
+
 " Bind <Plug> mappings in current buffer to values in g:sexp_mappings or
 " s:sexp_mappings
 " TODO: Consider moving more of this infrastructure into the plug autoload module.
@@ -576,7 +619,6 @@ function! s:sexp_create_mappings()
                 \ "Invalid format: must be string or dict."
                 \ . " (:help g:sexp_mappings)", string(gentry)))
         endif
-
         " Loop over all modes which are valid for this command.
         for mode in valid_modes_arr
             " Use mode-specific override if it exists, else default, which must exist.
@@ -585,24 +627,7 @@ function! s:sexp_create_mappings()
                 " No lhs mapping for this one, so skip it.
                 continue
             endif
-            " Check for a conflicting map defined for the current buffer.
-            " Assumption: maparg() can handle distinct but equivalent forms of lhs (e.g.,
-            " <LocalLeader> vs \, <C-...> vs <c-...>, etc...)
-            " TODO: Could alternatively check only mappings created by this plugin, but
-            " that would entail canonicalizing lhs and storing in dict of some sort.
-            let m = maparg(lhs, mode, 0, 1)
-            " Assumption: maparg returns a buffer map before a global one, but in the
-            " absence of a buffer map, will return a global one; thus, we must check
-            " buffer flag.
-            " Caveat: The check against <plug>(...) ensures we don't warn about our own
-            " mapping if this function is called twice.
-            if !empty(m) && m.buffer && m.rhs !=? '<nop>'
-                \ && m.rhs !=? '<plug>(' . plug . ')'
-                " Warn before overwriting existing map.
-                " TODO: Consider adding option for this.
-                call s:map_conflict_warn_once(
-                    \ lhs, m.rhs, '<Plug>(' . plug . ')', mode)
-            endif
+            call s:check_for_map_conflicts(lhs, mode, plug)
             " Create the mapping.
             execute mode . 'map <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
         endfor

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -142,9 +142,9 @@ if !exists('g:sexp_indent_aligns_comments')
 endif
 
 if !exists('g:sexp_auto_indent_range')
-    " Rationale: Larger (non-optimized) indent ranges are best when aligning comments.
-    " FIXME!
-    let g:sexp_auto_indent_range = !g:sexp_indent_aligns_comments
+    " Rationale: Larger (non-optimized) indent ranges are best when aligning comments, but
+    " toplevel can be noticeably slow for operations on large toplevels.
+    let g:sexp_auto_indent_range = 'mp'
 endif
 
 if !exists('g:sexp_aligncom_maxshift')

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -386,8 +386,8 @@ let s:sexp_mappings = {
     \ 'sexp_replace_P':                    {'x': '<LocalLeader>P', 'n': '<LocalLeader><LocalLeader>P'},
     \ 'sexp_put_before_op':                {'n': '<p'},
     \ 'sexp_put_after_op':                 {'n': '>p'},
-    \ 'sexp_put_at_head':                  {'n': '<LocalLeader>[p'},
-    \ 'sexp_put_at_tail':                  {'n': '<LocalLeader>]p'},
+    \ 'sexp_put_at_head':                  {'n': '<LocalLeader><p'},
+    \ 'sexp_put_at_tail':                  {'n': '<LocalLeader>>p'},
     \ }
 
 if !empty(g:sexp_filetypes)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -248,6 +248,10 @@ if !exists('g:sexp_regput_curpos')
     let g:sexp_regput_curpos = 0
 endif
 
+if !exists('g:sexp_regput_into_curpos')
+    let g:sexp_regput_into_curpos = 0
+endif
+
 if !exists('g:sexp_regput_invalid_register_action')
     let g:sexp_regput_invalid_register_action = -1
 endif

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -145,8 +145,8 @@ endif
 
 if !exists('g:sexp_auto_indent_range')
     " Rationale: Larger (non-optimized) indent ranges are best when aligning comments, but
-    " toplevel can be noticeably slow for operations on large toplevels.
-    let g:sexp_auto_indent_range = 'mp'
+    " toplevel can be noticeably slow for operations on large functions.
+    let g:sexp_auto_indent_range = 0
 endif
 
 if !exists('g:sexp_aligncom_maxshift')

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -706,15 +706,15 @@ Defplug! onoremap sexp_outer_element sexp#select_current_element('o', 0, v:count
 Defplug  xnoremap sexp_inner_element sexp#select_current_element('v', 1, v:prevcount)
 Defplug! onoremap sexp_inner_element sexp#select_current_element('o', 1, v:count)
 
-Defplug  xnoremap sexp_outer_child_head sexp#select_child('v', v:prevcount, 1, 0)
-Defplug! onoremap sexp_outer_child_head sexp#select_child('o', v:count, 1, 0)
-Defplug  xnoremap sexp_inner_child_head sexp#select_child('v', v:prevcount, 1, 1)
-Defplug! onoremap sexp_inner_child_head sexp#select_child('o', v:count, 1, 1)
+Defplug  xnoremap sexp_outer_child_head sexp#select_child('v', v:prevcount, 0, 0)
+Defplug! onoremap sexp_outer_child_head sexp#select_child('o', v:count, 0, 0)
+Defplug  xnoremap sexp_inner_child_head sexp#select_child('v', v:prevcount, 0, 1)
+Defplug! onoremap sexp_inner_child_head sexp#select_child('o', v:count, 0, 1)
 
-Defplug  xnoremap sexp_outer_child_tail sexp#select_child('v', v:prevcount, 0, 0)
-Defplug! onoremap sexp_outer_child_tail sexp#select_child('o', v:count, 0, 0)
-Defplug  xnoremap sexp_inner_child_tail sexp#select_child('v', v:prevcount, 0, 1)
-Defplug! onoremap sexp_inner_child_tail sexp#select_child('o', v:count, 0, 1)
+Defplug  xnoremap sexp_outer_child_tail sexp#select_child('v', v:prevcount, 1, 0)
+Defplug! onoremap sexp_outer_child_tail sexp#select_child('o', v:count, 1, 0)
+Defplug  xnoremap sexp_inner_child_tail sexp#select_child('v', v:prevcount, 1, 1)
+Defplug! onoremap sexp_inner_child_tail sexp#select_child('o', v:count, 1, 1)
 """ Text Object Motions {{{1
 
 " Nearest bracket

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -249,8 +249,15 @@ if !exists('g:sexp_regput_curpos')
 endif
 
 if !exists('g:sexp_regput_into_curpos')
-    " Default to the base variant that isn't specific to "put into" commands.
-    let g:sexp_regput_into_curpos = get(g:, 'sexp_regput_curpos', 0)
+    let g:sexp_regput_into_curpos = -1
+endif
+
+if !exists('g:sexp_regput_op_curpos')
+    let g:sexp_regput_op_curpos = -1
+endif
+
+if !exists('g:sexp_regput_op_ep_curpos')
+    let g:sexp_regput_op_ep_curpos = -1
 endif
 
 if !exists('g:sexp_regput_invalid_register_action')
@@ -263,6 +270,10 @@ endif
 
 if !exists('g:sexp_regput_replace_expanded')
     let g:sexp_regput_replace_expanded = 0
+endif
+
+if !exists('g:sexp_regput_op_tele')
+    let g:sexp_regput_op_tele = 0
 endif
 
 " Expert options
@@ -807,17 +818,17 @@ Defplug! nnoremap sexp_capture_next_element sexp#docount_stateful(v:count, 'sexp
 Defplug  xnoremap sexp_capture_next_element sexp#docount_stateful(v:prevcount, 'sexp#stackop', 'v', 1, 1)
 
 " Put register before/after
-DefplugN nnoremap sexp_put_before  sexp#put(v:count, 0)
-DefplugN nnoremap sexp_put_after   sexp#put(v:count, 1)
+DefplugN! nnoremap sexp_put_before  sexp#put(v:count, 0)
+DefplugN! nnoremap sexp_put_after   sexp#put(v:count, 1)
 " Replace operator
-Defoper! nnoremap sexp_replace_op   sexp#replace_op('n', v:count, 0)
-Defoper! nnoremap sexp_replace_op_P sexp#replace_op('n', v:count, 1)
+DefoperN! nnoremap sexp_replace_op   sexp#replace_op('n', v:count, 0)
+DefoperN! nnoremap sexp_replace_op_P sexp#replace_op('n', v:count, 1)
 " Replace selection with register
-DefplugN xnoremap sexp_replace   sexp#replace('v', v:prevcount, 0)
-DefplugN xnoremap sexp_replace_P sexp#replace('v', v:prevcount, 1)
+DefplugN! xnoremap sexp_replace   sexp#replace('v', v:prevcount, 0)
+DefplugN! xnoremap sexp_replace_P sexp#replace('v', v:prevcount, 1)
 " Put register into list
-DefplugN nnoremap sexp_put_at_head sexp#put_child(v:count, 0)
-DefplugN nnoremap sexp_put_at_tail sexp#put_child(v:count, 1)
+DefplugN! nnoremap sexp_put_at_head sexp#put_child(v:count, 0)
+DefplugN! nnoremap sexp_put_at_tail sexp#put_child(v:count, 1)
 
 """ Insert mode mappings {{{1
 

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -282,14 +282,6 @@ endif
 let s:sexp_mapping_preset__regput = {
     \ 'sexp_put_before':                   {'n': 'P'},
     \ 'sexp_put_after':                    {'n': 'p'},
-    \ 'sexp_replace':                      {'n': '<M-p>', 'x': 'p'},
-    \ 'sexp_replace_P':                    {'n': '<M-P>', 'x': 'P'},
-    \ 'sexp_put_at_head':                  {'n': '<p'},
-    \ 'sexp_put_at_tail':                  {'n': '>p'},
-    \ 'sexp_replace_at_head':              {'n': '[p'},
-    \ 'sexp_replace_at_tail':              {'n': ']p'},
-    \ 'sexp_replace_at_head_P':            {'n': '[P'},
-    \ 'sexp_replace_at_tail_P':            {'n': ']P'},
 \ }
 
 let s:sexp_mappings = {
@@ -363,14 +355,10 @@ let s:sexp_mappings = {
     \ 'sexp_capture_next_element':         {'nx': '<M-S-l>'},
     \ 'sexp_put_before':                   {'n': '<LocalLeader>P'},
     \ 'sexp_put_after':                    {'n': '<LocalLeader>p'},
-    \ 'sexp_replace':                      {'nx': '<M-p>'},
-    \ 'sexp_replace_P':                    {'nx': '<M-P>'},
-    \ 'sexp_put_at_head':                  {'n': '<LocalLeader><p'},
-    \ 'sexp_put_at_tail':                  {'n': '<LocalLeader>>p'},
-    \ 'sexp_replace_at_head':              {'n': '<LocalLeader>[p'},
-    \ 'sexp_replace_at_tail':              {'n': '<LocalLeader>]p'},
-    \ 'sexp_replace_at_head_P':            {'n': '<LocalLeader>[P'},
-    \ 'sexp_replace_at_tail_P':            {'n': '<LocalLeader>]P'},
+    \ 'sexp_replace_op':                   {'n': '<M-p>'},
+    \ 'sexp_replace_op_P':                 {'n': '<M-P>'},
+    \ 'sexp_put_at_head':                  {'n': '<p'},
+    \ 'sexp_put_at_tail':                  {'n': '>p'},
     \ }
 
 if !empty(g:sexp_filetypes)
@@ -897,6 +885,12 @@ Defplug  xnoremap sexp_capture_next_element sexp#docount_stateful(v:prevcount, '
 DefplugN nnoremap sexp_put_before  sexp#put(v:count, 0)
 DefplugN nnoremap sexp_put_after   sexp#put(v:count, 1)
 " Replace element/selection with register
+" TODO: Decide whether/how to use s:defplug for these operators. Either overhaul s:defplug
+" to accommodate or use separate mechanism for operators. Note that s:defplug() probably
+" could use overhaul either way.
+nnoremap <expr> <Plug>(sexp_replace_op)   sexp#replace_op('n', v:count, 0)
+nnoremap <expr> <Plug>(sexp_replace_op_P) sexp#replace_op('n', v:count, 1)
+" TODO: These 2 are going away!
 DefplugN nnoremap sexp_replace   sexp#replace('n', v:count, 0)
 DefplugN nnoremap sexp_replace_P sexp#replace('n', v:count, 1)
 DefplugN xnoremap sexp_replace   sexp#replace('v', v:prevcount, 0)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -277,6 +277,10 @@ else
     endif
 endif
 
+if !exists('g:sexp_regput_use_string_parser')
+    let g:sexp_regput_use_string_parser = 0
+endif
+
 " Expert options
 if !exists('g:sexp_inhibit_failsafe')
     let g:sexp_inhibit_failsafe = 0

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -307,8 +307,10 @@ endif
 let s:sexp_mapping_preset__regput = {
     \ 'sexp_put_before':                   {'n': 'P'},
     \ 'sexp_put_after':                    {'n': 'p'},
-    \ 'sexp_replace':                      {'x': 'p', 'n': '<LocalLeader><LocalLeader>p'},
-    \ 'sexp_replace_P':                    {'x': 'P', 'n': '<LocalLeader><LocalLeader>P'},
+    \ 'sexp_replace':                      {'x': 'p', 'n': '<LocalLeader>p'},
+    \ 'sexp_replace_P':                    {'x': 'P', 'n': '<LocalLeader>P'},
+    \ 'sexp_put_at_head':                  {'n': '[p'},
+    \ 'sexp_put_at_tail':                  {'n': ']p'},
 \ }
 
 let s:sexp_mappings = {

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -265,7 +265,7 @@ if !exists('g:sexp_regput_replace_expanded')
 endif
 
 if !exists('g:sexp_regput_tele_motion')
-    let g:sexp_regput_tele_motion = 0
+    let g:sexp_regput_tele_motion = 2
 else
     if g:sexp_regput_tele_motion && v:version < 801
         call sexp#warn#msg(

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -249,15 +249,15 @@ if !exists('g:sexp_regput_curpos')
 endif
 
 if !exists('g:sexp_regput_into_curpos')
-    let g:sexp_regput_into_curpos = -1
+    let g:sexp_regput_into_curpos = 0
 endif
 
 if !exists('g:sexp_regput_op_curpos')
     let g:sexp_regput_op_curpos = -1
 endif
 
-if !exists('g:sexp_regput_op_ep_curpos')
-    let g:sexp_regput_op_ep_curpos = -1
+if !exists('g:sexp_regput_op_tele_curpos')
+    let g:sexp_regput_op_tele_curpos = -1
 endif
 
 if !exists('g:sexp_regput_invalid_register_action')
@@ -300,11 +300,15 @@ endif
 " with the same format as s:sexp_mappings, to be searched for overrides.
 " Constraint: A given plug rhs should never belong to multiple presets, as this would give
 " rise to ambiguity when both presets were enabled.
+" Note: Currently, a preset entry completely *replaces* the corresponding plugin-defined
+" command entry.
+" TODO: Decide whether it should be merged with it instead...
+" TODO: Decide whether the normal mode replace commands should have default mappings.
 let s:sexp_mapping_preset__regput = {
     \ 'sexp_put_before':                   {'n': 'P'},
     \ 'sexp_put_after':                    {'n': 'p'},
-    \ 'sexp_replace':                      {'x': 'p'},
-    \ 'sexp_replace_P':                    {'x': 'P'},
+    \ 'sexp_replace':                      {'x': 'p', 'n': '<LocalLeader><LocalLeader>p'},
+    \ 'sexp_replace_P':                    {'x': 'P', 'n': '<LocalLeader><LocalLeader>P'},
 \ }
 
 let s:sexp_mappings = {
@@ -380,10 +384,12 @@ let s:sexp_mappings = {
     \ 'sexp_put_after':                    {'n': '<LocalLeader>p'},
     \ 'sexp_replace_op':                   {'n': '<M-p>'},
     \ 'sexp_replace_op_P':                 {'n': '<M-P>'},
-    \ 'sexp_replace':                      {'x': '<M-p>'},
-    \ 'sexp_replace_P':                    {'x': '<M-P>'},
-    \ 'sexp_put_at_head':                  {'n': '<p'},
-    \ 'sexp_put_at_tail':                  {'n': '>p'},
+    \ 'sexp_replace':                      {'x': '<LocalLeader>p', 'n': '<LocalLeader><LocalLeader>p'},
+    \ 'sexp_replace_P':                    {'x': '<LocalLeader>P', 'n': '<LocalLeader><LocalLeader>P'},
+    \ 'sexp_put_before_op':                {'n': '<p'},
+    \ 'sexp_put_after_op':                 {'n': '>p'},
+    \ 'sexp_put_at_head':                  {'n': '<LocalLeader>[p'},
+    \ 'sexp_put_at_tail':                  {'n': '<LocalLeader>]p'},
     \ }
 
 if !empty(g:sexp_filetypes)
@@ -826,11 +832,18 @@ Defplug  xnoremap sexp_capture_next_element sexp#docount_stateful(v:count, 'sexp
 DefplugN! nnoremap sexp_put_before  sexp#put(v:count, 0)
 DefplugN! nnoremap sexp_put_after   sexp#put(v:count, 1)
 " Replace operator
-DefoperN! nnoremap sexp_replace_op   sexp#replace_op('n', v:count, 0)
-DefoperN! nnoremap sexp_replace_op_P sexp#replace_op('n', v:count, 1)
+DefoperN! nnoremap sexp_replace_op   sexp#regput_op(1, 0)
+DefoperN! nnoremap sexp_replace_op_P sexp#regput_op(1, 1)
 " Replace selection with register
 DefplugN! xnoremap sexp_replace   sexp#replace('v', v:count, 0)
 DefplugN! xnoremap sexp_replace_P sexp#replace('v', v:count, 1)
+" Replace element under cursor with register
+" TODO: Decide whether to map this by default...
+DefplugN! nnoremap sexp_replace   sexp#replace('n', v:count, 0)
+DefplugN! nnoremap sexp_replace_P sexp#replace('n', v:count, 1)
+" Put before/after operators
+DefoperN! nnoremap sexp_put_before_op sexp#regput_op(0, 1)
+DefoperN! nnoremap sexp_put_after_op  sexp#regput_op(0, 0)
 " Put register into list
 DefplugN! nnoremap sexp_put_at_head sexp#put_child(v:count, 0)
 DefplugN! nnoremap sexp_put_at_tail sexp#put_child(v:count, 1)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -49,6 +49,7 @@ function! s:deprecate_options(optnames, obsolete, helphint)
     endif
 endfunction
 
+" Caveat: This must be called *prior to* option/mapping processing.
 call sexp#feat#record_user_awareness()
 
 " Note: The following options were introduced by PR #34 and removed in PR #51. Hopefully,
@@ -138,7 +139,6 @@ if !exists('g:sexp_cleanup_join_backwards')
     let g:sexp_cleanup_join_backwards = 1
 endif
 
-" TODO: Consider encapsulating related options in a dict.
 if !exists('g:sexp_indent_aligns_comments')
     let g:sexp_indent_aligns_comments = 0
 endif
@@ -216,10 +216,6 @@ if !exists('g:sexp_aligncom_optlevel')
     let g:sexp_aligncom_optlevel = 2
 endif
 
-if !exists('g:sexp_regput_override_builtins')
-    let g:sexp_regput_override_builtins = 0
-endif
-
 if !exists('g:sexp_regput_bracket_is_target')
     let g:sexp_regput_bracket_is_target = 1
 endif
@@ -281,6 +277,10 @@ if !exists('g:sexp_regput_use_string_parser')
     let g:sexp_regput_use_string_parser = 0
 endif
 
+if !exists('g:sexp_regput_silence_notification')
+    let g:sexp_regput_silence_notification = 0
+endif
+
 " Expert options
 if !exists('g:sexp_inhibit_failsafe')
     let g:sexp_inhibit_failsafe = 0
@@ -289,29 +289,6 @@ endif
 if !exists('g:sexp_mappings')
     let g:sexp_mappings = {}
 endif
-
-" Keymap Presets
-" Motivation: Give user an easy way to enable a (usually feature-specific) set of mappings
-" we don't dare create without permission (usually because they override builtin maps). A
-" keymap preset is selected by a user option: e.g.,
-"   let g:sexp_regput_override_builtins = 1
-" From all such options, logic in sexp_create_mappings() determines a list of enabled
-" presets, each of which causes a dict by the name of s:sexp_mapping_preset__{feat-name},
-" with the same format as s:sexp_mappings, to be searched for overrides.
-" Constraint: A given plug rhs should never belong to multiple presets, as this would give
-" rise to ambiguity when both presets were enabled.
-" Note: Currently, a preset entry completely *replaces* the corresponding plugin-defined
-" command entry.
-" TODO: Decide whether it should be merged with it instead...
-" TODO: Decide whether the normal mode replace commands should have default mappings.
-let s:sexp_mapping_preset__regput = {
-    \ 'sexp_put_before':                   {'n': 'P'},
-    \ 'sexp_put_after':                    {'n': 'p'},
-    \ 'sexp_replace':                      {'x': 'p', 'n': '<LocalLeader>p'},
-    \ 'sexp_replace_P':                    {'x': 'P', 'n': '<LocalLeader>P'},
-    \ 'sexp_put_at_head':                  {'n': '[p'},
-    \ 'sexp_put_at_tail':                  {'n': ']p'},
-\ }
 
 let s:sexp_mappings = {
     \ 'sexp_outer_list':                   {'xo': 'af'},
@@ -382,16 +359,20 @@ let s:sexp_mappings = {
     \ 'sexp_emit_tail_element':            {'nx': '<M-S-k>'},
     \ 'sexp_capture_prev_element':         {'nx': '<M-S-h>'},
     \ 'sexp_capture_next_element':         {'nx': '<M-S-l>'},
-    \ 'sexp_put_before':                   {'n': '<LocalLeader>P'},
-    \ 'sexp_put_after':                    {'n': '<LocalLeader>p'},
-    \ 'sexp_replace_op':                   {'n': '<M-p>'},
-    \ 'sexp_replace_op_P':                 {'n': '<M-P>'},
-    \ 'sexp_replace':                      {'x': '<LocalLeader>p', 'n': '<LocalLeader><LocalLeader>p'},
-    \ 'sexp_replace_P':                    {'x': '<LocalLeader>P', 'n': '<LocalLeader><LocalLeader>P'},
-    \ 'sexp_put_before_op':                {'n': '<p'},
-    \ 'sexp_put_after_op':                 {'n': '>p'},
-    \ 'sexp_put_at_head':                  {'n': '<LocalLeader><p'},
-    \ 'sexp_put_at_tail':                  {'n': '<LocalLeader>>p'},
+    \ 'sexp_put_before':                   {'n':  'P'},
+    \ 'sexp_put_after':                    {'n':  'p'},
+    \ 'sexp_put_before_op':                {'n':  '<p'},
+    \ 'sexp_put_after_op':                 {'n':  '>p'},
+    \ 'sexp_replace':                      {'x':  'p', 'n': 'gp'},
+    \ 'sexp_replace_P':                    {'x':  'P', 'n': 'gP'},
+    \ 'sexp_replace_op':                   {'n':  '<M-p>'},
+    \ 'sexp_replace_op_P':                 {'n':  '<M-P>'},
+    \ 'sexp_put_at_head':                  {'n':  '<LocalLeader><p'},
+    \ 'sexp_put_at_tail':                  {'n':  '<LocalLeader>>p'},
+    \ 'p':                                 {'nx': ''},
+    \ 'P':                                 {'nx': ''},
+    \ 'gp':                                {'n':  ''},
+    \ 'gP':                                {'n':  ''},
     \ }
 
 if !empty(g:sexp_filetypes)
@@ -448,25 +429,6 @@ function! s:defplug(flags, mapmode, name, ...)
         \ (!asexpr ? '<cr>' : ''))
 endfunction
 
-" Display warning with requested highlighting.
-function! s:warn(msg, ...)
-    let hl = a:0 ? a:1 : 'WarningMsg'
-    try
-        exe 'echohl' hl
-        echomsg a:msg
-    finally
-        echohl None
-    endtry
-endfunction
-
-" Simplify warning displays for mappings.
-" -- Args --
-"   plug: command name specified as the ... in <plug>(...)
-"   msg:  warning msg
-function! s:mapwarn(plug, msg)
-    call s:warn(printf("g:sexp_mappings['%s']: %s", a:plug, a:msg))
-endfunction
-
 " Warn once-only (per buffer) for the specified map conflict (or ambiguity).
 " -- Optional Args --
 " a:1  ambiguous (not conflict)
@@ -475,73 +437,11 @@ function! s:map_conflict_warn_once(lhs, rhs1, rhs2, mode, ...)
     " for the same conflict when s:sexp_create_mappings() is called twice.
     " Explanation: In the initial call, the second map overwrites the first, but then in
     " the second call, the first map will overwrite the second.
-    let s = call(function('sexp#warn#join_hashable'),
-                \ [a:mode, a:lhs] + sort([a:rhs1, a:rhs2]))
-    call sexp#warn#msg_once(s, printf(
+    let uniq_key = [a:mode, a:lhs] + sort([a:rhs1, a:rhs2]))
+    call sexp#warn#msg(printf(
         \ "Mapping %s => %s %s with existing mapping to %s in mode %s",
-        \ a:lhs, a:rhs2, (a:0 ? "is ambiguous" : "conflicts"), a:rhs1, a:mode))
-endfunction
-
-" Convert a single value in the sexp_mappings dict to a denormalized form conducive to use
-" in map creation.
-" Args:
-"   plug:         command name (i.e., the ... in <Plug>(...))
-"   entry:        lhs specification in one of the following forms:
-"   entry:        '<lhs>'
-"                 | {'<modes1>': '<lhs1>', ..., '<modesN>': '<lhsN>'}
-"   valid_modes:  string of chars in [nxo] constraining the modes for this command
-"                 default: 'nox'
-"                 override: subset of modes defined by default
-function! s:parse_map_entry(plug, entry, valid_modes)
-    let maps = {}
-    let valid_modes = empty(a:valid_modes) ? 'novx' : a:valid_modes
-    for [modes, lhs] in items(a:entry)
-        " Convert v to x: e.g., 'nvo' => 'nxo'
-        let modes = substitute(modes, 'v', 'x', 'g')
-        " Collapse multiple occurrences of same mode: e.g., {'x': ..., 'xo': ...}.
-        let modes = substitute(
-            \ join(sort(split(modes, '\zs')), ''), '\v(.)\1+', '\1', 'g')
-        " Loop over sorted/uniquified mode chars.
-        for mode in split(modes, '\zs')
-            " TODO: Distinguish between defaults and user here?
-            if mode !~ '[' . valid_modes . ']'
-                call s:mapwarn(a:plug, printf("Unrecognized mode %s", mode))
-                continue
-            endif
-            " We have a valid mode, but has it already been specified for this plug?
-            if has_key(maps, mode)
-                " TODO: Consider just ignoring malformed entry altogether since this is
-                " effectively UB without ordered keys.
-                call s:mapwarn(a:plug, printf(
-                    \ "Conflicting lhs specifications for mode %s: old=%s new=%s",
-                    \ mode, maps[mode], lhs))
-                continue
-            endif
-            " We have a valid mode that hasn't appeared in another key.
-            let maps[mode] = lhs
-        endfor
-    endfor
-    return maps
-endfunction
-
-" Return preset mapping override for specified plug, else {}.
-" See note on Keymap Presets.
-function! s:check_for_mapping_preset(plug)
-    " TODO: Add more preset groups as necessary.
-    let feats = {'regput': g:sexp_regput_override_builtins}
-    for [feat, enable] in items(feats)
-        if enable
-            " Get preset dict whose format is same as s:sexp_mappings[].
-            let o = s:sexp_mapping_preset__{feat}
-            " Does this preset group define an override for this plug?
-            if has_key(o, a:plug)
-                " Replace the default with the enabled override.
-                " Note: A plug should never be represented in 2 distinct feature sets.
-                return o[a:plug]
-            endif
-        endif
-    endfor
-    return {}
+        \ a:lhs, a:rhs2, (a:0 ? "is ambiguous" : "conflicts"), a:rhs1, a:mode),
+        \ {'once': uniq_key})
 endfunction
 
 " Warn user if the input args represent a mapping that would conflict or be ambiguous with
@@ -597,41 +497,42 @@ endfunction
 " s:sexp_mappings
 " TODO: Consider moving more of this infrastructure into the plug autoload module.
 function! s:sexp_create_mappings()
-    call sexp#feat#create_notifications()
+    if sexp#parse#in_buf()
+        " Skip map creation in the special parse buffer.
+        return
+    endif
     " Note: {s,g}entry stand for {s,g}:sexp_mappings entry, respectively.
     for [plug, sentry] in items(s:sexp_mappings)
-        " Check for preset override.
-        let override = s:check_for_mapping_preset(plug)
-        if !empty(override)
-            let sentry = override
-        endif
         " Get corresponding user override if it exists.
         let gentry = get(g:sexp_mappings, plug, {})
         " Parse entry into a flat dict of modechar => lhs: e.g.,
         " {'nx': '\s', 'o': '\t'} => {'n': '\s', 'x': '\s', 'o': \t'}
-        let sm = s:parse_map_entry(plug, sentry, '')
+        let [sm, _] = sexp#plug#parse_map_entry(plug, sentry, '')
         " Default map determines the valid keys.
         let valid_modes_arr = sort(keys(sm))
         let valid_modes_str = join(valid_modes_arr, '')
-        " Now parse any user-defined override
+        " Now parse any user-defined override.
+        " Note: We'll want gm to be empty in exception scenario.
         let gm = {}
-        if type(gentry) == type({})
-            " Empty dict indicates no user-override.
-            if !empty(gentry)
-                let gm = s:parse_map_entry(plug, gentry, valid_modes_str)
+        try
+            let [gm, invalid_modes_str] =
+                \ sexp#plug#parse_map_entry(plug, gentry, valid_modes_str)
+            if !empty(invalid_modes_str)
+                call sexp#warn#msg(printf("Ignoring unexpected modes in"
+                    \ . " user map override: `%s'", invalid_modes_str),
+                    \ {'once': [plug, gentry]})
             endif
-        elseif type(gentry) == type('')
-            " Create dict that uses specified lhs for all valid modes.
-            for mode in valid_modes_arr
-                let gm[mode] = gentry
-            endfor
-        else
+        catch /sexp-error/
             " Note: Leave gm empty to ensure default is used.
-            call s:mapwarn(sprintf(
-                \ "Invalid format: must be string or dict."
-                \ . " (:help g:sexp_mappings)", string(gentry)))
-        endif
+            call sexp#warn#msg(printf("Ignoring invalid user map override: %s: %s",
+                    \ string(gentry),
+                    \ substitute(v:exception, '^sexp-error:\s*', '', '')),
+                    \ {'once': [plug, gentry]})
+        endtry
         " Loop over all modes which are valid for this command.
+        " Design Decision: To simplify the merge, distinct modes within sm/gm are stored
+        " as keys, rather than list elements; an implication of this (probably good) is
+        " that user can't specify multiple LHS per mode.
         for mode in valid_modes_arr
             " Use mode-specific override if it exists, else default, which must exist.
             let lhs = get(gm, mode, get(sm, mode))
@@ -642,7 +543,16 @@ function! s:sexp_create_mappings()
             " TODO: Decide whether the plugin should warn, or simply override...
             "call s:check_for_map_conflicts(lhs, mode, plug)
             " Create the mapping.
-            execute mode . 'map <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
+            if plug !~ '^sexp_'
+                " A builtin override, which needs to be "noremapped" to prevent triggering
+                " a first-level sexp map.
+                " Note: This special case is implemented to provide a convenient way for
+                " user to create aliases to overridden builtins.
+                execute mode . 'noremap <silent><buffer> ' . lhs . ' ' . plug
+            else
+                " A true plug mapping
+                execute mode . 'map <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
+            endif
         endfor
     endfor
 

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -141,6 +141,12 @@ if !exists('g:sexp_indent_aligns_comments')
     let g:sexp_indent_aligns_comments = 0
 endif
 
+if !exists('g:sexp_auto_indent_range')
+    " Rationale: Larger (non-optimized) indent ranges are best when aligning comments.
+    " FIXME!
+    let g:sexp_auto_indent_range = !g:sexp_indent_aligns_comments
+endif
+
 if !exists('g:sexp_aligncom_maxshift')
     let g:sexp_aligncom_maxshift = -1
 endif

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -546,21 +546,29 @@ endfunction
 "   0  no problem
 "   1  ambiguity
 "   2  conflict
+" Design Decision: Warn about only *buffer* conflicts/ambiguities, silently overwriting a
+" global map with the same lhs.
+" Rationale: Buffer maps are typically filetype-specific, and thus, should generally take
+" precedence over global maps.
+" TODO: Decide whether these checks belong in the plugin and remove this function if not.
+" For now, the call to this function has been commented out due to the confusion the
+" warnings caused during smart-paste beta testing. If it's kept at all, the call should
+" probably be guarded by an expert option (disabled by default), which allows the user to
+" enable and customize warnings. Such an option could be enabled while user is attempting
+" to hash out a good set of keybindings.
 function! s:check_for_map_conflicts(lhs, mode, plug)
     let rhs = '<Plug>(' . a:plug . ')'
     " Assumption: maparg() can handle distinct but equivalent forms of lhs (e.g.,
     " <LocalLeader> vs \, <C-...> vs <c-...>, etc...)
     " TODO: Could alternatively check only mappings created by this plugin, but
     " that would entail canonicalizing lhs and storing in dict of some sort.
-    " Assumption: maparg returns a buffer map before a global one, but in the absence of a
-    " buffer map, will return a global one.
-    " Design Decision: Warn about both buffer and global map conflicts/ambiguities.
+    " Assumption: maparg() returns a buffer map before a global one, but in the absence of
+    " a buffer map, will return a global one.
     " Caveat: The check against <plug>(...) ensures we don't warn about our own mapping if
     " this function is called multiple times.
     " Note: 'rhs' key won't exist if the rhs is a Lua callback (stored in 'callback').
     let m = maparg(a:lhs, a:mode, 0, 1)
-    if !empty(m) && has_key(m, 'rhs') && m.rhs !=? '<nop>'
-        \ && m.rhs !=? rhs
+    if !empty(m) && m.buffer && has_key(m, 'rhs') && m.rhs !=? '<nop>' && m.rhs !=? rhs
         " Warn before overwriting existing map.
         " TODO: Consider adding option for this.
         call s:map_conflict_warn_once(a:lhs, m.rhs, rhs, a:mode)
@@ -627,7 +635,8 @@ function! s:sexp_create_mappings()
                 " No lhs mapping for this one, so skip it.
                 continue
             endif
-            call s:check_for_map_conflicts(lhs, mode, plug)
+            " TODO: Decide whether the plugin should warn, or simply override...
+            "call s:check_for_map_conflicts(lhs, mode, plug)
             " Create the mapping.
             execute mode . 'map <silent><buffer> ' . lhs . ' <Plug>(' . plug . ')'
         endfor

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -272,8 +272,13 @@ if !exists('g:sexp_regput_replace_expanded')
     let g:sexp_regput_replace_expanded = 0
 endif
 
-if !exists('g:sexp_regput_op_tele')
-    let g:sexp_regput_op_tele = 0
+if !exists('g:sexp_regput_enable_teleop')
+    let g:sexp_regput_enable_teleop = 0
+else
+    if g:sexp_regput_enable_teleop && v:version < 801
+        call sexp#warn#msg(
+            \ "Warning: Replace operator's telescopic mode requires Vim version >= 8.1.")
+    endif
 endif
 
 " Expert options
@@ -611,9 +616,9 @@ endfunction
 """ Text Object Selections {{{1
 
 " Current list (compound FORM)
-Defplug  xnoremap sexp_outer_list sexp#docount(v:prevcount, 'sexp#select_current_list', 'v', 0, 1)
+Defplug  xnoremap sexp_outer_list sexp#docount(v:count, 'sexp#select_current_list', 'v', 0, 1)
 Defplug! onoremap sexp_outer_list sexp#docount(v:count, 'sexp#select_current_list', 'o', 0, 1)
-Defplug  xnoremap sexp_inner_list sexp#docount(v:prevcount, 'sexp#select_current_list', 'v', 1, 1)
+Defplug  xnoremap sexp_inner_list sexp#docount(v:count, 'sexp#select_current_list', 'v', 1, 1)
 Defplug! onoremap sexp_inner_list sexp#docount(v:count, 'sexp#select_current_list', 'o', 1, 1)
 
 " Current top-level list (compound FORM)
@@ -629,28 +634,28 @@ Defplug  xnoremap sexp_inner_string sexp#select_current_string('v', 1)
 Defplug! onoremap sexp_inner_string sexp#select_current_string('o', 1)
 
 " Current element
-Defplug  xnoremap sexp_outer_element sexp#select_current_element('v', 0, v:prevcount)
+Defplug  xnoremap sexp_outer_element sexp#select_current_element('v', 0, v:count)
 Defplug! onoremap sexp_outer_element sexp#select_current_element('o', 0, v:count)
-Defplug  xnoremap sexp_inner_element sexp#select_current_element('v', 1, v:prevcount)
+Defplug  xnoremap sexp_inner_element sexp#select_current_element('v', 1, v:count)
 Defplug! onoremap sexp_inner_element sexp#select_current_element('o', 1, v:count)
 
-Defplug  xnoremap sexp_outer_child_head sexp#select_child('v', v:prevcount, 0, 0)
+Defplug  xnoremap sexp_outer_child_head sexp#select_child('v', v:count, 0, 0)
 Defplug! onoremap sexp_outer_child_head sexp#select_child('o', v:count, 0, 0)
-Defplug  xnoremap sexp_inner_child_head sexp#select_child('v', v:prevcount, 0, 1)
+Defplug  xnoremap sexp_inner_child_head sexp#select_child('v', v:count, 0, 1)
 Defplug! onoremap sexp_inner_child_head sexp#select_child('o', v:count, 0, 1)
 
-Defplug  xnoremap sexp_outer_child_tail sexp#select_child('v', v:prevcount, 1, 0)
+Defplug  xnoremap sexp_outer_child_tail sexp#select_child('v', v:count, 1, 0)
 Defplug! onoremap sexp_outer_child_tail sexp#select_child('o', v:count, 1, 0)
-Defplug  xnoremap sexp_inner_child_tail sexp#select_child('v', v:prevcount, 1, 1)
+Defplug  xnoremap sexp_inner_child_tail sexp#select_child('v', v:count, 1, 1)
 Defplug! onoremap sexp_inner_child_tail sexp#select_child('o', v:count, 1, 1)
 """ Text Object Motions {{{1
 
 " Nearest bracket
 Defplug  nnoremap sexp_move_to_prev_bracket sexp#docount(v:count, 'sexp#move_to_nearest_bracket', 'n', 0)
-DefplugN xnoremap sexp_move_to_prev_bracket sexp#docount(v:prevcount, 'sexp#move_to_nearest_bracket', 'v', 0)
+DefplugN xnoremap sexp_move_to_prev_bracket sexp#docount(v:count, 'sexp#move_to_nearest_bracket', 'v', 0)
 Defplug! onoremap sexp_move_to_prev_bracket sexp#move_to_nearest_bracket('o', 0)
 Defplug  nnoremap sexp_move_to_next_bracket sexp#docount(v:count, 'sexp#move_to_nearest_bracket', 'n', 1)
-DefplugN xnoremap sexp_move_to_next_bracket sexp#docount(v:prevcount, 'sexp#move_to_nearest_bracket', 'v', 1)
+DefplugN xnoremap sexp_move_to_next_bracket sexp#docount(v:count, 'sexp#move_to_nearest_bracket', 'v', 1)
 Defplug! onoremap sexp_move_to_next_bracket sexp#move_to_nearest_bracket('o', 1)
 
 " Adjacent element head
@@ -658,10 +663,10 @@ Defplug! onoremap sexp_move_to_next_bracket sexp#move_to_nearest_bracket('o', 1)
 " Visual mappings must break out of visual mode in order to detect which end
 " the user is using to adjust the selection.
 DefplugN  nnoremap sexp_move_to_prev_element_head sexp#move_to_adjacent_element('n', v:count, 0, 0, 0)
-DefplugN  xnoremap sexp_move_to_prev_element_head sexp#move_to_adjacent_element('v', v:prevcount, 0, 0, 0)
+DefplugN  xnoremap sexp_move_to_prev_element_head sexp#move_to_adjacent_element('v', v:count, 0, 0, 0)
 DefplugN! onoremap sexp_move_to_prev_element_head sexp#move_to_adjacent_element('o', v:count, 0, 0, 0)
 DefplugN  nnoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element('n', v:count, 1, 0, 0)
-DefplugN  xnoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element('v', v:prevcount, 1, 0, 0)
+DefplugN  xnoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element('v', v:count, 1, 0, 0)
 DefplugN! onoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element('o', v:count, 1, 0, 0)
 
 " Adjacent element tail
@@ -669,38 +674,38 @@ DefplugN! onoremap sexp_move_to_next_element_head sexp#move_to_adjacent_element(
 " Inclusive operator pending motions require a visual mode selection to
 " include the last character of a line.
 DefplugN  nnoremap sexp_move_to_prev_element_tail sexp#move_to_adjacent_element('n', v:count, 0, 1, 0)
-DefplugN  xnoremap sexp_move_to_prev_element_tail sexp#move_to_adjacent_element('v', v:prevcount, 0, 1, 0)
+DefplugN  xnoremap sexp_move_to_prev_element_tail sexp#move_to_adjacent_element('v', v:count, 0, 1, 0)
 DefplugN! onoremap sexp_move_to_prev_element_tail sexp#move_to_adjacent_element('o', v:count, 0, 1, 0)
 DefplugN  nnoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element('n', v:count, 1, 1, 0)
-DefplugN  xnoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element('v', v:prevcount, 1, 1, 0)
+DefplugN  xnoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element('v', v:count, 1, 1, 0)
 DefplugN! onoremap sexp_move_to_next_element_tail sexp#move_to_adjacent_element('o', v:count, 1, 1, 0)
 
 " List flow commands
 Defplug   nnoremap sexp_flow_to_prev_close sexp#list_flow('n', v:count, 0, 1)
-DefplugN  xnoremap sexp_flow_to_prev_close sexp#list_flow('v', v:prevcount, 0, 1)
+DefplugN  xnoremap sexp_flow_to_prev_close sexp#list_flow('v', v:count, 0, 1)
 Defplug   nnoremap sexp_flow_to_prev_open sexp#list_flow('n', v:count, 0, 0)
-DefplugN  xnoremap sexp_flow_to_prev_open sexp#list_flow('v', v:prevcount, 0, 0)
+DefplugN  xnoremap sexp_flow_to_prev_open sexp#list_flow('v', v:count, 0, 0)
 Defplug   nnoremap sexp_flow_to_next_open sexp#list_flow('n', v:count, 1, 0)
-DefplugN  xnoremap sexp_flow_to_next_open sexp#list_flow('v', v:prevcount, 1, 0)
+DefplugN  xnoremap sexp_flow_to_next_open sexp#list_flow('v', v:count, 1, 0)
 Defplug   nnoremap sexp_flow_to_next_close sexp#list_flow('n', v:count, 1, 1)
-DefplugN  xnoremap sexp_flow_to_next_close sexp#list_flow('v', v:prevcount, 1, 1)
+DefplugN  xnoremap sexp_flow_to_next_close sexp#list_flow('v', v:count, 1, 1)
 
 " Leaf flow commands
 DefplugN  nnoremap sexp_flow_to_prev_leaf_head sexp#leaf_flow('n', v:count, 0, 0)
-DefplugN  xnoremap sexp_flow_to_prev_leaf_head sexp#leaf_flow('v', v:prevcount, 0, 0)
+DefplugN  xnoremap sexp_flow_to_prev_leaf_head sexp#leaf_flow('v', v:count, 0, 0)
 DefplugN  nnoremap sexp_flow_to_next_leaf_head sexp#leaf_flow('n', v:count, 1, 0)
-DefplugN  xnoremap sexp_flow_to_next_leaf_head sexp#leaf_flow('v', v:prevcount, 1, 0)
+DefplugN  xnoremap sexp_flow_to_next_leaf_head sexp#leaf_flow('v', v:count, 1, 0)
 DefplugN  nnoremap sexp_flow_to_prev_leaf_tail sexp#leaf_flow('n', v:count, 0, 1)
-DefplugN  xnoremap sexp_flow_to_prev_leaf_tail sexp#leaf_flow('v', v:prevcount, 0, 1)
+DefplugN  xnoremap sexp_flow_to_prev_leaf_tail sexp#leaf_flow('v', v:count, 0, 1)
 DefplugN  nnoremap sexp_flow_to_next_leaf_tail sexp#leaf_flow('n', v:count, 1, 1)
-DefplugN  xnoremap sexp_flow_to_next_leaf_tail sexp#leaf_flow('v', v:prevcount, 1, 1)
+DefplugN  xnoremap sexp_flow_to_next_leaf_tail sexp#leaf_flow('v', v:count, 1, 1)
 
 " Adjacent top element
 Defplug  nnoremap sexp_move_to_prev_top_element sexp#move_to_adjacent_element('n', v:count, 0, 0, 1)
-DefplugN xnoremap sexp_move_to_prev_top_element sexp#move_to_adjacent_element('v', v:prevcount, 0, 0, 1)
+DefplugN xnoremap sexp_move_to_prev_top_element sexp#move_to_adjacent_element('v', v:count, 0, 0, 1)
 Defplug! onoremap sexp_move_to_prev_top_element sexp#move_to_adjacent_element('o', v:count, 0, 0, 1)
 Defplug  nnoremap sexp_move_to_next_top_element sexp#move_to_adjacent_element('n', v:count, 1, 0, 1)
-DefplugN xnoremap sexp_move_to_next_top_element sexp#move_to_adjacent_element('v', v:prevcount, 1, 0, 1)
+DefplugN xnoremap sexp_move_to_next_top_element sexp#move_to_adjacent_element('v', v:count, 1, 0, 1)
 Defplug! onoremap sexp_move_to_next_top_element sexp#move_to_adjacent_element('o', v:count, 1, 0, 1)
 
 " Adjacent element selection
@@ -708,10 +713,10 @@ Defplug! onoremap sexp_move_to_next_top_element sexp#move_to_adjacent_element('o
 " Unlike the other directional motions, calling this from normal mode places
 " us in visual mode, with the adjacent element as our selection.
 Defplug  nnoremap sexp_select_prev_element sexp#docount(v:count, 'sexp#select_adjacent_element', 'n', 0)
-Defplug  xnoremap sexp_select_prev_element sexp#docount(v:prevcount, 'sexp#select_adjacent_element', 'v', 0)
+Defplug  xnoremap sexp_select_prev_element sexp#docount(v:count, 'sexp#select_adjacent_element', 'v', 0)
 Defplug! onoremap sexp_select_prev_element sexp#docount(v:count, 'sexp#select_adjacent_element', 'o', 0)
 Defplug  nnoremap sexp_select_next_element sexp#docount(v:count, 'sexp#select_adjacent_element', 'n', 1)
-Defplug  xnoremap sexp_select_next_element sexp#docount(v:prevcount, 'sexp#select_adjacent_element', 'v', 1)
+Defplug  xnoremap sexp_select_next_element sexp#docount(v:count, 'sexp#select_adjacent_element', 'v', 1)
 Defplug! onoremap sexp_select_next_element sexp#docount(v:count, 'sexp#select_adjacent_element', 'o', 1)
 
 """ Commands {{{1
@@ -722,16 +727,16 @@ Defplug! onoremap sexp_select_next_element sexp#docount(v:count, 'sexp#select_ad
 " supported repeat for visual operations, so I guess I'll be consistent for
 " now.
 Defplug! nnoremap sexp_indent                sexp#indent('n', 0, v:count, -1)
-Defplug  xnoremap sexp_indent                sexp#indent('x', 0, v:prevcount, -1)
+Defplug  xnoremap sexp_indent                sexp#indent('x', 0, v:count, -1)
 Defplug! nnoremap sexp_indent_top            sexp#indent('n', 1, v:count, -1)
 Defplug! nnoremap sexp_indent_and_clean      sexp#indent('n', 0, v:count, 1)
-Defplug  xnoremap sexp_indent_and_clean      sexp#indent('x', 0, v:prevcount, 1)
+Defplug  xnoremap sexp_indent_and_clean      sexp#indent('x', 0, v:count, 1)
 Defplug! nnoremap sexp_indent_and_clean_top  sexp#indent('n', 1, v:count, 1)
 
 " TODO: Should these have dedicated default mappings, or just default to having it done by
 " indent and let user configure explicit maps if desired?
 Defplug! nnoremap sexp_align_comments        sexp#align_comments('n', 0, v:count)
-Defplug  xnoremap sexp_align_comments        sexp#align_comments('x', 0, v:prevcount)
+Defplug  xnoremap sexp_align_comments        sexp#align_comments('x', 0, v:count)
 Defplug! nnoremap sexp_align_comments_top    sexp#align_comments('n', 1, v:count)
 
 " Wrap list
@@ -768,9 +773,9 @@ Defplug! nnoremap sexp_insert_at_list_tail sexp#insert_at_list_terminal(1)
 
 " Raise list
 Defplug! nnoremap sexp_raise_list    sexp#docount_stateful(v:count, 'sexp#raise', 'n', 'sexp#select_current_list', 'n', 0, 0)
-Defplug  xnoremap sexp_raise_list    sexp#docount_stateful(v:prevcount, 'sexp#raise', 'v', '')
+Defplug  xnoremap sexp_raise_list    sexp#docount_stateful(v:count, 'sexp#raise', 'v', '')
 Defplug! nnoremap sexp_raise_element sexp#docount_stateful(v:count, 'sexp#raise', 'n', 'sexp#select_current_element', 'n', 1)
-Defplug  xnoremap sexp_raise_element sexp#docount_stateful(v:prevcount, 'sexp#raise', 'v', '')
+Defplug  xnoremap sexp_raise_element sexp#docount_stateful(v:count, 'sexp#raise', 'v', '')
 
 " Convolute
 " Note: convolute takes pains to preserve cursor position: hence, 'nojump'.
@@ -778,44 +783,44 @@ DefplugN! nnoremap sexp_convolute sexp#convolute(v:count, 'n')
 
 " Clone list
 DefplugN  nnoremap sexp_clone_list    sexp#clone('n', v:count, 1, 0, '')
-DefplugN  xnoremap sexp_clone_list    sexp#clone('v', v:prevcount, 1, 0, '')
+DefplugN  xnoremap sexp_clone_list    sexp#clone('v', v:count, 1, 0, '')
 DefplugN  nnoremap sexp_clone_list_sl sexp#clone('n', v:count, 1, 0, 's')
-DefplugN  xnoremap sexp_clone_list_sl sexp#clone('v', v:prevcount, 1, 0, 's')
+DefplugN  xnoremap sexp_clone_list_sl sexp#clone('v', v:count, 1, 0, 's')
 DefplugN  nnoremap sexp_clone_list_ml sexp#clone('n', v:count, 1, 0, 'm')
-DefplugN  xnoremap sexp_clone_list_ml sexp#clone('v', v:prevcount, 1, 0, 'm')
+DefplugN  xnoremap sexp_clone_list_ml sexp#clone('v', v:count, 1, 0, 'm')
 
 " Clone element
 DefplugN  nnoremap sexp_clone_element    sexp#clone('n', v:count, 0, 0, '')
-DefplugN  xnoremap sexp_clone_element    sexp#clone('v', v:prevcount, 0, 0, '')
+DefplugN  xnoremap sexp_clone_element    sexp#clone('v', v:count, 0, 0, '')
 DefplugN  nnoremap sexp_clone_element_sl sexp#clone('n', v:count, 0, 0, 's')
-DefplugN  xnoremap sexp_clone_element_sl sexp#clone('v', v:prevcount, 0, 0, 's')
+DefplugN  xnoremap sexp_clone_element_sl sexp#clone('v', v:count, 0, 0, 's')
 DefplugN  nnoremap sexp_clone_element_ml sexp#clone('n', v:count, 0, 0, 'm')
-DefplugN  xnoremap sexp_clone_element_ml sexp#clone('v', v:prevcount, 0, 0, 'm')
+DefplugN  xnoremap sexp_clone_element_ml sexp#clone('v', v:count, 0, 0, 'm')
 
 " Splice list
 Defplug! nnoremap sexp_splice_list sexp#splice_list(v:count)
 
 " Swap list
 Defplug! nnoremap sexp_swap_list_backward sexp#docount(v:count, 'sexp#swap_element', 'n', 0, 1)
-DefplugN xnoremap sexp_swap_list_backward sexp#docount(v:prevcount, 'sexp#swap_element', 'v', 0, 1)
+DefplugN xnoremap sexp_swap_list_backward sexp#docount(v:count, 'sexp#swap_element', 'v', 0, 1)
 Defplug! nnoremap sexp_swap_list_forward  sexp#docount(v:count, 'sexp#swap_element', 'n', 1, 1)
-DefplugN xnoremap sexp_swap_list_forward  sexp#docount(v:prevcount, 'sexp#swap_element', 'v', 1, 1)
+DefplugN xnoremap sexp_swap_list_forward  sexp#docount(v:count, 'sexp#swap_element', 'v', 1, 1)
 
 " Swap element
 Defplug! nnoremap sexp_swap_element_backward sexp#docount(v:count, 'sexp#swap_element', 'n', 0, 0)
-DefplugN xnoremap sexp_swap_element_backward sexp#docount(v:prevcount, 'sexp#swap_element', 'v', 0, 0)
+DefplugN xnoremap sexp_swap_element_backward sexp#docount(v:count, 'sexp#swap_element', 'v', 0, 0)
 Defplug! nnoremap sexp_swap_element_forward  sexp#docount(v:count, 'sexp#swap_element', 'n', 1, 0)
-DefplugN xnoremap sexp_swap_element_forward  sexp#docount(v:prevcount, 'sexp#swap_element', 'v', 1, 0)
+DefplugN xnoremap sexp_swap_element_forward  sexp#docount(v:count, 'sexp#swap_element', 'v', 1, 0)
 
 " Emit/capture element
 Defplug! nnoremap sexp_emit_head_element    sexp#docount_stateful(v:count, 'sexp#stackop', 'n', 0, 0)
-Defplug  xnoremap sexp_emit_head_element    sexp#docount_stateful(v:prevcount, 'sexp#stackop', 'v', 0, 0)
+Defplug  xnoremap sexp_emit_head_element    sexp#docount_stateful(v:count, 'sexp#stackop', 'v', 0, 0)
 Defplug! nnoremap sexp_emit_tail_element    sexp#docount_stateful(v:count, 'sexp#stackop', 'n', 1, 0)
-Defplug  xnoremap sexp_emit_tail_element    sexp#docount_stateful(v:prevcount, 'sexp#stackop', 'v', 1, 0)
+Defplug  xnoremap sexp_emit_tail_element    sexp#docount_stateful(v:count, 'sexp#stackop', 'v', 1, 0)
 Defplug! nnoremap sexp_capture_prev_element sexp#docount_stateful(v:count, 'sexp#stackop', 'n', 0, 1)
-Defplug  xnoremap sexp_capture_prev_element sexp#docount_stateful(v:prevcount, 'sexp#stackop', 'v', 0, 1)
+Defplug  xnoremap sexp_capture_prev_element sexp#docount_stateful(v:count, 'sexp#stackop', 'v', 0, 1)
 Defplug! nnoremap sexp_capture_next_element sexp#docount_stateful(v:count, 'sexp#stackop', 'n', 1, 1)
-Defplug  xnoremap sexp_capture_next_element sexp#docount_stateful(v:prevcount, 'sexp#stackop', 'v', 1, 1)
+Defplug  xnoremap sexp_capture_next_element sexp#docount_stateful(v:count, 'sexp#stackop', 'v', 1, 1)
 
 " Put register before/after
 DefplugN! nnoremap sexp_put_before  sexp#put(v:count, 0)
@@ -824,8 +829,8 @@ DefplugN! nnoremap sexp_put_after   sexp#put(v:count, 1)
 DefoperN! nnoremap sexp_replace_op   sexp#replace_op('n', v:count, 0)
 DefoperN! nnoremap sexp_replace_op_P sexp#replace_op('n', v:count, 1)
 " Replace selection with register
-DefplugN! xnoremap sexp_replace   sexp#replace('v', v:prevcount, 0)
-DefplugN! xnoremap sexp_replace_P sexp#replace('v', v:prevcount, 1)
+DefplugN! xnoremap sexp_replace   sexp#replace('v', v:count, 0)
+DefplugN! xnoremap sexp_replace_P sexp#replace('v', v:count, 1)
 " Put register into list
 DefplugN! nnoremap sexp_put_at_head sexp#put_child(v:count, 0)
 DefplugN! nnoremap sexp_put_at_tail sexp#put_child(v:count, 1)

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -244,6 +244,10 @@ if !exists('g:sexp_regput_ignore_list_shape')
     let g:sexp_regput_ignore_list_shape = 0
 endif
 
+if !exists('g:sexp_regput_curpos')
+    let g:sexp_regput_curpos = 0
+endif
+
 " Expert options
 if !exists('g:sexp_inhibit_failsafe')
     let g:sexp_inhibit_failsafe = 0

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -248,16 +248,12 @@ if !exists('g:sexp_regput_curpos')
     let g:sexp_regput_curpos = 0
 endif
 
-if !exists('g:sexp_regput_into_curpos')
-    let g:sexp_regput_into_curpos = 0
+if !exists('g:sexp_regput_curpos_child')
+    let g:sexp_regput_curpos_child = 0
 endif
 
-if !exists('g:sexp_regput_op_curpos')
-    let g:sexp_regput_op_curpos = -1
-endif
-
-if !exists('g:sexp_regput_op_tele_curpos')
-    let g:sexp_regput_op_tele_curpos = -1
+if !exists('g:sexp_regput_curpos_op')
+    let g:sexp_regput_curpos_op = 2
 endif
 
 if !exists('g:sexp_regput_invalid_register_action')
@@ -272,10 +268,10 @@ if !exists('g:sexp_regput_replace_expanded')
     let g:sexp_regput_replace_expanded = 0
 endif
 
-if !exists('g:sexp_regput_enable_teleop')
-    let g:sexp_regput_enable_teleop = 0
+if !exists('g:sexp_regput_tele_motion')
+    let g:sexp_regput_tele_motion = 0
 else
-    if g:sexp_regput_enable_teleop && v:version < 801
+    if g:sexp_regput_tele_motion && v:version < 801
         call sexp#warn#msg(
             \ "Warning: Replace operator's telescopic mode requires Vim version >= 8.1.")
     endif

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -214,8 +214,28 @@ if !exists('g:sexp_aligncom_optlevel')
     let g:sexp_aligncom_optlevel = 2
 endif
 
-if !exists('g:sexp_put_treats_list_as_element')
-    let g:sexp_put_treats_list_as_element = 0
+if !exists('g:sexp_regput_bracket_is_target')
+    let g:sexp_regput_bracket_is_target = 1
+endif
+
+if !exists('g:sexp_regput_bracket_is_child')
+    let g:sexp_regput_bracket_is_child = 0
+endif
+
+if !exists('g:sexp_regput_allow_comment_append')
+    let g:sexp_regput_allow_comment_append = 0
+endif
+
+if !exists('g:sexp_regput_untrimmed_is_linewise')
+    let g:sexp_regput_untrimmed_is_linewise = 0
+endif
+
+if !exists('g:sexp_regput_linewise_forces_multiline')
+    let g:sexp_regput_linewise_forces_multiline = 0
+endif
+
+if !exists('g:sexp_regput_ignore_list_shape')
+    let g:sexp_regput_ignore_list_shape = 0
 endif
 
 " Expert options

--- a/plugin/sexp.vim
+++ b/plugin/sexp.vim
@@ -237,7 +237,7 @@ if !exists('g:sexp_regput_untrimmed_is_linewise')
 endif
 
 if !exists('g:sexp_regput_linewise_forces_multiline')
-    let g:sexp_regput_linewise_forces_multiline = 0
+    let g:sexp_regput_linewise_forces_multiline = 1
 endif
 
 if !exists('g:sexp_regput_ignore_list_shape')
@@ -246,6 +246,14 @@ endif
 
 if !exists('g:sexp_regput_curpos')
     let g:sexp_regput_curpos = 0
+endif
+
+if !exists('g:sexp_regput_invalid_register_action')
+    let g:sexp_regput_invalid_register_action = -1
+endif
+
+if !exists('g:sexp_regput_inhibit_regparse')
+    let g:sexp_regput_inhibit_regparse = 0
 endif
 
 " Expert options


### PR DESCRIPTION
Inspired by guns#32 (@hoclun-rigsep)

# Important Note
This PR has evolved significantly since its creation. The original comment is preserved below (see "Original PR Comment") since the conversation contained in subsequent comments would make less sense without it.
Here's a summary of the most significant changes over the lifetime of the PR:
- Builtin put commands `p`, `P`, `gp` and `gP` are now overridden by default.
- Put/replace _operators_ and _telescopic mode_ have been added.
- The "replace child" commands have been removed since the replace operators obviate the need for them.
- Several options have been renamed.

# Final PR Comment
If you're working with S-Expressions, think of this feature as Vim's builtin put commands on steroids. For ordinary use cases, it will keep you from having to make the sorts of cursor and whitespace adjustments that would be required with builtin paste. However, the real power of these commands lies in their support for more advanced use cases: e.g.,

- Put/replace the [count]'th child of current list.
- Replace the S-Expression under the cursor.
- Put before/after/over the S-Expression selected by one of the following:
  - motion
  - text/sexp object
  - "telescopic mode" search

**Note:** "Telescopic mode" uses a non-traditional interpetation of operator-pending motion, designed to give you "cybernetic arms", capable of putting S-Expressions in distant parts of a buffer without even moving the cursor.  
:help sexp-regput-telescopic-motion

## Motivation (the Problem)
Vim provides various register put (paste) commands whose behavior in a Lisp buffer is sub-optimal. The problems can be summarized as follows:

- Whitespace surrounding pasted form(s) is likely to be incorrect, necessitating manual adjustments by user after the paste (e.g., insertion or removal of newlines).
- Indentation is often destroyed, especially when pasting multiple lines.
- Putting arbitrary text from a register may result in a Lisp buffer with unbalanced forms.
- Pre-positioning is sometimes required: e.g., moving to the end of an atom to paste after it or moving down into a list to paste before/after/over one of its children.

## The Solution
This commit provides a family of sexp-aware put (paste) commands and operators intended to address the problems outlined above.

- All of the commands permit use of a register, just like the builtin put operators.
- All of the commands perform an automatic re-indent after the put. By default, the plugin attempts to determine the smallest re-indent range capable of producing correct indentation (assuming the code was properly indented before the put), but the size of the indent is option-configurable (see `g:sexp_auto_indent_range`).
- By default, all commands position the cursor at the head of the put form(s), but this is option-configurable.  
  :help g:sexp_regput_curpos  
  :help g:sexp_regput_curpos_child  
  :help g:sexp_regput_curpos_op  
- All of the commands use both the surrounding buffer context and the content of the put register in an effort to determine what sort of leading/trailing whitespace should be inserted around the pasted form(s).
- Unless explicitly disabled by user, all commands attempt to parse the put register contents using either Treesitter or the legacy syntax engine. This parse serves two purposes:  
  1. Detect invalid lisp forms before they "contaminate" the buffer.
  1. Characterize the register contents in a way that aids the algorithm responsible for determining how to insert the register into the buffer.  
  **Note:** By default, the user will be warned/prompted on how to deal with invalid register contents, but this is configurable via `g:sexp_regput_invalid_register_action`.
- By analogy with builtin operators, the commands that replace existing forms have both a p and P variant; only the former updates the unnamed register.

# Original PR Comment
## Motivation (the Problem)
Vim provides various register put (paste) operators whose behavior in a Lisp buffer is sub-optimal. The problems can be summarized as follows:

- Whitespace surrounding pasted form(s) is likely to be incorrect, necessitating manual adjustments by user after the paste (e.g., insertion or removal of newlines).
- Indentation is often destroyed, especially when pasting multiple lines.
- Putting arbitrary text from a register may result in a Lisp buffer with unbalanced forms.
- _Pre-positioning_ is sometimes required: e.g., moving to the end of an atom to paste after it or moving down into a list to paste before/after/over one of its children.

## The Solution
This PR provides a family of _sexp-aware_ put (paste) commands intended to address the problems outlined above.
Some of these commands have analogous builtin operators; others have no builtin counterpart.
The commands can be grouped into two distinct, orthogonal categories, according to the following criteria:

* whether they operate on **_elements_** or **_lists_** (more specifically, children or _slots_ within lists)
* whether they **_insert_** _around_ or **_replace_** existing forms

All of the commands permit use of a register, just like the builtin put operators.
All of the commands perform an automatic code re-indent after the put. By default, the plugin attempts to determine the smallest re-indent range capable of producing correct indentation, provided the code was properly indented before the put.
However, the user can choose a more conservative (safer and larger) range with `g:sexp_auto_indent_range`.  
**Note:** I haven't fully committed to the format of this option.
By default, all commands position the cursor at the head of the put form(s), but option `g:sexp_regput_curpos` (applies to commands that target element under cursor) and/or `g:sexp_regput_into_curpos` (applies to commands that put into a list) can be used to choose the tail (analogous to builtin `p`) or even (for a more telescopic/put-at-a-distance feel) to preserve the original (pre-paste) cursor position.
All of the commands use both the surrounding buffer context and the content of the put register in an effort to determine what sort of leading/trailing whitespace should be inserted around the pasted form(s). In my testing, the results are mostly _DWIMMY_, but constructive feedback in this area is welcome.
Unless explicitly disabled by user, all commands attempt to parse the put register contents using either _Treesitter_ or legacy syntax engine. This parse serves two purposes:

1. Detect invalid lisp forms before they "contaminate" the buffer.
2. Characterize the register contents in a way that aids the algorithm responsible for determining how to insert the register into the buffer.

**Note:** By default, the user will be warned/prompted on how to deal with invalid register contents, but this is configurable via `g:sexp_regput_invalid_register_action`.
By analogy with builtin operators, the commands that replace existing forms have both a `p` and `P` variant; only the former updates the unnamed register. This can be useful in scenarios involving the swapping of elements (example below).

For an overview of the provided commands, refer to [the following README section](https://github.com/bpstahlman/vim-sexp/tree/feature/issue-32-paste?tab=readme-ov-file#smart-paste-commands-normal-visual).

### Overriding Builtins
I toyed with the idea of assigning these commands to builtin put operators, but wasn't convinced it was appropriate. Although I think most users will prefer the smart-paste operators to the builtins, they're not always functionally equivalent, and there may still be times when a builtin put is desired. Accordingly, the current defaults use `<LocalLeader>`-based keybindings for the smart-paste commands, but option `g:sexp_regput_override_builtins` provides an easy way to request a more convenient set of maps that override builtins.  
**Note:** Although this option is currently a boolean flag, I'm thinking of accepting a string form, which would serve as a request for the plugin to provide "backups" of the overridden builtins using the provided string as a leader sequence: e.g., the following setting would instruct the plugin to create the more convenient keybindings and also provide `,p`, `,P`, etc. for access to the corresponding builtins:
```
let g:sexp_regput_override_builtins = ','
```

### Illustrative Example
The following example illustrates use of the "replace child" commands to simplify swapping two children of a list. It is also used as a vehicle for discussing a couple of options whose default values I'm not completely decided on. Accordingly, the command sequence required to accomplish the goal will be repeated for each relevant option combination.  
**Note:** All command sequences assume builtin operators have been overridden (`let g:sexp_regput_override_builtins = 1`).

**Goal:** Swap the 4th and final forms of the following list: i.e., transform the following...  
```
(do (foo 42)
    (bar 43)
    (baz 44)
    (baz 45)
    (blammo 46))
```
...into this:
```
(do (foo 42)
    (bar 43)
    (blammo 46)
    (baz 45)
    (baz 44))
```

#### Option Combination \# 1
| Option | Value | Description |
| ------- | ------- | ------------ |
| g:sexp_regput_into_curpos | 2 | preserve cursor position (i.e., don't move to put text) |
| g:sexp_regput_bracket_is_child | 1 | treat list whose bracket is under cursor as a _child_ of target list |

With the cursor initially on the `do` (or the preceding open), execute the following sequence of commands:
```
y4ic        yank 4th inner child (from head) into unnamed register
]p          replace tail of list with unnamed register and update the unnamed register
4[p         replace 4th child (from head) with unnamed register
```
This option combination is not the default, but for reasons discussed below, it's probably the ideal combination for this use case.
In light of the description of the `g:sexp_regput_bracket_is_child` option, you might be wondering why it would be ok for the cursor to start on either the open preceding the `do` or the `do` itself. The answer is that the `g:sexp_regput_bracket_is_child` option is ignored when the bracket under the cursor belongs to a top-level list.

#### Option Combination \# 2 (the default)
| Option | Value | Description |
| ------- | ------- | ------------ |
| g:sexp_regput_into_curpos | 0 | move cursor to head of put form(s) |
| g:sexp_regput_bracket_is_child | 0 | treat a list whose bracket is under the cursor as the target (parent) list |

With the cursor initially on the `do` (or the preceding open), execute the following sequence of commands:
```
y4ic        yank 4th _inner child_ (from head) into unnamed register
h           move cursor off the open bracket of the yanked form
]p          replace tail of list with unnamed register and update the unnamed register
h           move cursor off the open bracket of the put form
4[p         replace 4th child (from head) with unnamed register
```
Note how this option combination required 2 extra steps because with `g:sexp_regput_into_curpos == 0`, both the yank and put commands leave the cursor on the operated-on elements, and the default setting of  `g:sexp_regput_bracket_is_child` would cause these forms, not the containing `do` form, to be targeted by the `]p` and `4[p` commands.

#### Option Combination \# 3
| Option | Value | Description |
| ------- | ------- | ------------ |
| g:sexp_regput_into_curpos | 2 | preserve cursor position (i.e., don't move to put text) |
| g:sexp_regput_bracket_is_child | 0 | treat a list whose bracket is under the cursor as the target (parent) list |

With the cursor initially on the `do` (or the preceding open), execute the following sequence of commands:
```
y4ic        yank 4th _inner child_ from head into unnamed register
h           move cursor off the open bracket of the yanked form
]p          replace tail of list with unnamed register and update the unnamed register
4[p         replace 4th child from head with unnamed register
```
Note how this example required 1 fewer step than the previous: we still had to move off the list bracket of the yanked form, but `g:sexp_regput_into_curpos == 2` prevented the cursor being moved by the subsequent puts.

### Thoughts on Possible Option Changes
This example makes me wonder whether I've chosen the best defaults for both `g:sexp_regput_into_curpos` and `g:sexp_regput_bracket_is_child`. The motivation behind the `g:sexp_regput_bracket_is_child` option is consistency: with the option set, as long as you're on an element _**terminal**_ (i.e., on the "edge" of an element), the put into list commands behave identically whether the element under the cursor is an atom or a list. For some users, I suspect that setting this option would significantly reduce cognitive load and error frequency. OTOH, a user who reflexively hits `(` before operating on a list may actually experience greater cognitive load and/or error frequency with this option set. Another consideration is that, for the sake of consistency, it might make sense to have a similar option for existing commands that target lists (e.g., the "inner/outer child" text objects).

## Feature Maturity
This PR is still in draft state because I've made quite a few commits to the PR branch lately and thus need to do some regression testing and cleanup. However, to the best of my knowledge, all commands are documented and implemented, and I'm not expecting to make major changes: mainly just bugfixes and tweaks driven by user feedback.

Feedback on any or all of this is welcome...
@SevereOverfl0w @nimaai