### PR TITLE
fix: honor keep-empty-lines setting in regput and cleanup (#70)

### DIFF
--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -3743,7 +3743,8 @@ function! s:regput__get_splice_info(count, ctx, reg, sep, flags)
             " Note: Because relevant sep has been determined to be NL, we must ensure a
             " min gap of 1, even if tgt and adj are currently colinear.
             " Question: Does num_nl need to take exc_typ into account?
-            let num_nl = min([max([gap, 1]), g:sexp_cleanup_keep_empty_lines + 1])
+            let num_nl = max([1, g:sexp_cleanup_keep_empty_lines < 0
+                    \ ? gap : min([gap, g:sexp_cleanup_keep_empty_lines + 1])])
             let sep[tail] = repeat("\n", num_nl)
         endif
         if is_repl
@@ -3953,7 +3954,8 @@ function! s:put__get_tgt(count, tail, ...)
     let curpos = getpos('.')
     let ret = a:0 && !empty(a:1)
         \ ? a:1
-        \ : s:regput__ctx_init('n', a:tail ? 'put_after' : 'put_before', a:count)
+        \ : s:regput__ctx_init('n', a:tail ? 'put_after' : 'put_before', a:count,
+        \   {'tail': a:tail})
     try
         " First, attempt to get natural target: i.e., side of *current* element in
         " direction of put. If no such element, special logic will determine a 'virtual'
@@ -6470,7 +6472,8 @@ function! s:cleanup_ws(start, ps, ...)
                 " Note: Treating negative 'keep_empty_lines' as infinity ensures removal
                 " of non-NL whitespace at EOL.
                 let precedes_com = next[1] && sexp#is_comment(next[1], next[2])
-                if gap > g:sexp_cleanup_keep_empty_lines + 1
+                if g:sexp_cleanup_keep_empty_lines >= 0
+                    \ && gap > g:sexp_cleanup_keep_empty_lines + 1
                     \ || getline(eff_prev[1])[eff_prev[2] - 1:] =~ '.\s\+$'
                     " Replace gap with number of newlines determined by existing line gap
                     " and g:sexp_cleanup_keep_empty_lines option, followed by original


### PR DESCRIPTION
This fixes issue #70 by making `g:sexp_cleanup_keep_empty_lines` behave consistently in both smart paste gap preservation and whitespace cleanup.

Fixes:
- initialize `tail` in `put__get_tgt()` so normal directional `p` / `P` puts actually enter the block containing the line gap logic in `s:regput__get_splice_info()`
- fix `s:regput__get_splice_info()` so negative `g:sexp_cleanup_keep_empty_lines` is treated as "infinite preservation" (never delete blanks)
- skip multiline cleanup in `s:cleanup_ws()` if empty lines are the sole reason for the cleanup and `g:sexp_cleanup_keep_empty_lines` is negative
  **Note:** The existing behavior isn't problematic, since the count passed to repeat() takes negative option correctly into account, but it's better to skip unnecessary splices.

Behaviorally, this means:
- existing empty line gaps are now preserved or contracted according to `g:sexp_cleanup_keep_empty_lines` during directional smart put
- `let g:sexp_cleanup_keep_empty_lines = -1` now consistently means "never delete empty lines", as documented
