### PR TITLE
Fix spurious fallback to builtin put after deletion of outer element

### DIFF
--- a/autoload/sexp.vim
+++ b/autoload/sexp.vim
@@ -1846,7 +1846,7 @@ function! s:trim_range_to_non_ws(start_pos, end_pos)
         return s:nullpos_pair
     endif
 
-    let trail = match(text, '\s*$')
+    let trail = match(text, '\_s*$')
     let range_start_byte = s:pos2byte(a:start_pos)
     let start_byte = range_start_byte + lead
     let end_byte = range_start_byte + trail - 1


### PR DESCRIPTION
When an outer-element selection includes trailing whitespace, regput’s completeness check trims the whitespace before deciding whether the register represents a complete s-expression (or sequence thereof).

The trim logic used `\s*$`, which doesn't match newlines. Thus, when the tail of the range was at the end of a line, the checked range ended _past_ the final deleted element, rather than on its tail. This caused the register to be marked incomplete, which in turn caused contextual smart put to fall back to builtin paste under the default "c" fallback flag.

This changes the trailing whitespace regex to `\_s*$` to ensure multiline trailing whitespace is trimmed correctly.

Fixes #83